### PR TITLE
fix: correct slice bounds in debug-file upload denibble (#24)

### DIFF
--- a/src/hex-extract.js
+++ b/src/hex-extract.js
@@ -1,0 +1,23 @@
+// Extract nibble bytes from a hex-text dump between the 0x17 screen-capture
+// start marker and the trailing 0xF7 SysEx terminator. Pure, DOM-free,
+// import-safe — kept separate from main.js (which has top-level DOM access)
+// so it can be unit-tested in isolation.
+//
+// Mirrors the slice logic in bitmap.js for the device-emitted bitmap path;
+// here we apply it to user-uploaded debug capture files.
+// Returns null if either the 0x17 start marker is absent or if no hex
+// digits were found at all.
+// bitmap.js retains its own inline copy for now (two callsites isn't worth
+// a shared dependency); if a third callsite appears, consolidate then.
+export function extractNibblesFromHex(content) {
+  const hexPattern = /[0-9a-f]{1,2}/g;
+  const hexMatches = content.toLowerCase().match(hexPattern);
+  if (!hexMatches) return null;
+  const startMarker = hexMatches.indexOf('17');
+  if (startMarker === -1) return null;
+  const startIdx = startMarker + 1;
+  const f7Idx = hexMatches.indexOf('f7', startIdx);
+  const endIdx = f7Idx !== -1 ? f7Idx : hexMatches.length;
+  const nibblesStr = hexMatches.slice(startIdx, endIdx);
+  return nibblesStr.map(h => parseInt(h, 16));
+}

--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,7 @@ import { setState } from './store.js';
 import { denibble, renderBitmap } from './bitmap.js';
 import { log } from './logger.js';
 import { registerEventBridge } from './event-bridge.js';
+import { extractNibblesFromHex } from './hex-extract.js';
 
 const lcdEl = document.getElementById('lcd');
 const logArea = document.getElementById('log-area');
@@ -219,14 +220,8 @@ processDebugFileBtn.addEventListener('click', () => {
   if (file) {
     const reader = new FileReader();
     reader.onload = function(e) {
-      const content = e.target.result.toLowerCase();
-      const hexPattern = /[0-9a-f]{1,2}/g;
-      const hexMatches = content.match(hexPattern);
-      if (hexMatches) {
-        const startIdx = hexMatches.indexOf('17') + 1;
-        const endIdx = hexMatches.indexOf('f7', startIdx) || hexMatches.length;
-        const nibblesStr = hexMatches.slice(startIdx, endIdx);
-        const nibbles = nibblesStr.map(h => parseInt(h, 16));
+      const nibbles = extractNibblesFromHex(e.target.result);
+      if (nibbles) {
         log(`[LOG] Extracted ${nibbles.length} nibbles from uploaded file`, 'debug', 'general');
         const rawBytes = denibble(nibbles);
         log(`[LOG] Denibbled to ${rawBytes.length} bytes`, 'debug', 'general');

--- a/tests/hex-extract.test.js
+++ b/tests/hex-extract.test.js
@@ -1,0 +1,49 @@
+import { extractNibblesFromHex } from '../src/hex-extract.js';
+
+describe('extractNibblesFromHex', () => {
+  test('returns null when input has no hex digits at all', () => {
+    // Note: a-f are valid hex digits, so test strings must avoid them.
+    // Using only 'g-z' chars and punctuation guarantees no regex matches.
+    expect(extractNibblesFromHex('zzz wrong junk!!!')).toBeNull();
+    expect(extractNibblesFromHex('')).toBeNull();
+  });
+
+  test('returns null when the 0x17 start marker is absent', () => {
+    // Input has hex digits but no 17 byte — formerly returned all hex
+    // from index 0 onward because indexOf returns -1 and -1 + 1 = 0.
+    const input = 'aa bb cc dd';
+    expect(extractNibblesFromHex(input)).toBeNull();
+  });
+
+  test('extracts nibbles between 0x17 and 0xF7 markers', () => {
+    // 17 = start marker, then payload nibbles, then f7 = end marker
+    const input = 'aa 17 01 02 03 04 f7 ff';
+    const result = extractNibblesFromHex(input);
+    expect(result).toEqual([0x01, 0x02, 0x03, 0x04]);
+  });
+
+  test('handles 17 at index 0 — regression for the || falsy bug', () => {
+    // Old code: startIdx = indexOf('17') + 1 = 1; endIdx = indexOf('f7', 1).
+    // If f7 was at index 0 this would have returned 0, which `|| length`
+    // would silently replace with length. Symmetric concern: this test
+    // ensures the start case at index 0 still works.
+    const input = '17 0a 0b 0c f7';
+    const result = extractNibblesFromHex(input);
+    expect(result).toEqual([0x0a, 0x0b, 0x0c]);
+  });
+
+  test('handles missing 0xF7 terminator by taking the rest of the input', () => {
+    // This is the bug. Old code: indexOf returns -1, `-1 || length` is -1,
+    // slice(startIdx, -1) silently DROPS THE LAST element. The fix should
+    // take everything from startIdx to end.
+    const input = '17 0a 0b 0c';
+    const result = extractNibblesFromHex(input);
+    expect(result).toEqual([0x0a, 0x0b, 0x0c]);
+  });
+
+  test('is case-insensitive on input', () => {
+    const input = '17 AB CD f7';
+    const result = extractNibblesFromHex(input);
+    expect(result).toEqual([0xab, 0xcd]);
+  });
+});


### PR DESCRIPTION
Closes #24. Extracts the hex-match-and-slice logic to a new pure module `src/hex-extract.js` (DOM-free, import-safe), fixes the `||` falsy bug on the end marker (mirrors bitmap.js's `!== -1` check), and adds a guard for missing start marker (latent symmetric bug discovered while writing tests). Adds tests/hex-extract.test.js with 6 unit tests. Full suite green (36 tests, 7 suites). bitmap.js retains its inline copy — has the same missing-start-marker latent bug, to be filed as a follow-up.