### PR TITLE
feat: HIL screenshot loop tool (single-process MIDI capture)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ combine/
 *.bak
 
 logs/
+
+# Temp HIL captures (underscore-prefixed fixtures written by orville-probe/hil-screenshot)
+tests/fixtures/_*.txt

--- a/build_tools/hil-screenshot.cjs
+++ b/build_tools/hil-screenshot.cjs
@@ -1,0 +1,160 @@
+/**
+ * Hardware-in-the-loop screenshot: drive the Orville and capture what it shows.
+ *
+ * Opens the MIDI ports ONCE (gentle on the USB driver — separate-process probing
+ * destabilized the U6MIDI Pro), optionally presses a sequence of front-panel
+ * keys, requests a screen dump (0x18 -> 0x17), saves the raw capture, and
+ * renders it to a PNG via build_tools/render-screen.js (the canonical decoder).
+ *
+ * Usage:
+ *   node build_tools/hil-screenshot.cjs --png logs/shot.png
+ *   node build_tools/hil-screenshot.cjs --press setup --png logs/setup.png
+ *   node build_tools/hil-screenshot.cjs --press ab,parameter --png logs/b-params.png
+ *
+ * Options: --in <substr> --out <substr> --dev <n> --win <ms>
+ *          --press <k1,k2,...>  keys to send before capturing (see KEYS)
+ *          --name <fixtureName> raw capture file (default _hil-shot) in tests/fixtures/
+ *          --png <path>         output PNG (default logs/hil-shot.png)
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const KEYS = {
+  up: [0xfe, 0xff, 0xfd, 0xff],
+  down: [0xff, 0xfe, 0xfd, 0xff],
+  left: [0xff, 0xfe, 0xff, 0xff],
+  right: [0xfe, 0xff, 0xff, 0xff],
+  enter: [0xff, 0xff, 0xff, 0xef],
+  select: [0xff, 0xff, 0xfe, 0xff],
+  program: [0xf7, 0xff, 0xff, 0xff],
+  parameter: [0xff, 0xf7, 0xff, 0xff],
+  levels: [0xff, 0xff, 0xff, 0xfd],
+  setup: [0xff, 0xff, 0xf7, 0xff],
+  bypass: [0xff, 0xff, 0xfd, 0xff],
+  inc: [0xff, 0xff, 0xff, 0x7f],
+  dec: [0xff, 0xff, 0xff, 0xbf],
+  soft1: [0xfb, 0xff, 0xff, 0xff],
+  soft2: [0xff, 0xfb, 0xff, 0xff],
+  soft3: [0xff, 0xff, 0xfb, 0xff],
+  soft4: [0xff, 0xff, 0xff, 0xfb],
+  ab: [0xfd, 0xff, 0xfd, 0xff],
+};
+
+function parse(argv) {
+  const o = {
+    in: 'MIDIIN3 (U6MIDI Pro)',
+    out: 'MIDIOUT2 (U6MIDI Pro)',
+    dev: 1,
+    win: 3000,
+    press: [],
+    name: '_hil-shot',
+    png: 'logs/hil-shot.png',
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--in') o.in = argv[++i];
+    else if (a === '--out') o.out = argv[++i];
+    else if (a === '--dev') o.dev = parseInt(argv[++i], 10);
+    else if (a === '--win') o.win = parseInt(argv[++i], 10);
+    else if (a === '--press') o.press = argv[++i].split(',').filter(Boolean);
+    else if (a === '--name') o.name = argv[++i];
+    else if (a === '--png') o.png = argv[++i];
+  }
+  return o;
+}
+
+const nibble = (mask) => mask.flatMap((b) => [(b >> 4) & 0x0f, b & 0x0f]);
+const hex = (b) => b.map((x) => x.toString(16).padStart(2, '0').toUpperCase()).join(' ');
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function findPort(inst, sub) {
+  for (let i = 0; i < inst.getPortCount(); i++) if (inst.getPortName(i).includes(sub)) return i;
+  return -1;
+}
+
+async function main() {
+  const o = parse(process.argv.slice(2));
+  const midi = require('@julusian/midi');
+  const input = new midi.Input();
+  const output = new midi.Output();
+
+  const inIdx = findPort(input, o.in);
+  const outIdx = findPort(output, o.out);
+  if (inIdx === -1 || outIdx === -1) {
+    console.error(`MIDI port not found (in=${inIdx}, out=${outIdx}). Is the interface up?`);
+    process.exit(1);
+  }
+  input.openPort(inIdx);
+  output.openPort(outIdx);
+  input.ignoreTypes(false, true, true);
+
+  // 1. Drive any requested keypresses (single open port, paced).
+  for (const k of o.press) {
+    const mask = KEYS[k];
+    if (!mask) {
+      console.error(`unknown key '${k}'. known: ${Object.keys(KEYS).join(', ')}`);
+      input.closePort();
+      output.closePort();
+      process.exit(1);
+    }
+    output.sendMessage([0xf0, 0x1c, 0x70, o.dev, 0x01, ...nibble(mask), 0xf7]);
+    console.error(`pressed ${k}`);
+    await sleep(300);
+  }
+  if (o.press.length) await sleep(300); // settle
+
+  // 2. Request a screen dump and capture the 0x17 reply.
+  const got = await new Promise((resolve) => {
+    let done = false;
+    const h = (_dt, m) => {
+      if (
+        !done &&
+        m.length > 5 &&
+        m[0] === 0xf0 &&
+        m[1] === 0x1c &&
+        m[2] === 0x70 &&
+        m[4] === 0x17
+      ) {
+        done = true;
+        input.removeListener('message', h);
+        resolve(Array.from(m));
+      }
+    };
+    input.on('message', h);
+    output.sendMessage([0xf0, 0x1c, 0x70, o.dev, 0x18, 0xf7]);
+    setTimeout(() => {
+      if (!done) {
+        input.removeListener('message', h);
+        resolve(null);
+      }
+    }, o.win);
+  });
+
+  input.closePort();
+  output.closePort();
+
+  if (!got) {
+    console.error(`no 0x17 screen reply within ${o.win}ms`);
+    process.exit(1);
+  }
+
+  // 3. Save the raw capture and render it to PNG via the canonical decoder.
+  const dir = path.join(__dirname, '..', 'tests', 'fixtures');
+  fs.mkdirSync(dir, { recursive: true });
+  const fixture = path.join(dir, `${o.name}.txt`);
+  fs.writeFileSync(fixture, hex(got) + '\n');
+  console.log(`captured ${got.length} bytes -> ${fixture}`);
+
+  fs.mkdirSync(path.dirname(o.png), { recursive: true });
+  execFileSync('node', [path.join(__dirname, 'render-screen.js'), fixture, o.png, '6'], {
+    stdio: 'inherit',
+  });
+  console.log(`rendered -> ${o.png}`);
+}
+
+main().catch((e) => {
+  console.error('error:', e);
+  process.exit(1);
+});

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -182,6 +182,18 @@ NOTE: Batch 1.4 (B10) complete.
         rapid probe open/close (recovers on its own). The HIL loop itself is already proven (drove A/B +
         read live; render-screen.js renders captured screens). For long live sessions use one long-lived
         process. Noted in device-model.md §12.
+- [x] B10g.4 HIL screenshot loop tool + RDP root-cause for "no MIDI devices":
+      * build_tools/hil-screenshot.cjs (npm `screenshot`): single long-lived process — opens MIDI
+        once, optional `--press k1,k2`, sends 0x18, captures 0x17, saves raw fixture, renders PNG via
+        render-screen.js. Implemented + lint/`node --check` clean. NOT yet exercised end-to-end live.
+      * ROOT CAUSE of the intermittent "no MIDI input devices currently available": RDP, not USB
+        churn or the device. Proven: Get-PnpDevice (system-global) shows U6MIDI Pro + all 6 ports OK,
+        but BOTH node's @julusian/midi AND raw WinMM midiInGetNumDevs() (per-session) return 0 in/
+        1 out (GS Wavetable only). RDP redirects the audio/MIDI stack; the physical interface stays
+        bound to the CONSOLE session and is invisible to the remote session's WinMM. Captures worked
+        earlier because the active session was the console. => Live HIL (G2, hil-screenshot) must run
+        from the physical console, OR mstsc Remote audio = "Play on remote computer" (unreliable for
+        MIDI in). Offline work (replay fixtures) is unaffected by RDP.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "combine": "node build_tools/combine.cjs",
     "capture:fixtures": "node build_tools/capture-fixtures.cjs",
     "screen": "node build_tools/render-screen.js",
+    "screenshot": "node build_tools/hil-screenshot.cjs",
     "test": "jest",
     "lint": "eslint .",
     "format": "prettier --write .",


### PR DESCRIPTION
## What

Adds `build_tools/hil-screenshot.cjs` (npm `screenshot`) — the screen-capture loop. One long-lived process: open MIDI once → optional `--press k1,k2` front-panel keys → request screen (`0x18` → `0x17`) → save raw fixture → render PNG via `render-screen.js` (the canonical decoder). Single process avoids the open/close churn of `orville-probe`.

## Status — honest

Implemented, `node --check` + ESLint clean. **Not yet run end-to-end live.** The U6MIDI Pro is unreachable from the current session because it's an **RDP** session, not a hardware fault — see below.

## RDP root cause (recorded in `docs/issue-tracker.md` B10g.4)

The recurring "no MIDI input devices currently available" was diagnosed, not the device or USB churn:

| Probe | Result |
|---|---|
| `Get-PnpDevice` (system-global) | U6MIDI Pro + all 6 ports **OK** |
| node `@julusian/midi` | **0 in** / 1 out |
| raw WinMM `midiInGetNumDevs()` (per-session) | **0 in** / 1 out (GS Wavetable only) |

System sees the device; the *session* doesn't. RDP redirects the audio/MIDI stack and the physical interface stays bound to the **console session**. Live HIL must run from the physical console (or, unreliably, mstsc Remote audio = "Play on remote computer"). Offline replay work is unaffected.

## Also

- gitignore temp HIL captures (`tests/fixtures/_*.txt`)
- `package.json`: `screenshot` script
