### PR TITLE
fix: dump-complete watchdog as idle timer with absolute cap (FB4)

### DIFF
--- a/docs/device-model.md
+++ b/docs/device-model.md
@@ -322,9 +322,12 @@ distinct ids; id 0 = broadcast (§1).
   the legacy commands; no `OK` is seen after a `VALUE_PUT`, hence reconcile-by-redump.
 - **Large enumerations are slow** `[V]` (live-probed) — most dumps reply in well
   under a second, but the bank list (`OBJECTINFO 10020012`, ~70 names) takes
-  **~4–6 s**. Implication: the per-wave watchdog in `midi.js` (1500 ms) is too
-  short and would fire mid-enumeration; raise it / make it adaptive before the
-  eager loader relies on it (tracked FB4). `OBJECTINFO` is otherwise context-free
+  **~4–6 s**. Implication: a fixed per-wave watchdog would fire mid-enumeration.
+  The `midi.js` watchdog is therefore an idle/silence timer (`WATCHDOG_IDLE_MS`,
+  rearmed on each send/receive) bounded by an absolute `WATCHDOG_MAX_MS` cap, so a
+  healthy slow enumeration drains to completion rather than being cut short (FB4,
+  resolved; see [`protocol.md`](protocol.md) "Request/response tracking — the dump
+  wave"). `OBJECTINFO` is otherwise context-free
   — load-menu keys (`10020011`/`10020012`) answer without navigating there, just
   slowly.
 - **Keypress table** `[D]` — verified `controls.js:keypressMasks` against Tech

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -131,9 +131,11 @@ reviewer agents swept all of src/; findings consolidated below.
 ### Device-research follow-ups (from Tech Note 34)
 - [ ] FB1 framebuffer.js robustness: READ width/height/size from the 0x17 header (per TN34) instead of
       hardcoding 240x64, and verify the trailing checksum. CODE change — pending (own PR). Low priority.
-- [ ] FB4 (NEW, from live capture) midi.js watchdog (WATCHDOG_MS 1500) is too SHORT: large enumerations
-      like the bank list (OBJECTINFO 10020012, ~70 names) take ~4-6s, so a wave would hit the watchdog
-      mid-response. Raise it / make adaptive before the Phase 3 eager loader relies on dumpComplete. CODE.
+- [x] FB4 RESOLVED (branch fix/dump-watchdog-idle-reset): the midi.js dump watchdog was a fixed 1500ms hard
+      ceiling that fired mid-response on large enumerations like the bank list (OBJECTINFO 10020012, ~70 names,
+      ~4-6s). Replaced with an idle/silence watchdog (WATCHDOG_IDLE_MS 1500, rearmed on every send and receive)
+      bounded by an absolute WATCHDOG_MAX_MS (10000) ceiling, so a healthy slow wave drains to all-received.
+      Documented in protocol.md ("Request/response tracking — the dump wave"); device-model.md §9 updated.
 - [x] FB2 RESOLVED via the Programming Manual: a sigfile (0x08/0x09) is the ASCII module netlist (the .sig
       design/transport form); loading it makes the unit compile+load a whole program and does NOT expose
       live menu-tree values. So it's NOT a shortcut for the eager loader — keep walking OBJECTINFO. (Only

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -144,12 +144,50 @@ Structural patterns on otherwise-dynamic keys:
 - `KEY_SUFFIX.PRESET` (`'000b'`) — a preset/DSP root key.
 - `KEY_SUFFIX.METER` (`'0002'`) — a meter parameter (immediate re-render).
 
-## Request/response tracking (app-side)
+## Request/response tracking — the dump wave (app-side)
 
 Not part of the wire protocol, but relevant when reading the code: `midi.js`
-counts outstanding requests per "wave" and emits a `dumpComplete` event when the
-count returns to zero or a `WATCHDOG_MS` (1500 ms) ceiling fires. This backs the
-render-coalescing in `event-bridge.js`.
+groups request/response activity into **dump waves** and emits a `dumpComplete`
+event when a wave finishes. This is the substrate the Phase 3.1 eager loader and
+render-coalescing build on (see
+[`refactor/phase3-state-model.md`](refactor/phase3-state-model.md)).
+
+**Wave lifecycle:**
+
+- A wave **starts** when the `outstanding` request counter transitions `0 → 1`.
+- Each `OBJECTINFO_DUMP` (`0x31`) and `VALUE_DUMP` request (`0x2d`) increments
+  `outstanding` (via `recordRequest`). `VALUE_PUT` is **not** counted — the
+  device sends no response to a put (see the `0x2d` section above).
+- Each matching `0x32` / `0x2e` response decrements `outstanding`, via
+  `notifyResponse`, which `parser.js` calls at the top of each branch. The
+  counter is a pure count — it does not yet correlate responses to requests by
+  key or type.
+- A wave **ends** one of two ways, both emitting `dumpComplete` with a `reason`:
+  - `all-received` — `outstanding` returns to `0` (the healthy path).
+  - `watchdog` — the timeout fires (a stall or a runaway wave).
+
+The `dumpComplete` payload is
+`{ reason, sendCount, receiveCount, durationMs, lastKey }`; it is also written to
+`appState.lastDumpComplete` and logged. `getDumpStats()` exposes a session tally
+of `all` vs `watchdog` reasons.
+
+**Watchdog (idle/silence timer, not a hard ceiling).** Two timing constants in
+[`src/constants.js`](../src/constants.js) bound a wave:
+
+- `WATCHDOG_IDLE_MS` (1500 ms) — the watchdog is **rearmed for this interval on
+  every send and every received response** while a wave is in flight. It fires
+  only after this much *silence*, i.e. a genuine stall.
+- `WATCHDOG_MAX_MS` (10000 ms) — an absolute per-wave ceiling measured from wave
+  start; a rearm never extends the timer past this, so a pathological wave that
+  keeps producing traffic still terminates.
+
+The idle design replaced an earlier fixed 1500 ms ceiling set once at wave start.
+That ceiling tripped during normal large enumerations — the bank list
+(`OBJECTINFO 10020012`, ~70 names) takes ~4–6 s on real hardware (see
+[`device-model.md`](device-model.md) §9, "Large enumerations are slow") — cutting
+the wave short and dropping every response that arrived after. The idle window
+lets a healthy multi-second enumeration drain to `all-received`; the absolute cap
+is the backstop.
 
 ## Sources
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -18,7 +18,8 @@ export const TIMING = {
   PORT_INIT_MS: 500, // delay after auto-selecting cached ports at boot
   POLL_INTERVAL_MS: 500, // meter-polling re-request interval
   REDUMP_MS: 200, // parser re-dump after the Favorites re-order fix
-  WATCHDOG_MS: 1500, // per-wave dump-complete hard ceiling
+  WATCHDOG_IDLE_MS: 1500, // dump-complete idle/silence watchdog: rearmed on each send and receive
+  WATCHDOG_MAX_MS: 10000, // dump-complete absolute per-wave ceiling regardless of activity
   SYNC_STEP_MS: 1000, // pause between steps of the dev sync test loop
 };
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -18,8 +18,11 @@ export const TIMING = {
   PORT_INIT_MS: 500, // delay after auto-selecting cached ports at boot
   POLL_INTERVAL_MS: 500, // meter-polling re-request interval
   REDUMP_MS: 200, // parser re-dump after the Favorites re-order fix
-  WATCHDOG_IDLE_MS: 1500, // dump-complete idle/silence watchdog: rearmed on each send and receive
-  WATCHDOG_MAX_MS: 10000, // dump-complete absolute per-wave ceiling regardless of activity
+  WATCHDOG_IDLE_MS: 1500, // dump-complete idle/silence watchdog, rearmed on each send and receive;
+  //                         well over the sub-second gap between responses in a healthy wave, so it
+  //                         fires only on a genuine stall (see docs/protocol.md "the dump wave")
+  WATCHDOG_MAX_MS: 10000, // dump-complete absolute per-wave ceiling regardless of activity; comfortably
+  //                         above the slowest observed enumeration (bank list ~4-6s, device-model.md §9)
   SYNC_STEP_MS: 1000, // pause between steps of the dev sync test loop
 };
 

--- a/src/midi.js
+++ b/src/midi.js
@@ -10,14 +10,18 @@ import { TIMING } from './constants.js';
 let selectedOutput = null;
 let selectedInput = null;
 
-// 7c shadow-fire — per-wave request counter and 1500ms hard-ceiling
-// watchdog. A wave begins when outstanding transitions 0->1. The
-// watchdog is set once at wave start and is NOT reset on subsequent
-// sends within the wave (hard ceiling, not silence detector). The
-// wave ends either when outstanding returns to 0
-// (reason='all-received') or when the watchdog fires
-// (reason='watchdog'). Existing 200ms parser timers remain in place;
-// consumer migration is 7d.
+// Per-wave request counter and idle-reset watchdog. A wave begins when
+// outstanding transitions 0->1. The watchdog is an idle/silence timer:
+// it is rearmed for WATCHDOG_IDLE_MS on every send AND every received
+// response, bounded by an absolute WATCHDOG_MAX_MS ceiling measured from
+// wave start. This lets a healthy multi-second tree enumeration complete
+// via outstanding returning to 0 (reason='all-received') instead of being
+// cut short mid-stream; the watchdog (reason='watchdog') now fires only on
+// a genuine stall (silence longer than the idle window) or the absolute
+// cap. (Earlier this was a fixed 1500ms hard ceiling set once at wave
+// start, which tripped during normal 4-6s enumerations and dropped every
+// response that arrived after.) Existing 200ms parser timers remain in
+// place; consumer migration is Phase 3.1.
 let outstanding = 0;
 let waveSends = 0;
 let waveReceives = 0;
@@ -26,17 +30,27 @@ let waveLastKey = null;
 let watchdogHandle = null;
 const dumpStats = { all: 0, watchdog: 0 };
 
+// (Re)arm the idle watchdog for WATCHDOG_IDLE_MS, never extending past the
+// absolute WATCHDOG_MAX_MS ceiling from wave start. Called on every send and
+// every received response while a wave is in flight.
+function rearmWatchdog() {
+  if (watchdogHandle !== null) clearTimeout(watchdogHandle);
+  const remaining = TIMING.WATCHDOG_MAX_MS - (Date.now() - waveStart);
+  const delay = Math.max(0, Math.min(TIMING.WATCHDOG_IDLE_MS, remaining));
+  watchdogHandle = setTimeout(forceComplete, delay);
+}
+
 function recordRequest(key) {
   if (outstanding === 0 && watchdogHandle === null) {
     waveStart = Date.now();
     waveSends = 0;
     waveReceives = 0;
     waveLastKey = null;
-    watchdogHandle = setTimeout(forceComplete, TIMING.WATCHDOG_MS);
   }
   outstanding++;
   waveSends++;
   waveLastKey = key;
+  rearmWatchdog();
 }
 
 /**
@@ -59,6 +73,8 @@ export function notifyResponse(_type, _key) {
   waveReceives++;
   if (outstanding === 0) {
     finishWave('all-received');
+  } else {
+    rearmWatchdog();
   }
 }
 

--- a/tests/midi.test.js
+++ b/tests/midi.test.js
@@ -1,17 +1,17 @@
 // tests/midi.test.js
 //
-// 7c-scoped: covers the per-wave request counter, 1500ms hard-ceiling
-// watchdog, and getDumpStats added in this step. The byte-level contract
-// suite for sendSysEx / sendObjectInfoDump / sendValuePut / sendKeypress
-// (CLAUDE.md "Testing", originally planned for roadmap step 1) is still
-// pending and is not in scope for this file. The 5 cases below mirror
-// the counter's actual contract as approved in 7c plan review:
+// Covers the per-wave request counter, the idle-reset watchdog, and
+// getDumpStats. The byte-level contract suite for sendSysEx /
+// sendObjectInfoDump / sendValuePut / sendKeypress lives in the second
+// describe below. The counter/watchdog cases mirror its actual contract:
 //
-//   1. 0->1 transition starts the watchdog.
+//   1. 0->1 transition arms the idle watchdog.
 //   2. all-received fires when outstanding returns to 0.
-//   3. watchdog fires at the ceiling and is NOT reset by mid-wave sends.
-//   4. notifyResponse with outstanding===0 is a no-op.
-//   5. getDumpStats returns a snapshot copy, not a live reference.
+//   3. the idle watchdog is rearmed by mid-wave sends and receives
+//      (it is a silence timer, not a fixed hard ceiling).
+//   4. the absolute WATCHDOG_MAX_MS cap fires under continuous activity.
+//   5. notifyResponse with outstanding===0 is a no-op.
+//   6. getDumpStats returns a snapshot copy, not a live reference.
 //
 // midi.js's finishWave touches a single appState key (lastDumpComplete)
 // via the real store.setState. The real store/state are safe under jest
@@ -62,7 +62,7 @@ describe('midi.js per-wave counter and watchdog (7c)', () => {
     jest.useRealTimers();
   });
 
-  test('first send (0->1 transition) starts the watchdog', () => {
+  test('first send (0->1 transition) arms the idle watchdog', () => {
     sendObjectInfoDump('a');
     jest.advanceTimersByTime(1499);
     expect(received).toHaveLength(0);
@@ -88,19 +88,36 @@ describe('midi.js per-wave counter and watchdog (7c)', () => {
     expect(appState.lastDumpComplete).toMatchObject({ reason: 'all-received' });
   });
 
-  test('watchdog is per-wave hard ceiling: subsequent sends within the wave do NOT reset it', () => {
-    sendObjectInfoDump('a');
-    jest.advanceTimersByTime(1000);
-    sendObjectInfoDump('b');
-    jest.advanceTimersByTime(499);
+  test('idle watchdog is rearmed by mid-wave sends and receives (not a hard ceiling)', () => {
+    sendObjectInfoDump('a'); // armed at t=0, would fire t=1500
+    jest.advanceTimersByTime(1000); // t=1000
+    sendObjectInfoDump('b'); // send rearms -> would fire t=2500
+    jest.advanceTimersByTime(1000); // t=2000, outstanding=2
+    notifyResponse('objectinfo', 'a'); // receive rearms -> would fire t=3500, outstanding=1
+    jest.advanceTimersByTime(1499); // t=3499
     expect(received).toHaveLength(0);
-    jest.advanceTimersByTime(1);
+    jest.advanceTimersByTime(1); // t=3500
     expect(received).toHaveLength(1);
     expect(received[0]).toMatchObject({
       reason: 'watchdog',
       sendCount: 2,
+      receiveCount: 1,
       lastKey: 'b',
     });
+  });
+
+  test('absolute WATCHDOG_MAX_MS cap fires even under continuous activity', () => {
+    sendObjectInfoDump('a'); // waveStart t=0, outstanding stays >0 throughout
+    // Rearm the idle window every second so only the absolute cap can end
+    // the wave. WATCHDOG_MAX_MS is 10000 and WATCHDOG_IDLE_MS is 1500.
+    for (let t = 1000; t < 10000; t += 1000) {
+      jest.advanceTimersByTime(1000);
+      sendObjectInfoDump('x');
+      expect(received).toHaveLength(0);
+    }
+    jest.advanceTimersByTime(1000); // reach t=10000, the absolute cap
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({ reason: 'watchdog' });
   });
 
   test('notifyResponse with outstanding===0 is a no-op', () => {


### PR DESCRIPTION
## What (FB4)

The per-wave `dumpComplete` watchdog was a fixed **1500 ms hard ceiling** armed once at wave start and never reset. A healthy multi-second tree enumeration (the bank list `OBJECTINFO 10020012`, ~70 names, takes **4-6 s** on real hardware) tripped it mid-stream: it emitted `dumpComplete('watchdog')`, reset `outstanding` to 0, then silently **dropped every response that arrived after** (each hit the `outstanding===0` early-return in `notifyResponse`).

## Fix

Make the watchdog an **idle/silence timer**: rearm for `WATCHDOG_IDLE_MS` (1500 ms) on every send **and** every received response, bounded by an absolute `WATCHDOG_MAX_MS` (10000 ms) ceiling from wave start. Healthy enumerations now complete via `outstanding` returning to 0 (`all-received`); the watchdog fires only on a genuine stall or the cap. Replaces `WATCHDOG_MS` with the two new constants.

## Tests

`tests/midi.test.js`: the old "hard ceiling, sends don't reset it" case becomes "idle watchdog rearmed by sends **and** receives", plus a new absolute-cap case. Full suite green (76 tests, 10 snapshots), lint clean.

## Code review (per the new always-review workflow)

Two reviewer agents audited this branch before merge:
- **Correctness** — verdict: correct; no blockers/majors. Confirmed no timer leak, no reentrancy (cap uses a 0 ms macrotask, never synchronous), no double-fire; tests pin both rearm paths and the cap. Residual hardware risk noted (a >1500 ms mid-enumeration gap would still trip the idle timer) — already covered by the existing `getDumpStats` watchdog-rate escalation instrument.
- **Docs/self-document** — the dump-wave model was only in code comments; added a durable section to `docs/protocol.md`, fixed stale `WATCHDOG_MS`/"1500ms ceiling" references in `device-model.md` §9 and the tracker, and strengthened the constant comments to justify their values.

A prioritized list of broader README gaps the docs reviewer found is captured for a separate dedicated docs batch.
