### PR TITLE
fix: read screen dims from 0x17 header + verify checksum (FB1)

### DIFF
--- a/docs/device-model.md
+++ b/docs/device-model.md
@@ -227,7 +227,7 @@ specifies the denibbled layout exactly:
 | 4–7   | height     | screen height in pixels                              |
 | 8–11  | dumpSize   | bitmap size in bytes                                 |
 | 12 …  | bitmap     | `ceil(width/8) * height` bytes, 1bpp, MSB = leftmost |
-| last  | checksum   | 1 byte (2 nibbles); all bytes incl. size sum to 0    |
+| last  | checksum   | 1 byte (2 nibbles); see checksum note below          |
 
 For the Orville (240×64) this is the **1933-byte** stream we observe: 12 header
 + 1920 pixels + 1 checksum. **Verified against `screen-dump-black-hole.txt`**:
@@ -235,12 +235,19 @@ the header decodes to width `0x000000F0` = 240, height `0x00000040` = 64. So the
 12-byte header we'd been treating as opaque is really three u32 fields, and the
 trailing byte is the documented **checksum** (not a mystery).
 
-Pixels are row-major, MSB = leftmost (`src/framebuffer.js`). Note our decoder
-currently **hardcodes** 240×64 and skips a fixed 12-byte header; per this spec
-it could instead **read** width/height/size from the header and verify the
-checksum (logged as a robustness follow-up — see issue tracker). This is the
-physical LCD, independent of app navigation. Render any capture with
-`npm run screen <fixture> out.png`.
+**Checksum, exactly** `[V]`: the sum of every byte from the **size field
+(offset 8) through the checksum byte**, inclusive, is `0 mod 256` — confirmed
+against the full `screen-dump-black-hole.txt` capture. It does not include the
+width/height fields. (Tech Note 34's "all bytes incl. size sum to 0" means
+*from* the size field; see `protocol.md` §Screen bitmap and
+`SCREEN.CHECKSUM_SUM_OFFSET`.)
+
+Pixels are row-major, MSB = leftmost (`src/framebuffer.js`). The decoder
+**reads** width/height/size from the header (`parseScreenHeader`/`computePixels`,
+falling back to 240×64 only when the header dims are missing/insane) and
+`renderBitmap` flags truncated, bad-checksum, or insane-dimension dumps instead
+of silently rendering them (FB1, resolved). This is the physical LCD, independent
+of app navigation. Render any capture with `npm run screen <fixture> out.png`.
 
 ## 8. Dual DSP & presets `[V/D]`
 
@@ -312,8 +319,9 @@ distinct ids; id 0 = broadcast (§1).
   mis-tokenize (latent).
 - **Framing** `[V]` — OBJECTINFO uses CRLF lines + trailing NUL; VALUE_DUMP does
   not (see §1).
-- **Screen dump carries a checksum** `[D]` — the trailing byte is a sum-to-zero
-  checksum (§7); the app currently doesn't verify it.
+- **Screen dump carries a checksum** `[V]` — the trailing byte is a sum-to-zero
+  checksum over the size field through the checksum byte (§7); the decoder now
+  verifies it and flags a mismatch (FB1, resolved).
 - **Bad reads degrade to empty, not error** `[V]` (live-probed) — `OBJECTINFO`
   on an unknown key returns a **type-8 empty object**; `VALUE_DUMP` on an unknown
   key returns the key with an **empty value**. No `SYSEXC_ERROR` for reads. So a

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -129,8 +129,21 @@ reviewer agents swept all of src/; findings consolidated below.
       layout + framing notes. TN34 PDF kept locally in logs/ (gitignored; copyright) — cited by URL only.
 
 ### Device-research follow-ups (from Tech Note 34)
-- [ ] FB1 framebuffer.js robustness: READ width/height/size from the 0x17 header (per TN34) instead of
-      hardcoding 240x64, and verify the trailing checksum. CODE change — pending (own PR). Low priority.
+- [x] FB1 RESOLVED (branch fix/framebuffer-header-checksum): parseScreenHeader() reads width/height/size from
+      the three big-endian u32 header fields; computePixels derives dims from the header (fallback 240x64 if
+      missing/insane); renderBitmap logs an error on truncation / checksum-mismatch / bad-dims instead of
+      silently painting a partial screen. CHECKSUM ALGORITHM confirmed against a full hardware capture: the
+      sum of every byte from the size field (offset 8) through the trailing checksum byte is 0 mod 256 (TN34's
+      "all bytes incl. size sum to 0" = from the size field). Tests pin it against screen-dump-black-hole.txt.
+- [ ] FB5 (NEW, found during FB1) HIL capture truncates SysEx at 2048 bytes: hil-screenshot.cjs /
+      orville-probe.cjs (via @julusian/midi on WinMM) receive a 0x17 screen dump as exactly 2048 message
+      bytes -> only 1021 of the expected 1933 denibbled bytes (header says size=1920; we get ~1009 pixel
+      bytes = top ~34 of 64 rows). The five golden captures in tests/fixtures/golden/ (PR #75) are therefore
+      TOP-PORTION-ONLY, not full screens — the bottom half is zero-filled, not blank. The full-capture path
+      works (screen-dump-black-hole.txt is a complete 1933-byte dump from the browser/app debug path), so this
+      is specific to the @julusian/midi CLI receive buffer. NEEDS DEVICE: fix the CLI sysex buffer (or
+      reassemble multi-buffer sysex), then recapture full goldens. Until then the goldens regression-test only
+      the top rows. FB1's truncation check (complete=false) now detects this class of bug at decode time.
 - [x] FB4 RESOLVED (branch fix/dump-watchdog-idle-reset): the midi.js dump watchdog was a fixed 1500ms hard
       ceiling that fired mid-response on large enumerations like the bank list (OBJECTINFO 10020012, ~70 names,
       ~4-6s). Replaced with an idle/silence watchdog (WATCHDOG_IDLE_MS 1500, rearmed on every send and receive)

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -77,14 +77,30 @@ The denibbled stream is **1933 bytes**, and Tech Note 34 specifies its layout:
 | 4–7          | height in pixels (u32) — `0x00000040` = 64        |
 | 8–11         | bitmap size in bytes (u32) — 1920                 |
 | 12–1931      | 1920 bytes of pixel data                          |
-| 1932         | 1-byte checksum (all bytes incl. size sum to 0)   |
+| 1932         | 1-byte checksum (see below)                        |
 
 So `SCREEN.HEADER_BYTES = 12` is really three u32 fields (width/height/size).
 Pixels are **`ceil(width/8) × height`, 1 bit per pixel, MSB = leftmost** — for
 240×64 that's 30 bytes/row — a plain row-major decode
-(`framebuffer.js:computePixels`). A set bit is a lit (green) pixel. The decoder
-hardcodes 240×64 today; per the spec it could read the dimensions from the
-header and verify the checksum (tracker follow-up).
+(`framebuffer.js:computePixels`). A set bit is a lit (green) pixel.
+
+**Checksum (exact, confirmed against a full hardware capture).** The trailing
+byte is set so that the sum of **every byte from the size field (offset 8)
+through the checksum byte, inclusive, is `0 mod 256`** — i.e.
+`sum(bytes[8 .. 1932]) & 0xFF === 0`. It does *not* cover the width/height
+fields (offsets 0–7). Tech Note 34's terser phrasing "all bytes incl. size sum
+to 0" means *from* the size field; the constants
+(`SCREEN.CHECKSUM_SUM_OFFSET = 8`) and `framebuffer.js:parseScreenHeader` make
+this unambiguous, and it is pinned by a test against `screen-dump-black-hole.txt`.
+
+**The decoder reads the header.** `framebuffer.js:parseScreenHeader` reads
+width/height/size from the header, `computePixels` derives the dimensions from
+it (falling back to `SCREEN.WIDTH`/`HEIGHT` = 240×64 only when the header dims
+are missing or out of range), and `bitmap.js:renderBitmap` logs an integrity
+error — rather than silently painting a partial or corrupt screen — when a dump
+is truncated, has a bad checksum, or carries insane dimensions. (A truncated
+dump is exactly the FB5 capture failure mode: the `@julusian/midi` CLI receive
+path caps the screen SysEx at 2048 bytes; see the issue tracker.)
 
 > Historical note: earlier code used a 13-byte header and compensated for the
 > resulting 1-byte misalignment with a column rotate + a 1px shift of the first

--- a/src/bitmap.js
+++ b/src/bitmap.js
@@ -1,6 +1,6 @@
 // bitmap.js
 import { log } from './logger.js';
-import { denibble, computePixels } from './framebuffer.js';
+import { denibble, computePixels, parseScreenHeader } from './framebuffer.js';
 import { SCREEN } from './sysex-commands.js';
 import { CANVAS } from './constants.js';
 
@@ -12,8 +12,27 @@ export { denibble };
 export function renderBitmap(canvasId, rawBytes) {
   const canvas = document.getElementById(canvasId);
   const ctx = canvas.getContext('2d');
-  const width = SCREEN.WIDTH;
-  const height = SCREEN.HEIGHT;
+  // Use the dimensions the device reports in the header (falling back to the
+  // 240x64 defaults if the header is missing/insane), and surface integrity
+  // problems rather than silently rendering a partial or corrupt screen.
+  const hdr = parseScreenHeader(rawBytes);
+  const width = hdr.dimsValid ? hdr.width : SCREEN.WIDTH;
+  const height = hdr.dimsValid ? hdr.height : SCREEN.HEIGHT;
+  if (!hdr.dimsValid) {
+    log(
+      `[SCREEN] Header dims out of range (${hdr.width}x${hdr.height}); using ${width}x${height}`,
+      'error',
+      'error'
+    );
+  } else if (!hdr.complete) {
+    log(
+      `[SCREEN] Dump truncated: got ${rawBytes.length} bytes, expected ${hdr.expectedLength}`,
+      'error',
+      'error'
+    );
+  } else if (!hdr.checksumOk) {
+    log('[SCREEN] Dump checksum mismatch', 'error', 'error');
+  }
   canvas.width = width;
   canvas.height = height;
   canvas.style.width = CANVAS.CSS_WIDTH;

--- a/src/framebuffer.js
+++ b/src/framebuffer.js
@@ -42,8 +42,7 @@ function readU32BE(bytes, offset) {
   );
 }
 
-const dimsSane = (w, h) =>
-  w > 0 && h > 0 && w <= SCREEN.MAX_DIMENSION && h <= SCREEN.MAX_DIMENSION;
+const dimsSane = (w, h) => w > 0 && h > 0 && w <= SCREEN.MAX_DIMENSION && h <= SCREEN.MAX_DIMENSION;
 
 /**
  * Parse and integrity-check a denibbled 0x17 screen dump's 12-byte header.

--- a/src/framebuffer.js
+++ b/src/framebuffer.js
@@ -31,24 +31,73 @@ export function denibble(nibbles) {
   return rawBytes;
 }
 
+// Read a big-endian u32 from a byte array at the given offset.
+function readU32BE(bytes, offset) {
+  return (
+    ((bytes[offset] << 24) |
+      (bytes[offset + 1] << 16) |
+      (bytes[offset + 2] << 8) |
+      bytes[offset + 3]) >>>
+    0
+  );
+}
+
+const dimsSane = (w, h) =>
+  w > 0 && h > 0 && w <= SCREEN.MAX_DIMENSION && h <= SCREEN.MAX_DIMENSION;
+
+/**
+ * Parse and integrity-check a denibbled 0x17 screen dump's 12-byte header.
+ *
+ * @param {number[]} rawBytes - Denibbled screen-dump bytes.
+ * @returns {{
+ *   width: number, height: number, size: number, bytesPerRow: number,
+ *   expectedLength: number, dimsValid: boolean, complete: boolean, checksumOk: boolean
+ * }} width/height/size as reported by the header; bytesPerRow = ceil(width/8);
+ *   expectedLength = header + size + checksum; dimsValid = dims within bounds;
+ *   complete = buffer holds the full expected length; checksumOk = the
+ *   size-field-through-checksum sum is 0 mod 256 (only meaningful when complete).
+ */
+export function parseScreenHeader(rawBytes) {
+  const width = readU32BE(rawBytes, SCREEN.WIDTH_OFFSET);
+  const height = readU32BE(rawBytes, SCREEN.HEIGHT_OFFSET);
+  const size = readU32BE(rawBytes, SCREEN.SIZE_OFFSET);
+  const dimsValid = dimsSane(width, height);
+  const bytesPerRow = Math.ceil(width / 8);
+  const expectedLength = SCREEN.HEADER_BYTES + size + SCREEN.CHECKSUM_BYTES;
+  const complete = rawBytes.length >= expectedLength;
+  let checksumOk = false;
+  if (complete) {
+    let sum = 0;
+    for (let i = SCREEN.CHECKSUM_SUM_OFFSET; i < expectedLength; i++) sum += rawBytes[i];
+    checksumOk = (sum & 0xff) === 0;
+  }
+  return { width, height, size, bytesPerRow, expectedLength, dimsValid, complete, checksumOk };
+}
+
 /**
  * Decode raw screen-dump bytes into an RGBA pixel buffer (green-on-black,
  * matching the device's LCD). Straight row-major 1bpp decode, no heuristics.
  *
  * @param {number[]} rawBytes - Denibbled screen-dump bytes (12-byte header + data).
  * @param {Object} [opts]
- * @param {number} [opts.width=240]
- * @param {number} [opts.height=64]
+ * @param {number} [opts.width] - Override width. Defaults to the header's width
+ *   when sane, else SCREEN.WIDTH.
+ * @param {number} [opts.height] - Override height. Defaults to the header's
+ *   height when sane, else SCREEN.HEIGHT.
  * @param {number} [opts.header=12] - Bytes to skip before the pixel data.
  *   Exposed for diagnosing future captures; 12 is correct for the 0x17 dump.
  * @returns {Uint8ClampedArray} width*height*4 RGBA bytes.
  */
-export function computePixels(
-  rawBytes,
-  { width = SCREEN.WIDTH, height = SCREEN.HEIGHT, header = SCREEN.HEADER_BYTES } = {}
-) {
+export function computePixels(rawBytes, opts = {}) {
+  const header = opts.header ?? SCREEN.HEADER_BYTES;
+  let { width, height } = opts;
+  if (width == null || height == null) {
+    const hdr = parseScreenHeader(rawBytes);
+    if (width == null) width = hdr.dimsValid ? hdr.width : SCREEN.WIDTH;
+    if (height == null) height = hdr.dimsValid ? hdr.height : SCREEN.HEIGHT;
+  }
   const data = new Uint8ClampedArray(width * height * 4);
-  const bytesPerRow = width / 8;
+  const bytesPerRow = Math.ceil(width / 8);
   const bitmap = rawBytes.slice(header, header + bytesPerRow * height);
   const processed = NO_FLIP ? bitmap : bitmap.map((b) => bit_reverse_table[b]);
   for (let y = 0; y < height; y++) {

--- a/src/sysex-commands.js
+++ b/src/sysex-commands.js
@@ -11,11 +11,22 @@ export const SYSEX = {
   FRAME_PREFIX_LEN: 5, // F0 1C 70 <deviceId> <cmd> before the payload
 };
 
-// Screen-dump (0x17) geometry, after denibbling.
+// Screen-dump (0x17) geometry, after denibbling. The 12-byte header is three
+// big-endian u32 fields (width, height, bitmap size in bytes), followed by the
+// 1bpp pixel data and a 1-byte checksum. See docs/protocol.md "Screen bitmap".
 export const SCREEN = {
-  WIDTH: 240,
-  HEIGHT: 64,
+  WIDTH: 240, // fallback width if the header is missing/insane
+  HEIGHT: 64, // fallback height if the header is missing/insane
   HEADER_BYTES: 12, // header bytes before the 1bpp pixel data
+  WIDTH_OFFSET: 0, // u32 width field
+  HEIGHT_OFFSET: 4, // u32 height field
+  SIZE_OFFSET: 8, // u32 bitmap-size field
+  CHECKSUM_BYTES: 1, // trailing checksum byte after the pixel data
+  // The checksum is set so that the sum of every byte from the size field
+  // (SIZE_OFFSET) through the checksum byte, inclusive, is 0 mod 256. Verified
+  // against hardware captures; TN34 phrases it "all bytes incl. size sum to 0".
+  CHECKSUM_SUM_OFFSET: 8,
+  MAX_DIMENSION: 4096, // sanity bound for a header-reported width/height
 };
 
 export const CMD = {

--- a/tests/fixtures/golden/README.md
+++ b/tests/fixtures/golden/README.md
@@ -3,6 +3,14 @@
 Canonical 240x64 (1bpp, 1x) renders of real Orville LCD states, captured live
 over MIDI from the physical unit on 2026-06-08 via `build_tools/hil-screenshot.cjs`.
 
+> **Known limitation (tracker FB5): these captures are TOP-PORTION-ONLY.** The
+> `@julusian/midi` CLI receive path truncates the `0x17` SysEx at 2048 message
+> bytes, so each `.txt` here denibbles to ~1021 of the expected 1933 bytes — only
+> the top ~34 of 64 rows. The bottom of each PNG is zero-filled (black), not blank
+> screen. They still regression-test the decoder for the captured rows; recapture
+> full screens once the CLI buffer is fixed (needs the device). A complete capture
+> looks like `tests/fixtures/screen-dump-black-hole.txt` (full 1933 bytes).
+
 Each `screen-<name>.png` here is the expected render of the raw `0x17` capture in
 `tests/fixtures/screen-<name>.txt`, decoded by `build_tools/render-screen.js`
 (which shares `computePixels` from `src/framebuffer.js`). They are the reference

--- a/tests/framebuffer.test.js
+++ b/tests/framebuffer.test.js
@@ -21,7 +21,9 @@ describe('denibble', () => {
 });
 
 describe('computePixels', () => {
-  // 13-byte header + 1920 data bytes, all 0xff (every pixel lit).
+  // 1933 bytes all 0xff (12-byte header + 1920 pixels + checksum); every
+  // pixel lit. The all-0xff header parses as an insane width, so dims fall
+  // back to 240x64 (see the fallback test below).
   const allOn = new Array(13 + 1920).fill(0xff);
 
   test('returns a full RGBA buffer of the right size', () => {
@@ -70,6 +72,13 @@ describe('computePixels', () => {
   test('falls back to 240x64 when the header dims are insane', () => {
     const px = computePixels(new Array(13 + 1920).fill(0xff)); // width parses as 0xffffffff
     expect(px.length).toBe(240 * 64 * 4);
+  });
+
+  test('zero-fills without throwing when the buffer is truncated below its dims', () => {
+    const px = computePixels(tinyScreen.slice(0, 14)); // 16x2 header intact, pixels cut short
+    expect(px.length).toBe(16 * 2 * 4);
+    expect(px[(0 * 16 + 0) * 4 + 1]).toBe(255); // first captured pixel still lit
+    expect(px[(1 * 16 + 15) * 4 + 1]).toBe(0); // beyond captured bytes -> off
   });
 });
 

--- a/tests/framebuffer.test.js
+++ b/tests/framebuffer.test.js
@@ -1,7 +1,14 @@
 // tests/framebuffer.test.js
 // Direct coverage of the pure framebuffer decoder.
 
-import { denibble, computePixels } from '../src/framebuffer.js';
+import { denibble, computePixels, parseScreenHeader } from '../src/framebuffer.js';
+import { loadFixture } from './helpers/sysex-fixture.js';
+
+// A minimal but well-formed screen dump: 16x2 (bytesPerRow=2, size=4),
+// top-left pixel lit, with a valid checksum (sum of size field..checksum == 0).
+// header: width=16, height=2, size=4 (each big-endian u32); then 4 pixel
+// bytes; then the checksum. sum(bytes[8..end]) = 4 + 0x80 + 0x7c = 256 -> 0.
+const tinyScreen = [0, 0, 0, 16, 0, 0, 0, 2, 0, 0, 0, 4, 0x80, 0, 0, 0, 0x7c];
 
 describe('denibble', () => {
   test('combines high/low nibble pairs into bytes', () => {
@@ -46,5 +53,82 @@ describe('computePixels', () => {
     while (bytes.length < 13 + 1920) bytes.push(0);
     expect(computePixels(bytes, { header: 12 })[(0 * 240 + 0) * 4 + 1]).toBe(0);
     expect(computePixels(bytes, { header: 13 })[(0 * 240 + 0) * 4 + 1]).toBe(255);
+  });
+
+  test('derives dimensions from the header when not overridden (FB1)', () => {
+    const px = computePixels(tinyScreen);
+    expect(px.length).toBe(16 * 2 * 4); // header-reported 16x2, not 240x64
+    expect(px[(0 * 16 + 0) * 4 + 1]).toBe(255); // top-left lit
+    expect(px[(0 * 16 + 1) * 4 + 1]).toBe(0); // next pixel off
+  });
+
+  test('explicit width/height override the header', () => {
+    const px = computePixels(tinyScreen, { width: 240, height: 64 });
+    expect(px.length).toBe(240 * 64 * 4);
+  });
+
+  test('falls back to 240x64 when the header dims are insane', () => {
+    const px = computePixels(new Array(13 + 1920).fill(0xff)); // width parses as 0xffffffff
+    expect(px.length).toBe(240 * 64 * 4);
+  });
+});
+
+describe('parseScreenHeader (FB1)', () => {
+  test('reads width/height/size and validates a well-formed dump', () => {
+    const h = parseScreenHeader(tinyScreen);
+    expect(h).toMatchObject({
+      width: 16,
+      height: 2,
+      size: 4,
+      bytesPerRow: 2,
+      expectedLength: 17, // 12 header + 4 pixels + 1 checksum
+      dimsValid: true,
+      complete: true,
+      checksumOk: true,
+    });
+  });
+
+  test('flags a checksum mismatch', () => {
+    const bad = tinyScreen.slice();
+    bad[bad.length - 1] = 0x00; // break the trailing checksum
+    const h = parseScreenHeader(bad);
+    expect(h.complete).toBe(true);
+    expect(h.checksumOk).toBe(false);
+  });
+
+  test('flags a truncated dump (the 2048-byte capture failure mode)', () => {
+    const truncated = tinyScreen.slice(0, 15); // missing last pixel byte + checksum
+    const h = parseScreenHeader(truncated);
+    expect(h.expectedLength).toBe(17);
+    expect(h.complete).toBe(false);
+    expect(h.checksumOk).toBe(false); // not evaluated on an incomplete buffer
+  });
+
+  test('reports dims invalid for an all-0xff (garbage) header', () => {
+    const h = parseScreenHeader(new Array(20).fill(0xff));
+    expect(h.dimsValid).toBe(false);
+  });
+
+  test('bytesPerRow rounds up for non-multiple-of-8 widths', () => {
+    // width=20 -> ceil(20/8)=3 bytes/row
+    const h = parseScreenHeader([0, 0, 0, 20, 0, 0, 0, 1, 0, 0, 0, 3]);
+    expect(h.bytesPerRow).toBe(3);
+  });
+
+  test('validates a real full-screen hardware capture (240x64, checksum ok)', () => {
+    // screen-dump-black-hole.txt is a complete 0x17 capture (1933 denibbled
+    // bytes). Pins the real-hardware header + checksum algorithm.
+    const msg = loadFixture('screen-dump-black-hole.txt'); // F0 1C 70 dev 17 ... F7
+    const raw = denibble(msg.slice(5, msg.length - 1));
+    const h = parseScreenHeader(raw);
+    expect(h).toMatchObject({
+      width: 240,
+      height: 64,
+      size: 1920,
+      expectedLength: 1933,
+      dimsValid: true,
+      complete: true,
+      checksumOk: true,
+    });
   });
 });


### PR DESCRIPTION
## What (FB1)

`framebuffer.js` hardcoded 240×64 and skipped a fixed 12-byte header with no validation. Now:
- **`parseScreenHeader(rawBytes)`** reads width/height/size from the three big-endian u32 header fields, computes expected length (header + size + checksum), and verifies the trailing checksum.
- **`computePixels`** derives dims from the header when not overridden (falls back to 240×64 if missing/insane); `bytesPerRow = ceil(width/8)`.
- **`renderBitmap`** uses the header dims and logs an `error` on truncation / checksum-mismatch / out-of-range dims instead of silently painting a partial/garbled screen.

## Checksum algorithm (confirmed against real hardware)

The trailing byte makes `sum(bytes[8 .. checksum]) & 0xFF === 0` — the sum runs **from the size field** (offset 8) through the checksum, *excluding* width/height. TN34's terse "all bytes incl. size sum to 0" was ambiguous; pinned by a test against the full `screen-dump-black-hole.txt` capture (1933 bytes).

## Side-finding (logged as FB5, needs device)

While verifying, found the **`@julusian/midi` CLI capture path truncates the screen SysEx at 2048 bytes** → live captures are ~1021 of 1933 bytes (top ~34 of 64 rows). The PR #75 golden fixtures are therefore top-portion-only; caveat added to their README and to the tracker. FB1's `complete: false` check now detects this class of bug at decode time. Full recapture needs the device + a CLI buffer fix.

## Tests / review

86 green (+10), lint clean. Reviewed by correctness + docs agents (always-review workflow): no blockers/majors; correctness verdict "correct and well-tested"; docs reviewer documented the exact checksum in `protocol.md`/`device-model.md`. Applied the cheap review nits (truncation-safety test, stale comment). One deferred minor noted by review: a sane-but-large (≤4096²) garbage header would allocate before the log-only integrity check — remote, left as-is.
