### PR TITLE
fix: reassemble multi-packet SysEx in the app inbound path (FB6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,9 @@ index.html
       └─ hex-extract.js     debug-file hex parsing
 ```
 
-Data flow: user clicks → `controls.js` sends SysEx via `midi.js` → Orville responds → `midi.js` listener → `parser.js` parses, writes state via `store.setState`, and emits events on `events.js` → `event-bridge.js` coalesces and calls `renderer.renderScreen` → paints `#lcd`. Bitmap path: `0x17` SysEx → `parser.js` denibbles (`bitmap.js`) → emits `screen:received` → `event-bridge.js` → `renderBitmap` on the canvas.
+Data flow: user clicks → `controls.js` sends SysEx via `midi.js` → Orville responds → `midi.js` listener (`addSysexListener` reassembles multi-packet SysEx from `F0` to `F7` before parsing — see below) → `parser.js` parses, writes state via `store.setState`, and emits events on `events.js` → `event-bridge.js` coalesces and calls `renderer.renderScreen` → paints `#lcd`. Bitmap path: `0x17` SysEx → `parser.js` denibbles (`bitmap.js`) → emits `screen:received` → `event-bridge.js` → `renderBitmap` on the canvas.
+
+Inbound SysEx is not necessarily one WebMIDI event per message: a long dump (`0x17` screen, large `0x32` OBJECTINFO like the ~70-name bank list) can be split across packets, so `addSysexListener` buffers from `F0` until `F7` and calls `parseResponse` once per complete message — a pass-through when messages already arrive whole. Applies to every inbound type, not just screens. See `docs/protocol.md` §Framing "Inbound reassembly" and tracker FB6.
 
 ## Module structure (refactor complete)
 

--- a/docs/device-model.md
+++ b/docs/device-model.md
@@ -254,7 +254,8 @@ of app navigation. Render any capture with `npm run screen <fixture> out.png`.
 ~3872-byte SysEx), so `npm run screenshot`
 (`build_tools/hil-screenshot.cjs`) reassembles chunks until `F7` before
 decoding — see `protocol.md` §Screen bitmap "Capturing screens (HIL)" and
-tracker FB5.
+tracker FB5. (Reassembling inbound SysEx until `F7` is general to every inbound
+type; the browser app does it too in `midi.js:addSysexListener` — tracker FB6.)
 
 ## 8. Dual DSP & presets `[V/D]`
 

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -147,6 +147,15 @@ reviewer agents swept all of src/; findings consolidated below.
       complete && checksumOk) and re-rendered. Verified against the device. SCOPE: only hil-screenshot.cjs
       (the golden-capture path) was fixed; orville-probe.cjs's diagnostic `screen` action still keeps only the
       first chunk, which is fine for a quick diagnostic dump — fix it there too only if it ever needs full screens.
+- [x] FB6 RESOLVED (branch fix/app-sysex-reassembly): the SAME multi-packet truncation could hit the BROWSER
+      APP, not just the CLI. midi.js addSysexListener handed a single WebMIDI `e.data` straight to parseResponse
+      with no reassembly, so if Chrome ever delivers a long SysEx split across packets, the app would render a
+      truncated screen (0x17) OR a truncated/corrupt OBJECTINFO menu (e.g. the ~70-name bank list). FIX:
+      addSysexListener now buffers — starts a new buffer on F0 (SYSEX.START), appends continuation packets, and
+      only calls parseResponse on the F7 terminator; a pass-through when messages already arrive complete.
+      Covers every inbound SysEx type, not just the screen. Tested (complete pass-through, split reassembly,
+      buffer reset on new F0, Uint8Array data). NOT yet verified whether Chrome actually chunks on this device
+      (would need an in-browser test against the unit); the fix is correct either way (defensive + matches FB5).
 - [x] FB4 RESOLVED (branch fix/dump-watchdog-idle-reset): the midi.js dump watchdog was a fixed 1500ms hard
       ceiling that fired mid-response on large enumerations like the bank list (OBJECTINFO 10020012, ~70 names,
       ~4-6s). Replaced with an idle/silence watchdog (WATCHDOG_IDLE_MS 1500, rearmed on every send and receive)

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -156,6 +156,12 @@ reviewer agents swept all of src/; findings consolidated below.
       Covers every inbound SysEx type, not just the screen. Tested (complete pass-through, split reassembly,
       buffer reset on new F0, Uint8Array data). NOT yet verified whether Chrome actually chunks on this device
       (would need an in-browser test against the unit); the fix is correct either way (defensive + matches FB5).
+- [ ] FB7 (NEW, from FB6 review) midi.js addSysexListener can double-register: selectPorts() (main.js) is wired
+      to a button and also auto-runs on cached-config load, and nothing removes the prior 'sysex' listener, so
+      re-selecting ports attaches a second listener -> parseResponse fires twice per message (over-decrements
+      the dump-wave counter, can cause a premature all-received). PRE-EXISTING (the old one-line listener
+      double-fired too); FB6 only carried it forward. FIX: guard re-registration (track an attached flag, or
+      selectedInput.removeListener before re-adding). CODE, low priority.
 - [x] FB4 RESOLVED (branch fix/dump-watchdog-idle-reset): the midi.js dump watchdog was a fixed 1500ms hard
       ceiling that fired mid-response on large enumerations like the bank list (OBJECTINFO 10020012, ~70 names,
       ~4-6s). Replaced with an idle/silence watchdog (WATCHDOG_IDLE_MS 1500, rearmed on every send and receive)

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -33,6 +33,19 @@ F0 1C 70 <deviceId> <cmd> <payload...> F7
 The five bytes before the payload are `SYSEX.FRAME_PREFIX_LEN`; inbound parsing
 slices `data.slice(5, -1)` to get the payload.
 
+**Inbound reassembly (every inbound type).** A single inbound SysEx is not
+guaranteed to arrive in one delivery: a long message can be split across packets
+by the platform/MIDI stack, and the slow 31250-baud DIN link makes the big dumps
+(`0x17` screen, large `0x32` OBJECTINFO such as the ~70-name bank list) the most
+likely to fragment. Both inbound paths therefore reassemble from `F0`
+(`SYSEX.START`) until the `F7` terminator before parsing, and feed the parser one
+complete message — start a new buffer on `F0`, append continuation packets, parse
+on `F7`. When a message already arrives whole this is a pass-through. The browser
+app does this in `midi.js:addSysexListener` (tracker FB6); the CLI capture tool
+does the same (tracker FB5; see **Capturing screens (HIL)** for the
+hardware-specific chunk sizes/timing). This applies to *all* inbound types
+(`0x17`, `0x2e`, `0x32`), not just screens.
+
 **Device ID.** The hardware uses 1–63. OrvilleCommander treats `0` as an
 auto-detect sentinel: on the first inbound message it adopts `data[3]` as the
 device ID, then matches on it thereafter.
@@ -122,7 +135,11 @@ accumulates chunks from the header until it sees `F7` (a ~4 s window with retry)
 then validates completeness. An earlier version kept only the first chunk and so
 produced a 2048-byte / top-rows-only capture — this is FB5 in the issue tracker,
 and was a transmission-speed/chunking artifact, **not** a device or buffer-size
-limit. Anyone capturing screens over this MIDI path hits the same chunking.
+limit. Anyone capturing screens over this MIDI path hits the same chunking. The
+reassemble-until-`F7` rule itself is general to every inbound type and is not
+CLI-specific — see **Inbound reassembly** under §Framing; the browser app does
+the same in `midi.js:addSysexListener` (tracker FB6). This section just documents
+the hardware-specific chunk sizes and timing the CLI tool observes.
 
 ### Object-info — request `0x31` (out), response `0x32` (in)
 

--- a/src/midi.js
+++ b/src/midi.js
@@ -165,7 +165,9 @@ export function addSysexListener() {
     const data = Array.from(e.data);
     if (data[0] === SYSEX.START) sysexBuffer = data;
     else sysexBuffer = sysexBuffer.concat(data);
-    if (sysexBuffer[sysexBuffer.length - 1] === SYSEX.END) {
+    // Flush only a properly framed message (starts F0, ends F7). The F0 guard
+    // discards a stray continuation packet that arrives with no header.
+    if (sysexBuffer[0] === SYSEX.START && sysexBuffer[sysexBuffer.length - 1] === SYSEX.END) {
       parseResponse(sysexBuffer);
       sysexBuffer = [];
     }

--- a/src/midi.js
+++ b/src/midi.js
@@ -152,8 +152,23 @@ export function addSysexListener() {
     log('Error: MIDI input not set; cannot add listener', 'error', 'error');
     return;
   }
+  // Reassemble multi-packet SysEx before parsing. Chrome's Web MIDI normally
+  // delivers a complete F0..F7 message in one event, but a long SysEx can be
+  // split across packets by the platform/driver (the ~3872-byte 0x17 screen
+  // dump and large OBJECTINFO dumps travel over a 31250-baud DIN link from the
+  // Orville). Start a new buffer on F0, append continuation packets, and only
+  // parse once the F7 terminator arrives. When messages already arrive complete
+  // this is a pass-through. (Matches the CLI capture tool; see
+  // docs/protocol.md "Capturing screens (HIL)".)
+  let sysexBuffer = [];
   selectedInput.addListener('sysex', (e) => {
-    parseResponse(e.data);
+    const data = Array.from(e.data);
+    if (data[0] === SYSEX.START) sysexBuffer = data;
+    else sysexBuffer = sysexBuffer.concat(data);
+    if (sysexBuffer[sysexBuffer.length - 1] === SYSEX.END) {
+      parseResponse(sysexBuffer);
+      sysexBuffer = [];
+    }
   });
 }
 

--- a/src/sysex-commands.js
+++ b/src/sysex-commands.js
@@ -6,7 +6,7 @@
 // SysEx framing bytes.
 export const SYSEX = {
   START: 0xf0, // F0 SysEx start (first byte of every inbound message)
-  END: 0xf7, // F7 SysEx end (used as a text marker when scanning hex dumps)
+  END: 0xf7, // F7 SysEx end (inbound reassembly terminator; also a text marker when scanning hex dumps)
   MANUFACTURER: [0x1c, 0x70], // Eventide ID + DSP4000 product ID
   VALUE_SEPARATOR: 0x20, // space between key and value in a VALUE_PUT
   FRAME_PREFIX_LEN: 5, // F0 1C 70 <deviceId> <cmd> before the payload

--- a/src/sysex-commands.js
+++ b/src/sysex-commands.js
@@ -5,6 +5,7 @@
 
 // SysEx framing bytes.
 export const SYSEX = {
+  START: 0xf0, // F0 SysEx start (first byte of every inbound message)
   END: 0xf7, // F7 SysEx end (used as a text marker when scanning hex dumps)
   MANUFACTURER: [0x1c, 0x70], // Eventide ID + DSP4000 product ID
   VALUE_SEPARATOR: 0x20, // space between key and value in a VALUE_PUT

--- a/tests/midi.test.js
+++ b/tests/midi.test.js
@@ -246,4 +246,21 @@ describe('addSysexListener multi-packet reassembly', () => {
     handler({ data: Uint8Array.from([0xf0, 0x1c, 0x70, 1, 0x2e, 0x41, 0xf7]) });
     expect(parseResponse).toHaveBeenCalledWith([0xf0, 0x1c, 0x70, 1, 0x2e, 0x41, 0xf7]);
   });
+
+  test('reassembles a SysEx split across three packets', () => {
+    handler({ data: [0xf0, 0x1c, 0x70, 1, 0x17] }); // header
+    handler({ data: [0x01, 0x02] }); // middle continuation
+    expect(parseResponse).not.toHaveBeenCalled();
+    handler({ data: [0x03, 0xf7] }); // final continuation + terminator
+    expect(parseResponse).toHaveBeenCalledTimes(1);
+    expect(parseResponse).toHaveBeenCalledWith([0xf0, 0x1c, 0x70, 1, 0x17, 0x01, 0x02, 0x03, 0xf7]);
+  });
+
+  test('ignores a stray continuation packet (no F0 header) ending in F7', () => {
+    handler({ data: [0x03, 0x04, 0xf7] }); // headerless fragment that happens to end in F7
+    expect(parseResponse).not.toHaveBeenCalled(); // F0 guard rejects it
+    handler({ data: [0xf0, 0x1c, 0x70, 1, 0x2e, 0x41, 0xf7] }); // then a real message
+    expect(parseResponse).toHaveBeenCalledTimes(1);
+    expect(parseResponse).toHaveBeenCalledWith([0xf0, 0x1c, 0x70, 1, 0x2e, 0x41, 0xf7]);
+  });
 });

--- a/tests/midi.test.js
+++ b/tests/midi.test.js
@@ -42,7 +42,9 @@ import {
   sendSysEx,
   sendValuePut,
   sendKeypress,
+  addSysexListener,
 } from '../src/midi.js';
+import { parseResponse } from '../src/parser.js';
 import { on } from '../src/events.js';
 import { appState } from '../src/state.js';
 
@@ -198,5 +200,50 @@ describe('midi.js SysEx byte contract', () => {
   test('sendSysEx with no output logs an error and does not throw', () => {
     setMidiPorts(null, null, 0);
     expect(() => sendSysEx(0x18, [])).not.toThrow();
+  });
+});
+
+describe('addSysexListener multi-packet reassembly', () => {
+  let handler;
+
+  beforeEach(() => {
+    parseResponse.mockClear();
+    handler = null;
+    const input = {
+      addListener: (type, cb) => {
+        if (type === 'sysex') handler = cb;
+      },
+    };
+    setMidiPorts({ sendSysex: jest.fn() }, input, 1);
+    addSysexListener();
+  });
+
+  test('passes a complete single-packet SysEx straight through', () => {
+    const msg = [0xf0, 0x1c, 0x70, 1, 0x2e, 0x41, 0xf7];
+    handler({ data: msg });
+    expect(parseResponse).toHaveBeenCalledTimes(1);
+    expect(parseResponse).toHaveBeenCalledWith(msg);
+  });
+
+  test('reassembles a SysEx split across packets and parses once on F7', () => {
+    handler({ data: [0xf0, 0x1c, 0x70, 1, 0x17, 0x01, 0x02] }); // header packet, no F7
+    expect(parseResponse).not.toHaveBeenCalled();
+    handler({ data: [0x03, 0x04, 0xf7] }); // continuation + terminator
+    expect(parseResponse).toHaveBeenCalledTimes(1);
+    expect(parseResponse).toHaveBeenCalledWith([
+      0xf0, 0x1c, 0x70, 1, 0x17, 0x01, 0x02, 0x03, 0x04, 0xf7,
+    ]);
+  });
+
+  test('a new F0 packet resets the buffer (no leakage between messages)', () => {
+    handler({ data: [0xf0, 0x1c, 0x70, 1, 0x17, 0x01] }); // incomplete, no F7
+    handler({ data: [0xf0, 0x1c, 0x70, 1, 0x2e, 0x41, 0xf7] }); // fresh complete message
+    expect(parseResponse).toHaveBeenCalledTimes(1);
+    expect(parseResponse).toHaveBeenCalledWith([0xf0, 0x1c, 0x70, 1, 0x2e, 0x41, 0xf7]);
+  });
+
+  test('accepts Uint8Array event data', () => {
+    handler({ data: Uint8Array.from([0xf0, 0x1c, 0x70, 1, 0x2e, 0x41, 0xf7]) });
+    expect(parseResponse).toHaveBeenCalledWith([0xf0, 0x1c, 0x70, 1, 0x2e, 0x41, 0xf7]);
   });
 });


### PR DESCRIPTION
## What (FB6)

FB5 fixed the CLI capture tool, but the **browser app** had the same latent truncation. `midi.js:addSysexListener` handed a single WebMIDI `e.data` to `parseResponse` with **no reassembly** — so if Chrome ever delivers a long SysEx split across packets (the ~3872-byte `0x17` screen dump, or a large `0x32` OBJECTINFO like the ~70-name bank list, all arriving over the Orville's 31250-baud DIN link), the app would render a truncated screen **or a corrupt menu**.

## Fix

`addSysexListener` now buffers: start a new buffer on `F0` (new `SYSEX.START` constant), append continuation packets, flush to `parseResponse` only on the `F7` terminator (and only when the buffer is properly framed — starts F0, ends F7). It's a **pass-through** when messages already arrive whole, so it's safe regardless of whether Chrome chunks. Covers every inbound SysEx type, not just the screen.

## Tests

6 reassembly cases: complete pass-through, 2-way + 3-way split, buffer reset on a new F0, stray headerless continuation rejected, `Uint8Array` input. Full suite 90 green, lint + format clean.

## Review

Correctness + docs reviewers (always-review workflow). Correctness verdict: **safe to merge, no regression on the normal complete-message path** (parser is type-agnostic for Array vs Uint8Array; F7 can't appear mid-body for any inbound type). Applied its hardening (F0 start-guard, extra tests). Docs reviewer documented the inbound reassembly as general behavior in `protocol.md`/`CLAUDE.md`/`device-model.md`.

Note: the reviewer flagged a **pre-existing** defect (addSysexListener can double-register if ports are re-selected, since the old listener is never removed) — logged as **FB7**, out of this PR's scope.
