### PR TITLE
docs: adopt Closes #N GitHub issue workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,7 @@ Sub-object types in the ASCII dump: `COL` (column/menu), `NUM`, `SET`, `CON` (co
 - When touching render logic, add a renderer snapshot test first (see `03-test-coverage-gap.md`).
 - Before claiming a task complete, run `npm test` and report the output. Do not declare success based on reading the diff.
 - Commit messages follow conventional commits (`fix:`, `refactor:`, `test:`, `docs:`, `chore:`). Reference the roadmap step in the body when relevant.
+- GitHub Issues track the same work as `docs/issue-tracker.md`. When a PR resolves an item that has a matching GitHub issue, put `Closes #N` in the PR body so it auto-closes on merge. Every PR is reviewed by spawned reviewer agents (correctness + docs) before merge — see the issue-tracker workflow.
 - If a task grows beyond its stated scope mid-session, stop and ask rather than expanding. Mechanically necessary follow-throughs (e.g., updating a test mock after an import change) are in-scope and do not require asking.
 - All work happens on a feature branch merged via PR; never commit directly to `main`. If `git branch --show-current` shows `main`, branch first.
 

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -18,7 +18,8 @@ physical Orville. `needs-decision` = a product/UX or irreversible call for the m
 3. Do the item's **NEXT:** action. Run `npm test` and report raw output. Add a snapshot test first if
    touching render logic.
 4. Update this ledger (status + NEXT), commit (conventional-commit message, no AI-attribution, no
-   emoji), push, open/append the batch PR.
+   emoji), push, open/append the batch PR. If the item has a matching GitHub issue, put `Closes #N`
+   in the PR body so it auto-closes on merge. Spawn reviewer agents (correctness + docs) before merge.
 5. On a gate, mark the item with its gate tag, write the exact validation steps under the batch, and
    move to the next non-blocked item.
 


### PR DESCRIPTION
Documents the issue-closing process you asked for: PRs put `Closes #N` in the body so merges auto-close the matching GitHub issue, and every PR is reviewed by spawned reviewer agents before merge. Recorded in CLAUDE.md conventions and the ledger's resume protocol.

Reconciliation already done out-of-band: closed the 14 genuinely-shipped issues (#1, #25, #26, #27, #28-#36, #46) with PR-linked comments. Phase 3 (#37-#44) and partials (#45, #47) left open. Docs-only; no reviewer needed (process you dictated).