### PR TITLE
fix: autoload-descend sources keyStack entry from param subs, not global (C5)

### DIFF
--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -272,10 +272,14 @@ HUMAN-GATE: none
 
 ### Batch 3.2 — State-shape hardening
 - [ ] C3  Normalize keyStack mixed types (string@0, objects@1+) to always-objects or split structures (GH #39)
-- [x] C5  (branch fix/autoload-subs-param, GH #41) renderer autoload-descend now records the `subs` param it
-      was invoked with, not the global appState.currentSubs — under stale debounced delivery the global may be
-      a newer dump, which recorded the wrong keyStack parent lineage. currentKey stays global (it is the loaded
-      key, distinct from subs[0]; startup.test pins this). New renderer.test case pins the stale-delivery path.
+- [x] C5  (branch fix/autoload-subs-param, GH #41) renderer autoload-descend now sources the keyStack parent
+      entry from the `subs` param it was invoked with, not the global appState.currentSubs. NOTE (from review):
+      renderScreen re-pins currentSubs=subs at its top (render-pin), so global==param today and this was NOT an
+      observable bug — the fix is correct-by-construction / defensive (robust if the pin is ever moved/removed).
+      currentKey stays global (it is the loaded key, distinct from subs[0]; startup.test pins this). New
+      renderer.test forces a divergent stale global (no-op setter) to prove the descend reads the param —
+      verified fail-on-old / pass-on-fix. RESIDUAL (minor, follow-up): the entry's `key` still reads the global
+      appState.currentKey, the same staleness class, but no param carries the loaded key.
 - [ ] C8  Clear childSubs on navigation (GH #44 — partial clears exist in renderer; some nav paths bypass them)
 - [ ] C7  Replace endsWith('0002') meter heuristic with a protocol-based check (GH #43 — "heuristic
       masquerading as protocol"; literal already named KEY_SUFFIX.METER in #57, deeper fix = detect CON-type

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -271,10 +271,15 @@ config toggles lazy) -> render on dumpComplete.
 HUMAN-GATE: none
 
 ### Batch 3.2 — State-shape hardening
-- [ ] C3  Normalize keyStack mixed types (string@0, objects@1+) to always-objects or split structures
-- [ ] C5  Renderer autoload: use `subs` param instead of global appState.currentSubs[0]
-- [ ] C8  Clear childSubs on navigation
-- [ ] C7  Replace endsWith('0002') meter heuristic with a defined check (KEY_SUFFIX.METER)
+- [ ] C3  Normalize keyStack mixed types (string@0, objects@1+) to always-objects or split structures (GH #39)
+- [x] C5  (branch fix/autoload-subs-param, GH #41) renderer autoload-descend now records the `subs` param it
+      was invoked with, not the global appState.currentSubs — under stale debounced delivery the global may be
+      a newer dump, which recorded the wrong keyStack parent lineage. currentKey stays global (it is the loaded
+      key, distinct from subs[0]; startup.test pins this). New renderer.test case pins the stale-delivery path.
+- [ ] C8  Clear childSubs on navigation (GH #44 — partial clears exist in renderer; some nav paths bypass them)
+- [ ] C7  Replace endsWith('0002') meter heuristic with a protocol-based check (GH #43 — "heuristic
+      masquerading as protocol"; literal already named KEY_SUFFIX.METER in #57, deeper fix = detect CON-type
+      from loaded subs rather than key suffix; needs more VALUE_DUMP coverage first)
 - [ ] NEW Persist active DSP (A/B) app-side as view state (default A)
 HUMAN-GATE: none
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -846,7 +846,13 @@ export function renderScreen(subs, ascii, logParam) {
         'info',
         'general'
       );
-      const parentMain = appState.currentSubs[0];
+      // Use the `subs` this render was invoked with, not the global
+      // appState.currentSubs — under stale debounced delivery the global may
+      // have been overwritten by a newer dump, which would record the wrong
+      // parent lineage in keyStack (C5 / #41). currentKey stays global: it is
+      // the key being loaded (e.g. the preset), distinct from subs[0] (the
+      // rendered page's main object).
+      const parentMain = subs[0];
       const parentTag = parentMain.tag.trim() || parentMain.statement.split(' ')[0].trim();
       setState(
         {
@@ -855,7 +861,7 @@ export function renderScreen(subs, ascii, logParam) {
             {
               key: appState.currentKey,
               tag: parentTag,
-              subs: (appState.currentSubs || []).slice(),
+              subs: subs.slice(),
             },
           ],
           currentKey: softSubsLocal[0].key,

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -846,12 +846,13 @@ export function renderScreen(subs, ascii, logParam) {
         'info',
         'general'
       );
-      // Use the `subs` this render was invoked with, not the global
-      // appState.currentSubs — under stale debounced delivery the global may
-      // have been overwritten by a newer dump, which would record the wrong
-      // parent lineage in keyStack (C5 / #41). currentKey stays global: it is
-      // the key being loaded (e.g. the preset), distinct from subs[0] (the
-      // rendered page's main object).
+      // Source the keyStack parent entry from the `subs` this render was invoked
+      // with, not the global appState.currentSubs. The render-pin at the top of
+      // renderScreen keeps the global == subs today, but reading the param is
+      // correct-by-construction and stays right if a stale/newer dump ever
+      // diverges the global from this render's input (C5 / #41). currentKey stays
+      // global: it is the key being loaded (e.g. the preset), distinct from
+      // subs[0] (the rendered page's main object).
       const parentMain = subs[0];
       const parentTag = parentMain.tag.trim() || parentMain.statement.split(' ')[0].trim();
       setState(

--- a/tests/renderer.test.js
+++ b/tests/renderer.test.js
@@ -265,6 +265,37 @@ describe('renderer.js', () => {
     expect(sendValueDump).toHaveBeenCalledWith('10010000', null);
   });
 
+  test('autoload-descend records the param subs, not the stale global currentSubs (#41)', () => {
+    appState.autoLoad = true;
+    appState.currentKey = '401000b'; // the key being loaded (stays global)
+    // A stale global left by a newer dump — must NOT seed the keyStack entry.
+    appState.currentSubs = [
+      { type: 'COL', position: '0', key: 'STALE', parent: '', statement: 'Stale', tag: 'stale' },
+    ];
+    // The subs THIS render was invoked with: two short-tag COL children, no params.
+    const subs = [
+      { type: 'COL', position: '0', key: '0', parent: '', statement: 'Real Root', tag: 'realroot' },
+      {
+        type: 'COL',
+        position: '1',
+        key: '10010000',
+        parent: '0',
+        statement: 'Setup',
+        tag: 'setup',
+      },
+      { type: 'COL', position: '2', key: '10020000', parent: '0', statement: 'Prog', tag: 'prog' },
+    ];
+    renderScreen(subs, '', mockLog);
+
+    expect(appState.keyStack).toHaveLength(1);
+    const entry = appState.keyStack[0];
+    expect(entry.tag).toBe('realroot'); // from param subs[0], not the stale 'stale'
+    expect(entry.subs[0].key).toBe('0');
+    expect(entry.subs.map((s) => s.key)).not.toContain('STALE');
+    expect(entry.key).toBe('401000b'); // currentKey (loaded key) stays global
+    expect(appState.currentKey).toBe('10010000'); // descended to first child
+  });
+
   test('lcd click on dsp-clickable swaps active preset and pushes keyStack', () => {
     appState.currentKey = '0';
     appState.dspAName = 'Reverb';

--- a/tests/renderer.test.js
+++ b/tests/renderer.test.js
@@ -265,13 +265,9 @@ describe('renderer.js', () => {
     expect(sendValueDump).toHaveBeenCalledWith('10010000', null);
   });
 
-  test('autoload-descend records the param subs, not the stale global currentSubs (#41)', () => {
+  test('autoload-descend sources the keyStack entry from the param subs, not the global (#41)', () => {
     appState.autoLoad = true;
     appState.currentKey = '401000b'; // the key being loaded (stays global)
-    // A stale global left by a newer dump — must NOT seed the keyStack entry.
-    appState.currentSubs = [
-      { type: 'COL', position: '0', key: 'STALE', parent: '', statement: 'Stale', tag: 'stale' },
-    ];
     // The subs THIS render was invoked with: two short-tag COL children, no params.
     const subs = [
       { type: 'COL', position: '0', key: '0', parent: '', statement: 'Real Root', tag: 'realroot' },
@@ -285,7 +281,30 @@ describe('renderer.js', () => {
       },
       { type: 'COL', position: '2', key: '10020000', parent: '0', statement: 'Prog', tag: 'prog' },
     ];
-    renderScreen(subs, '', mockLog);
+    // renderScreen re-pins appState.currentSubs = subs at its top, which normally
+    // keeps global == param and masks the divergence. Pin the global to a STALE
+    // value with a no-op setter so it survives that re-pin — simulating stale
+    // debounced delivery. This makes the test fail on the old code (which read
+    // appState.currentSubs[0]) and pass on the fix (which reads subs[0]).
+    const stale = [
+      { type: 'COL', position: '0', key: 'STALE', parent: '', statement: 'Stale', tag: 'stale' },
+    ];
+    Object.defineProperty(appState, 'currentSubs', {
+      configurable: true,
+      get: () => stale,
+      set: () => {}, // swallow renderScreen's render-pin write
+    });
+    try {
+      renderScreen(subs, '', mockLog);
+    } finally {
+      // Restore currentSubs as a normal data property for subsequent tests.
+      Object.defineProperty(appState, 'currentSubs', {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value: [],
+      });
+    }
 
     expect(appState.keyStack).toHaveLength(1);
     const entry = appState.keyStack[0];


### PR DESCRIPTION
## What (Phase 3.2 / C5 / #41)

`renderScreen`'s autoload-descend built the keyStack parent entry from the global `appState.currentSubs[0]` instead of the `subs` param it was called with. Now it uses `subs[0]` for parentMain/tag and `subs.slice()` for the snapshot. `appState.currentKey` intentionally stays the entry's `key` (it's the key being loaded — e.g. a preset — distinct from `subs[0].key`; startup.test Tier B pins they differ).

## Honest scope (from review)

`renderScreen` re-pins `currentSubs = subs` at its top, so global == param at the descend **today** — this is **not an observable bug**; the fix is **correct-by-construction / defensive** (reads its own input, robust if that pin is ever moved/removed). The review caught that the first test couldn't fail on the old code for this reason.

## Test

Rewritten to genuinely guard the regression: it forces a **divergent stale global** (defines `currentSubs` with a no-op setter that swallows the render-pin write), so it **fails on the old global-read and passes on the param-read** — verified by temporarily reverting the fix (`Expected "realroot", Received "stale"`). 99 green, lint + format clean.

## Review

Correctness + docs reviewers. Correctness verdict: fix correct/complete/safe (strictly more robust; no-op in happy path), but flagged the test efficacy gap (now fixed) and a **residual minor** — the entry's `key` still reads global `currentKey` (same staleness class; no param carries the loaded key) — logged in the ledger as a follow-up. Docs reviewer: no doc changes needed (living docs accurate).

Closes #41
