### PR TITLE
docs: restore original README structure + mermaid diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,83 +1,121 @@
 # Orville Commander
 
-A browser front-end for viewing and controlling the Eventide Orville over MIDI.
-It talks to the unit's SysEx interface, reconstructs the LCD from the device's
-text dumps, and renders it as HTML (plus an optional 1bpp screen-capture canvas),
-so the device can be driven from a browser instead of the front panel.
+A web-based remote interface for viewing and controlling the Eventide Orville effects processor screen via MIDI. Built with WebMIDI, JavaScript, and HTML/CSS. The goal is to enable remote access on devices like browsers, with future cross-platform potential once a prototype is complete.
 
-Vanilla ES modules, no UI framework.
+## Table of Contents
+- [Overview](#overview)
+- [Setup and Installation](#setup-and-installation)
+- [Architecture](#architecture)
+- [Key Modules](#key-modules)
+- [Data Flow](#data-flow)
+- [Known Issues and Refactoring Opportunities](#known-issues-and-refactoring-opportunities)
+- [Contributing](#contributing)
 
-## Quick start
+## Overview
+This project emulates the Orville's LCD screen and controls in a browser, using SysEx MIDI messages for communication. It parses responses, renders the screen as text/HTML (with optional bitmap canvas), and handles user interactions like keypresses and value changes.
 
-```
-npm install
-npm run dev      # Vite dev server, src/ as root — open the printed URL
-```
+- **Core Features**:
+  - MIDI connection and SysEx handling.
+  - Screen rendering (text-based with params, softkeys, and breadcrumbs).
+  - Virtual controls (buttons, keypad).
+  - State management for navigation (key stack, values).
+  - Debugging tools (logs, polling, config saving).
 
-Use **Chrome, Edge, or Opera** — WebMIDI is required, and Firefox/Safari will
-silently fail to connect. Grant MIDI permission, pick the input/output ports,
-set the device ID (default 0), then navigate with the on-screen panel.
+- **Tech Stack**:
+  - JavaScript (ES modules).
+  - WebMIDI API for MIDI.
+  - HTML/CSS for UI.
+  - Runtime deps: `webmidi` and `lodash.debounce` only. Dev: Vite, Jest, ESLint, Prettier.
 
-Other scripts:
+## Setup and Installation
+1. Clone the repo: `git clone <repo-url>`.
+2. Install dependencies: `npm install`.
+3. Start the dev server: `npm run dev` (Vite), then open the printed URL in Chrome, Edge, or Opera (WebMIDI support; Firefox/Safari silently fail).
+4. Connect MIDI devices via the UI (select input/output ports).
+5. Configure device ID (default: 0) and other settings (log level, bitmap fetching).
+6. Use the virtual panel to navigate and interact.
 
-```
-npm test           # Jest + jsdom
-npm run lint       # ESLint (flat config)
-npm run format     # Prettier
-npm run screenshot # Hardware-in-the-loop: capture the live screen to a PNG (needs the device)
-```
-
-**Dependencies:** runtime — `webmidi` and `lodash.debounce` only. Dev toolchain —
-Vite, Jest, ESLint, Prettier, Babel.
+**Dependencies**: `webmidi` + `lodash.debounce` (runtime); requires browser MIDI access.
 
 ## Architecture
+The app follows a modular structure with separation of concerns:
+- **State Management**: Centralized in `state.js`/`store.js` (appState object behind an audited `setState`).
+- **MIDI Communication**: Handled in `midi.js` (send/receive SysEx, inbound reassembly).
+- **Parsing**: In `parser.js` (processes responses, emits events).
+- **Rendering**: In `renderer.js` (LCD HTML) and `bitmap.js`/`framebuffer.js` (screen-capture canvas), driven by `event-bridge.js` off the `events.js` bus.
+- **Controls/UI**: In `controls.js` and `index.html` (button events).
+- **Config/Persistence**: In `config.js` (localStorage).
+- **Entry Point**: `main.js` (initializes everything, event listeners).
 
-User input → `controls.js` sends SysEx via `midi.js` → the Orville replies →
-`midi.js`'s inbound listener reassembles multi-packet SysEx and hands complete
-messages to `parser.js` → the parser writes state via `store.setState` and emits
-events on the `events.js` bus → `event-bridge.js` coalesces those and calls the
-renderer → `renderer.js` paints the LCD (and `bitmap.js`/`framebuffer.js` paint
-the screen-capture canvas).
+High-level diagram:
+```mermaid
+graph TD
+    A["User Input (Buttons/Keypad)"] --> B["controls.js"]
+    B --> C["midi.js: Send SysEx/Keypress"]
+    C --> D["Orville Device"]
+    D --> E["midi.js: Receive + reassemble SysEx"]
+    E --> F["parser.js: Parse Response"]
+    F --> G["store.js: Update appState"]
+    F --> K["events.js: Emit events"]
+    K --> L["event-bridge.js: Coalesce"]
+    L --> H["renderer.js: Render LCD"]
+    H --> I["index.html: Display"]
+    J["main.js: Init & Config"] --> G
+```
 
-| Module | Role |
-|---|---|
-| `main.js` | Entry point: DOM wiring, connect flow, event-bridge registration |
-| `controls.js` | Front-panel keypress masks + button → SysEx mapping |
-| `midi.js` | WebMIDI send, SysEx framing, inbound reassembly, dump-wave counter |
-| `parser.js` | SysEx byte stream → structured sub-objects & values; emits events |
-| `event-bridge.js` | Subscribes to parser events; owns render timing |
-| `renderer.js` | Sub-objects → LCD HTML; click/change handlers |
-| `bitmap.js` / `framebuffer.js` | `0x17` screen-dump decode + canvas render |
-| `store.js` / `state.js` | `appState` singleton behind an audited `setState` |
-| `events.js` | Tiny pub/sub bus (`emit` / `on`) |
-| `sysex-commands.js` | `CMD` / `KEY` / `SYSEX` / `SCREEN` protocol constants |
-| `sysex-split.js` | Shared ASCII dump tokenizer |
-| `navigation.js` | `toggleDspKey` |
-| `logger.js` | Gated `log()` + its own log-level/category config |
-| `hex-extract.js` | Debug-file hex parsing |
+## Key Modules
 
-The eight-step decoupling refactor that broke the original import cycles is
-complete (merged in PR #23). `CLAUDE.md` has the authoritative, current
-architecture and conventions.
+* state.js / store.js: Holds global appState (e.g., currentKey, values, stack) behind `setState`. Why? Single source of truth for reactivity.
 
-## How the device works
+* midi.js: Manages ports, listeners, SysEx commands (e.g., sendObjectInfoDump), and inbound multi-packet reassembly. Key functions: setMidiPorts, sendSysEx, addSysexListener.
 
-The SysEx wire format is in [`docs/protocol.md`](docs/protocol.md); the device's
-behaviour (object tree, presets, value semantics, screen format, quirks) is in
-[`docs/device-model.md`](docs/device-model.md) — a from-scratch spec built by
-reverse-engineering plus live hardware capture. All frames are
-`F0 1C 70 <deviceId> <cmd> … F7`.
+* parser.js: Parses ASCII dumps into subs/objects and emits events. Exports: parseResponse.
 
-## Status & contributing
+* event-bridge.js / events.js: Pub/sub bus + render-timing coalescer between parser and renderer.
 
-Production-readiness work is tracked in two places that mirror each other:
-[GitHub Issues](https://github.com/auntiepickle/orvilleCommander/issues) and the
-checked-in ledger [`docs/issue-tracker.md`](docs/issue-tracker.md) (the
-resumable source of truth). The active Phase 3 design is in
+* renderer.js: Builds HTML for LCD (params, softkeys, breadcrumbs). Handles clicks/changes. Exports: updateScreen, renderScreen.
+
+* bitmap.js / framebuffer.js: Decode the `0x17` screen dump and paint the capture canvas. Exports: renderBitmap, computePixels.
+
+* controls.js: Maps buttons to keypress masks; sets up event listeners. Exports: setupKeypressControls.
+
+* main.js: Bootstraps app, connects MIDI, adds listeners. Exports: showLoading, hideLoading.
+
+* config.js: Loads/saves config (ports, logs). Exports: loadConfig, saveConfig.
+
+* index.html: UI layout (LCD, buttons, debug tools).
+
+## Data Flow
+
+1. User clicks button → controls.js sends keypress via midi.js.
+
+2. Device responds with SysEx → midi.js listener reassembles it → parser.js processes.
+
+3. parser.js updates appState (store.js) and emits events on events.js.
+
+4. event-bridge.js coalesces and renderer.js re-renders the LCD (index.html).
+
+5. For values: Similar flow with VALUE_DUMP/PUT.
+
+Polling (e.g., meters) runs intervals in main.js.
+
+## Known Issues and Refactoring Opportunities
+
+The eight-step decoupling refactor that resolved the original tight-coupling,
+testing, and render-pipeline items is complete (merged in PR #23). Active
+production-readiness work is tracked in the checked-in ledger
+[`docs/issue-tracker.md`](docs/issue-tracker.md) (mirrored to
+[GitHub Issues](https://github.com/auntiepickle/orvilleCommander/issues)), with
+the Phase 3 design in
 [`docs/refactor/phase3-state-model.md`](docs/refactor/phase3-state-model.md).
 
-- One feature/fix per PR; conventional-commit messages (`fix:`, `refactor:`,
-  `test:`, `docs:`, `chore:`).
-- `npm test`, `npm run lint`, and `npm run format:check` must pass; CI enforces them.
-- When a PR resolves a tracked GitHub issue, put `Closes #N` in the body.
-- See `CLAUDE.md` for the full conventions and the smoke-test checklist.
+The SysEx wire format is in [`docs/protocol.md`](docs/protocol.md) and the
+device behaviour spec in [`docs/device-model.md`](docs/device-model.md).
+
+## Contributing
+
+* Fork and PR changes.
+
+* Focus on one feature/fix per PR (e.g., "Add JSDoc to midi.js").
+
+* Use git commit messages like: "docs: add initial README structure for overview and architecture".


### PR DESCRIPTION
Reverts the heavy README rewrite back to your original layout (TOC, Overview, Setup, Architecture + **mermaid diagram**, Key Modules, Data Flow, Known Issues, Contributing). Kept only the necessary factual fixes: Vite setup (not `open index.html`), real deps (webmidi + lodash.debounce, not "None"), the events-bus/event-bridge path, corrected module exports, and live doc links (the old 05-status.md/future-work.md links were dead after the refactor-folder prune). Mermaid diagram restored. Docs-only.