### PR TITLE
refactor: centralize childSubs clearing; make child-dump guard explicit (C8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ Sub-object types in the ASCII dump: `COL` (column/menu), `NUM`, `SET`, `CON` (co
 
 ## Where state lives
 
-Almost all runtime state is on `appState` (state.js). The exception: `logger.js` owns its own log level and per-category visibility as private module state (defaults from `constants.DEFAULT_LOG_CATEGORIES`), set via `setLogLevel` / `setLogCategories`. This was moved off `appState` (C6) so `logger.js` no longer imports `state.js`, breaking the `store` → `logger` → `state` → `store` import cycle. Everything persistent is in `localStorage.midiConfig` (config.js). There is no other store. If you need durable state, add it to `midiConfig` via `saveConfig`.
+Almost all runtime state is on `appState` (state.js). The per-menu caches `childSubs` and `currentValues` are cleared in exactly one place — `renderer.js:updateScreen`, which every navigation path funnels through — so don't add per-handler clears (C8/#44). The exception: `logger.js` owns its own log level and per-category visibility as private module state (defaults from `constants.DEFAULT_LOG_CATEGORIES`), set via `setLogLevel` / `setLogCategories`. This was moved off `appState` (C6) so `logger.js` no longer imports `state.js`, breaking the `store` → `logger` → `state` → `store` import cycle. Everything persistent is in `localStorage.midiConfig` (config.js). There is no other store. If you need durable state, add it to `midiConfig` via `saveConfig`.
 
 ## Dev server quirks
 

--- a/docs/device-model.md
+++ b/docs/device-model.md
@@ -101,11 +101,13 @@ multi-word field (so `'space parameters'` is one token). This is `splitLine` in
 
 On the object's **own** line, the `PARENT` field echoes the object's **own key**
 (self-referential), not its real parent — verified across every captured dump,
-including root (`COL 0 0 0 …`, `COL 0 4040001 4040001 …`). `[V]` Only the child
-lines carry a real parent (the dump's main key). Consequence: a dump does not
-identify where it sits in the tree, so a consumer correlating an unsolicited or
-late `OBJECTINFO` reply to a parent menu must use its own request/view state —
-the dump itself cannot be trusted for that.
+e.g. setup (`COL 0 10010000 10010000 …`, real parent `0`) and `space parameters`
+(`COL 0 4040001 4040001 …`, real parent `401000b`); root's `COL 0 0 0 …` is
+consistent but trivially so (key and parent are both `0` either way). `[V]` Only
+the child lines carry a real parent (the dump's main key). Consequence: a dump
+does not identify where it sits in the tree, so a consumer correlating an
+unsolicited or late `OBJECTINFO` reply to a parent menu must use its own
+request/view state — the dump itself cannot be trusted for that.
 
 The object's **own** line ends with its **child count in hex**; child lines show
 `0` for that field until you query them. Verified across fixtures:

--- a/docs/device-model.md
+++ b/docs/device-model.md
@@ -99,6 +99,14 @@ Tokenized like a shell line: whitespace-separated, single/double quotes group a
 multi-word field (so `'space parameters'` is one token). This is `splitLine` in
 `src/sysex-split.js`.
 
+On the object's **own** line, the `PARENT` field echoes the object's **own key**
+(self-referential), not its real parent — verified across every captured dump,
+including root (`COL 0 0 0 …`, `COL 0 4040001 4040001 …`). `[V]` Only the child
+lines carry a real parent (the dump's main key). Consequence: a dump does not
+identify where it sits in the tree, so a consumer correlating an unsolicited or
+late `OBJECTINFO` reply to a parent menu must use its own request/view state —
+the dump itself cannot be trusted for that.
+
 The object's **own** line ends with its **child count in hex**; child lines show
 `0` for that field until you query them. Verified across fixtures:
 

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -280,7 +280,19 @@ HUMAN-GATE: none
       renderer.test forces a divergent stale global (no-op setter) to prove the descend reads the param —
       verified fail-on-old / pass-on-fix. RESIDUAL (minor, follow-up): the entry's `key` still reads the global
       appState.currentKey, the same staleness class, but no param carries the loaded key.
-- [ ] C8  Clear childSubs on navigation (GH #44 — partial clears exist in renderer; some nav paths bypass them)
+- [x] C8  (branch fix/childsubs-nav-clear, GH #44) FINDING: the filed premise ("some nav paths bypass the
+      clear") no longer holds — every nav path (LCD clicks, keypress controls, sync, connect, polling)
+      funnels through updateScreen(), which clears childSubs+currentValues unconditionally and predates the
+      refactor. Cross-menu stale stores were also already blocked by the parser guard, but only implicitly
+      (a child entry's parent always equals the dump's main key, so the membership check can only pass when
+      currentSubs IS currentKey's dump). Shipped: removed the three redundant childSubs:{} patches in the
+      renderer click handlers (updateScreen documented as the single clear point); made the parser guard's
+      consistency precondition explicit (currentSubs[0].key === currentKey — fail-closed for late dumps
+      after navigation; new test proven fail-on-old); pinned the clear across descend/sibling/back/DSP-toggle
+      paths; documented the main-line PARENT self-echo in device-model.md §3 (a dump cannot self-identify
+      its parent — verified across all 8 OBJECTINFO fixtures). RESIDUAL (defer to C1): a VALID child dump
+      can be dropped if a stale re-render re-pins currentSubs before it lands — harmless (next updateScreen
+      refetch self-heals); request-correlated dumpComplete events are the real fix.
 - [ ] C7  Replace endsWith('0002') meter heuristic with a protocol-based check (GH #43 — "heuristic
       masquerading as protocol"; literal already named KEY_SUFFIX.METER in #57, deeper fix = detect CON-type
       from loaded subs rather than key suffix; needs more VALUE_DUMP coverage first)

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -288,8 +288,10 @@ HUMAN-GATE: none
       currentSubs IS currentKey's dump). Shipped: removed the three redundant childSubs:{} patches in the
       renderer click handlers (updateScreen documented as the single clear point); made the parser guard's
       consistency precondition explicit (currentSubs[0].key === currentKey — fail-closed for late dumps
-      after navigation; new test proven fail-on-old); pinned the clear across descend/sibling/back/DSP-toggle
-      paths; documented the main-line PARENT self-echo in device-model.md §3 (a dump cannot self-identify
+      after navigation; new test proven fail-on-old); pinned the clear with stale-seeded childSubs across
+      descend/sibling/back paths (the pre-existing DSP-toggle test also asserts childSubs is empty after
+      nav, but starts from empty childSubs, so that path alone would not catch a clear regression);
+      documented the main-line PARENT self-echo in device-model.md §3 (a dump cannot self-identify
       its parent — verified across all 8 OBJECTINFO fixtures). RESIDUAL (defer to C1): a VALID child dump
       can be dropped if a stale re-render re-pins currentSubs before it lands — harmless (next updateScreen
       refetch self-heals); request-correlated dumpComplete events are the real fix.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -160,6 +160,11 @@ Field order per line — `type position key parent statement tag …`:
 | `TRG` | trigger / action   | —                                                          |
 | `INF` | info / read-only   | `value`                                                    |
 
+On the dump's first line (the queried object itself), `parent` echoes the
+object's **own key**, not its real parent; only the child lines carry a real
+parent (the dump's main key). So a `0x32` reply cannot be correlated to a
+parent menu from its own bytes — see [`device-model.md`](device-model.md) §3.
+
 For `SET`, the option count is hex; the named options follow and become the
 dropdown choices.
 
@@ -172,9 +177,11 @@ dropdown choices.
   space) + `value` ASCII. Example — load DSP A (`sendValuePut('1002001c','1')`):
   `... 2D  31 30 30 32 30 30 31 63  20  31  F7`.
 
-The device does **not** acknowledge a put. The only confirmation is a subsequent
-`0x2e` dump, so the app issues a value request after a put to reconcile rather
-than trusting an optimistic local write.
+The device acknowledges a put by **echoing a `0x2e` dump** of the resulting —
+possibly clamped — value, even when the value is unchanged (live-probed; this
+corrects an earlier "no ack" note here — see `device-model.md` §6/§9 and
+tracker B10g.3). The app still issues a value request after a put to reconcile
+rather than trusting an optimistic local write.
 
 `0x2e` response payload is ASCII `"<key> <value…>"`; `parser.js` caches it under
 the key. `CON` values and meter keys trigger an immediate re-render; others are
@@ -205,8 +212,10 @@ render-coalescing build on (see
 
 - A wave **starts** when the `outstanding` request counter transitions `0 → 1`.
 - Each `OBJECTINFO_DUMP` (`0x31`) and `VALUE_DUMP` request (`0x2d`) increments
-  `outstanding` (via `recordRequest`). `VALUE_PUT` is **not** counted — the
-  device sends no response to a put (see the `0x2d` section above).
+  `outstanding` (via `recordRequest`). `VALUE_PUT` is **not** counted, although
+  the device does echo a `0x2e` for a put (see the `0x2d` section above): with
+  no wave in flight the echo is a no-op (`notifyResponse` returns at zero), but
+  mid-wave it decrements the counter as an uncounted response.
 - Each matching `0x32` / `0x2e` response decrements `outstanding`, via
   `notifyResponse`, which `parser.js` calls at the top of each branch. The
   counter is a pure count — it does not yet correlate responses to requests by

--- a/src/parser.js
+++ b/src/parser.js
@@ -84,10 +84,21 @@ export function parseResponse(data) {
         // current screen so the new top-bar/DSP names land. isLoadingPreset clear lives in event-bridge.js.
         emit('objectinfo:received', { key: main.key });
       } else {
-        // Store child sub-menu data if it's a child of the current menu
-        const isChild = appState.currentSubs.some(
-          (s) => s.key === main.key && s.parent === appState.currentKey
-        );
+        // Store child sub-menu data only if it's a child of the current menu.
+        // A dump cannot self-identify its parent: the object's own line echoes
+        // its own key in the parent slot (docs/device-model.md §3), so the only
+        // correlation available is the current menu's child list. currentSubs
+        // can lag navigation (it is replaced when the new menu's dump lands and
+        // re-pinned by renders), so first require that it actually describes
+        // currentKey; the membership check then guarantees the arriving dump is
+        // a child of the menu being viewed. Late dumps from a menu navigated
+        // away from fail this and are dropped (fail-closed, C8/#44); the next
+        // updateScreen refetch self-heals any drop. C1's request-correlated
+        // dump events will replace this view-state correlation.
+        const describesCurrentMenu = appState.currentSubs[0]?.key === appState.currentKey;
+        const isChild =
+          describesCurrentMenu &&
+          appState.currentSubs.some((s) => s.key === main.key && s.parent === appState.currentKey);
         if (isChild) {
           setState(
             { childSubs: { ...appState.childSubs, [main.key]: subs } },

--- a/src/parser.js
+++ b/src/parser.js
@@ -135,10 +135,11 @@ export function parseResponse(data) {
                   'general'
                 );
                 sendValuePut(programSub.key, newIndex.toString());
-                // No optimistic cache write (A3): the Orville does not
-                // acknowledge a PUT, so the re-dump below is the single source
-                // of truth and avoids a divergent cached value if the PUT does
-                // not take.
+                // No optimistic cache write (A3): the device echoes a 0x2e
+                // dump of the resulting (possibly clamped) value after a PUT
+                // (B10g.3), and the delayed re-dump below reconciles on top of
+                // that — either way the device, not a local write, is the
+                // single source of truth if the PUT does not take as sent.
                 setTimeout(() => sendValueDump(programSub.key), TIMING.REDUMP_MS);
               }
             }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -11,6 +11,10 @@ import { log } from './logger.js';
  * Updates the current screen by requesting OBJECTINFO_DUMP and VALUE_DUMP for the current key.
  * Clears childSubs and currentValues to refresh data. Optionally clears softkeys at root/top levels.
  *
+ * This is the single clear point for childSubs/currentValues (C8/#44): every
+ * navigation path (LCD clicks, keypress controls, sync, connect, polling)
+ * funnels through here, so per-handler clears are redundant by construction.
+ *
  * @param {Function} [logParam=null] - Optional logging function (defaults to global log).
  *
  * @example
@@ -42,8 +46,7 @@ const handleLcdClick = (e) => {
       presetKey: newPresetKey,
       currentKey: newPresetKey,
       autoLoad: true,
-      currentSoftkeys: [], // Clear softkeys on DSP switch
-      childSubs: {}, // Clear child subs on DSP switch
+      currentSoftkeys: [], // Clear softkeys on DSP switch; childSubs cleared by updateScreen below
     };
     if (
       !appState.currentKey.startsWith(KEY_PREFIX.DSP_A) &&
@@ -76,7 +79,6 @@ const handleLcdClick = (e) => {
             currentKey: newKey,
             paramOffset: 0,
             autoLoad: true,
-            childSubs: {},
           },
           'renderer:lcd-click-softkey-sibling'
         );
@@ -100,7 +102,6 @@ const handleLcdClick = (e) => {
         currentKey: newKey,
         paramOffset: 0, // Reset offset for new menu
         autoLoad: true,
-        childSubs: {}, // Clear child subs on navigation
       },
       'renderer:lcd-click-softkey-descend'
     );

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -72,11 +72,12 @@ describe('parseResponse', () => {
   test('handles valid OBJECTINFO_DUMP for child sub-menu and stores in childSubs', () => {
     appState.currentKey = '10010000'; // Set to parent key
     appState.currentSubs = [
-      { key: '10010000', type: 'COL', parent: '0' }, // Main
+      { key: '10010000', type: 'COL', parent: '10010000' }, // Main (own line echoes own key in parent slot)
       { key: '10010010', type: 'COL', parent: '10010000' }, // Child reference in parent menu
     ];
-    // Mock SysEx: child sub under current
-    const asciiString = 'COL 1 10010010 10010000 "Child" "Child"';
+    // Mock SysEx: child sub under current. The dump's own line echoes its own
+    // key in the parent slot (device-model.md §3), matching hardware captures.
+    const asciiString = 'COL 1 10010010 10010010 "Child" "Child"';
     const asciiData = asciiString.split('').map((c) => c.charCodeAt(0));
     const data = [0xf0, 0x1c, 0x70, 0x00, 0x32, ...asciiData, 0xf7];
     parseResponse(data);
@@ -88,6 +89,37 @@ describe('parseResponse', () => {
     );
     expect(appState.childSubs['10010010']).toBeDefined();
     expect(emit).toHaveBeenCalledWith('objectinfo:received', { key: '10010010' });
+  });
+
+  test('late child OBJECTINFO arriving after navigation is dropped, not stored (C8/#44)', () => {
+    // User navigated to the B preset; currentSubs still describes the old
+    // setup menu (it is only replaced when the new menu's dump lands). The
+    // old menu's in-flight child dump must not be stored under the new view.
+    appState.currentKey = '801000b';
+    appState.currentSubs = [
+      { key: '10010000', type: 'COL', parent: '10010000' },
+      { key: '10010010', type: 'COL', parent: '10010000' },
+    ];
+    const asciiString = 'COL 1 10010010 10010010 "Child" "Child"';
+    const asciiData = asciiString.split('').map((c) => c.charCodeAt(0));
+    parseResponse([0xf0, 0x1c, 0x70, 0x00, 0x32, ...asciiData, 0xf7]);
+    expect(appState.childSubs).toEqual({});
+    expect(emit).not.toHaveBeenCalledWith('objectinfo:received', { key: '10010010' });
+  });
+
+  test('child store requires currentSubs to describe the current menu (C8/#44)', () => {
+    // Defensive pin: even if view state were inconsistent (an entry matching
+    // key+parent inside subs whose own line is NOT the current key — e.g. a
+    // stale re-pin), the guard must fail closed rather than trust it.
+    appState.currentKey = '10010000';
+    appState.currentSubs = [
+      { key: 'deadbeef', type: 'COL', parent: 'deadbeef' },
+      { key: '10010010', type: 'COL', parent: '10010000' },
+    ];
+    const asciiString = 'COL 1 10010010 10010010 "Child" "Child"';
+    const asciiData = asciiString.split('').map((c) => c.charCodeAt(0));
+    parseResponse([0xf0, 0x1c, 0x70, 0x00, 0x32, ...asciiData, 0xf7]);
+    expect(appState.childSubs).toEqual({});
   });
 
   test('handles valid VALUE_DUMP and updates currentValues', () => {

--- a/tests/renderer.test.js
+++ b/tests/renderer.test.js
@@ -437,6 +437,8 @@ describe('renderer.js', () => {
       },
     ];
     renderScreen(subs, '', mockLog);
+    // Seed stale entries so the clear assertion below is not vacuous (C8/#44).
+    appState.childSubs = { stale: [{ key: 'stale', type: 'NUM' }] };
 
     const dspB = document.querySelector('.dsp-clickable[data-key="801000b"]');
     expect(dspB).toBeTruthy();

--- a/tests/renderer.test.js
+++ b/tests/renderer.test.js
@@ -250,6 +250,7 @@ describe('renderer.js', () => {
       },
     ];
     renderScreen(subs, '', mockLog);
+    appState.childSubs = { 10010011: [{ key: '10010011', type: 'NUM' }] };
 
     const back = document.querySelector('.back-link');
     expect(back).toBeTruthy();
@@ -261,8 +262,110 @@ describe('renderer.js', () => {
     expect(appState.keyStack.length).toBe(0);
     expect(appState.autoLoad).toBe(true);
     expect(appState.currentSoftkeys).toEqual([]);
+    expect(appState.childSubs).toEqual({}); // single clear point in updateScreen (C8/#44)
     expect(sendObjectInfoDump).toHaveBeenCalledWith('10010000', null);
     expect(sendValueDump).toHaveBeenCalledWith('10010000', null);
+  });
+
+  test('softkey descend clears childSubs via the updateScreen single clear point (C8/#44)', () => {
+    appState.currentKey = '10010000';
+    appState.childSubs = { stale: [{ key: 'stale', type: 'NUM' }] };
+    const subs = [
+      {
+        type: 'COL',
+        position: '0',
+        key: '10010000',
+        parent: '10010000',
+        statement: 'Setup',
+        tag: 'setup',
+      },
+      {
+        type: 'COL',
+        position: '1',
+        key: '10010010',
+        parent: '10010000',
+        statement: 'Input',
+        tag: 'input',
+      },
+      {
+        type: 'COL',
+        position: '2',
+        key: '10010020',
+        parent: '10010000',
+        statement: 'Output',
+        tag: 'output',
+      },
+    ];
+    renderScreen(subs, '', mockLog);
+
+    const softkey = document.querySelector('.softkey[data-key="10010010"]');
+    expect(softkey).toBeTruthy();
+    softkey.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(appState.currentKey).toBe('10010010');
+    expect(appState.keyStack.length).toBe(1);
+    expect(appState.childSubs).toEqual({});
+  });
+
+  test('sibling softkey navigation clears childSubs via the updateScreen single clear point (C8/#44)', () => {
+    const parentSubs = [
+      {
+        type: 'COL',
+        position: '0',
+        key: '10010000',
+        parent: '10010000',
+        statement: 'Setup',
+        tag: 'setup',
+      },
+      {
+        type: 'COL',
+        position: '1',
+        key: '10010010',
+        parent: '10010000',
+        statement: 'Input',
+        tag: 'input',
+      },
+      {
+        type: 'COL',
+        position: '2',
+        key: '10010020',
+        parent: '10010000',
+        statement: 'Output',
+        tag: 'output',
+      },
+    ];
+    appState.currentKey = '10010010';
+    appState.keyStack = [{ key: '10010000', tag: 'setup', subs: parentSubs }];
+    appState.childSubs = { stale: [{ key: 'stale', type: 'NUM' }] };
+    // Leaf menu: params only, so the parent's COLs render as the softkeys.
+    const subs = [
+      {
+        type: 'COL',
+        position: '0',
+        key: '10010010',
+        parent: '10010010',
+        statement: 'Input',
+        tag: 'input',
+      },
+      {
+        type: 'NUM',
+        position: '1',
+        key: '10010011',
+        parent: '10010010',
+        statement: 'lvl %3.0f',
+        tag: '',
+        value: '5',
+      },
+    ];
+    renderScreen(subs, '', mockLog);
+
+    const sibling = document.querySelector('.softkey[data-key="10010020"]');
+    expect(sibling).toBeTruthy();
+    sibling.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(appState.currentKey).toBe('10010020');
+    expect(appState.keyStack.length).toBe(1); // sibling nav does not push
+    expect(appState.childSubs).toEqual({});
   });
 
   test('autoload-descend sources the keyStack entry from the param subs, not the global (#41)', () => {


### PR DESCRIPTION
Closes #44

## Summary

Batch 3.2 / C8. Investigation found the filed premise ("some nav paths bypass the clear") no longer holds: every navigation path — LCD clicks (DSP toggle, softkey sibling/descend, back-link), keypress controls, sync, connect, and polling — funnels through `updateScreen()`, which has always cleared `childSubs` + `currentValues` unconditionally. Cross-menu stale stores were also already blocked by the parser guard, but only implicitly. This PR makes those invariants explicit, hardened, and pinned:

- **renderer.js** — removed the three redundant `childSubs: {}` patches in `handleLcdClick` (DSP toggle, sibling, descend); `updateScreen` documented as the single clear point. Behavior-preserving: the intermediate state between the nav `setState` and the clear is unobservable (synchronous, no subscribers).
- **parser.js** — the child-dump store guard now requires `currentSubs[0].key === currentKey` before the membership check. For consistent device data this is logically equivalent to the old guard (a child line's parent always equals the dump's main key), but it now fails closed by construction against inconsistent view state (stale re-pins). Proven fail-on-old by a new test.
- **docs/device-model.md §3** — documented that a dump's own line echoes its own key in the PARENT slot (verified across all 8 OBJECTINFO fixtures), so a `0x32` reply cannot self-identify its parent; correlation must come from request/view state.
- **docs/protocol.md** — wire-level note for the self-echo, plus correction of two stale "device does not acknowledge a PUT" claims missed by B10g.3 (a PUT echoes a `0x2e` of the resulting, possibly clamped, value). parser.js A3 comment aligned.
- **Tests** — childSubs clear pinned with stale-seeded state across descend, sibling, back-link, and DSP-toggle navigation; late-dump fail-closed pinned.

Known residual (deferred to C1 / #37): a valid child dump can be dropped if a stale debounced re-render re-pins `currentSubs` before the dump lands; harmless (next `updateScreen` refetch self-heals); pre-existing under the old guard too. Request-correlated dumpComplete events are the proper fix.

## Review

Spawned reviewers per workflow:
- Correctness reviewer: **approve-with-nits** — independently enumerated all nav paths, proved guard equivalence for consistent dumps, verified the new tests discriminate (sibling vs descend branch; fail-on-old), and decoded all 8 fixtures to confirm the PARENT self-echo. Nits addressed or recorded in the ledger.
- Docs reviewer: corrections folded into the second commit (protocol.md PUT-ack, device-model.md examples, CLAUDE.md state note, ledger precision, DSP-toggle test seeding).

## Testing

```
Test Suites: 12 passed, 12 total
Tests:       103 passed, 103 total
Snapshots:   10 passed, 10 total
```

`npm run lint` and `npm run format:check` clean.
