### PR TITLE
refactor: classify meters by CON type, not key suffix (C7)

### DIFF
--- a/docs/device-model.md
+++ b/docs/device-model.md
@@ -191,10 +191,11 @@ decimal (omit the `.` → 6 decimals); a `textknob`/string field uses `%s`. The
 handles `%-Ns` (left-justified) and `%%` (literal percent) — consistent with
 this family. (Updates the `[V]` in §3 STATEMENT/TAG to `[D]`.)
 
-## 5. Keys & conventions `[V]`
+## 5. Keys & conventions `[V/I]`
 
 Keys are firmware-defined and stable per object; discover them dynamically
-(don't hardcode beyond the handful named in `src/sysex-commands.js`).
+(don't hardcode beyond the handful named in `src/sysex-commands.js`). Items
+below are `[V]` unless marked otherwise.
 
 - `0` — root (`'ORVILLE ROOT OBJECT'`).
 - First char selects the DSP: `4…` = DSP A, `8…` = DSP B.

--- a/docs/device-model.md
+++ b/docs/device-model.md
@@ -157,7 +157,8 @@ After the six common fields, trailing fields depend on TYPE:
   options become the choice list; `currentIndex` is **hex** and **0-based** —
   the Programming Manual's `textknob`: "if the 1st selection is made the output
   = 0, if the 3rd, = 2". `[V/D]`
-- **CON** — `value` (continuous; rendered as a bar; meter keys end `0002`).
+- **CON** — `value` (continuous; rendered as a bar; meter keys observed to end
+  `0002` — naming convention only, see §5).
   Maps to the documented `monitor`/`hmonitor`/`vmonitor`/`meter` modules, which
   have their own min/max display specifiers `[D]`; the absolute value range is
   still `[?]` (we treat ≈0..1).
@@ -198,7 +199,9 @@ Keys are firmware-defined and stable per object; discover them dynamically
 - `0` — root (`'ORVILLE ROOT OBJECT'`).
 - First char selects the DSP: `4…` = DSP A, `8…` = DSP B.
 - Suffix `000b` — a preset/DSP root (`401000b` A, `801000b` B).
-- Suffix `0002` — a meter parameter.
+- Suffix `0002` — observed on meter parameters `[I]` (naming convention, not a
+  type guarantee: non-meter keys can end `0002` — e.g. menu keys at child slot
+  2. The app classifies meters by `CON` type from dumps, not by suffix).
 - Function menus: setup `10010000`, program `10020000`, level `10030000`,
   bypass `10030500`.
 - Load menu: program select `10020011`, bank select `10020012`, load triggers

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -296,17 +296,20 @@ HUMAN-GATE: none
       can be dropped if a stale re-render re-pins currentSubs before it lands — harmless (next updateScreen
       refetch self-heals); request-correlated dumpComplete events are the real fix.
 - [x] C7  (branch refactor/meter-con-type-check, GH #43) Replaced the endsWith('0002') meter heuristic with
-      a type-based check: a VALUE_DUMP renders immediately iff the loaded subs type the key CON — looked up
-      in currentSubs or any stored childSubs (OBJECTINFO declares the type; that is the protocol truth).
-      Behavior change confined to keys absent from every loaded dump: they now take the coalesced render
-      path instead of immediate (an unknown key has no on-screen line an immediate render could update, and
-      menu keys can end 0002 too — the snapshot suite itself uses 10010002 as a COL key). Loaded meters keep
-      identical behavior: top-level CONs hit the CON branch as before; child-menu CONs were already
-      immediate via the child-param fallback and now classify as CON proper. KEY_SUFFIX.METER removed from
-      sysex-commands.js (the suffix no longer drives logic); the observed 0002 naming convention stays
-      documented in device-model.md §4/§5 (downgraded to [I]: naming convention, not a type guarantee) and
-      protocol.md. Tests: child-CON immediate + unknown-key coalesce pinned (the latter fails pre-C7).
-      VALUE_DUMP-coverage precondition was met by Batch 0.3's 0x2e characterization.
+      a type-based check: a VALUE_DUMP takes the CON immediate-render path iff the loaded subs type the key
+      CON — looked up in currentSubs or any stored childSubs (the type comes from OBJECTINFO; non-CON child
+      params keep their separate immediate fallback). Behavior change confined to 0002-suffixed keys that
+      are neither typed CON in a loaded dump nor stored child params — chiefly keys absent from every
+      loaded dump, which now coalesce (an unknown key has no on-screen line an immediate render could
+      update, and menu keys can end 0002 too — the snapshot suite itself uses 10010002 as a COL key), plus
+      the narrow case of a top-level non-CON key ending 0002, which now coalesces with its menu instead of
+      rendering immediately on the suffix alone. Loaded meters keep identical behavior: top-level CONs hit
+      the CON branch as before; child-menu CONs were already immediate via the child-param fallback and now
+      classify as CON proper. KEY_SUFFIX.METER removed from sysex-commands.js (the suffix no longer drives
+      logic); the observed 0002 naming convention stays documented in device-model.md §4/§5 (downgraded to
+      [I]: naming convention, not a type guarantee) and protocol.md. Tests: child-CON immediate +
+      unknown-key coalesce pinned (the latter fails pre-C7). VALUE_DUMP-coverage precondition was met by
+      Batch 0.3's 0x2e characterization.
 - [ ] NEW Persist active DSP (A/B) app-side as view state (default A)
 HUMAN-GATE: none
 

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -280,7 +280,7 @@ HUMAN-GATE: none
       renderer.test forces a divergent stale global (no-op setter) to prove the descend reads the param —
       verified fail-on-old / pass-on-fix. RESIDUAL (minor, follow-up): the entry's `key` still reads the global
       appState.currentKey, the same staleness class, but no param carries the loaded key.
-- [x] C8  (branch fix/childsubs-nav-clear, GH #44) FINDING: the filed premise ("some nav paths bypass the
+- [x] C8  (branch fix/childsubs-nav-clear, GH #44, PR #85) FINDING: the filed premise ("some nav paths bypass the
       clear") no longer holds — every nav path (LCD clicks, keypress controls, sync, connect, polling)
       funnels through updateScreen(), which clears childSubs+currentValues unconditionally and predates the
       refactor. Cross-menu stale stores were also already blocked by the parser guard, but only implicitly
@@ -295,9 +295,18 @@ HUMAN-GATE: none
       its parent — verified across all 8 OBJECTINFO fixtures). RESIDUAL (defer to C1): a VALID child dump
       can be dropped if a stale re-render re-pins currentSubs before it lands — harmless (next updateScreen
       refetch self-heals); request-correlated dumpComplete events are the real fix.
-- [ ] C7  Replace endsWith('0002') meter heuristic with a protocol-based check (GH #43 — "heuristic
-      masquerading as protocol"; literal already named KEY_SUFFIX.METER in #57, deeper fix = detect CON-type
-      from loaded subs rather than key suffix; needs more VALUE_DUMP coverage first)
+- [x] C7  (branch refactor/meter-con-type-check, GH #43) Replaced the endsWith('0002') meter heuristic with
+      a type-based check: a VALUE_DUMP renders immediately iff the loaded subs type the key CON — looked up
+      in currentSubs or any stored childSubs (OBJECTINFO declares the type; that is the protocol truth).
+      Behavior change confined to keys absent from every loaded dump: they now take the coalesced render
+      path instead of immediate (an unknown key has no on-screen line an immediate render could update, and
+      menu keys can end 0002 too — the snapshot suite itself uses 10010002 as a COL key). Loaded meters keep
+      identical behavior: top-level CONs hit the CON branch as before; child-menu CONs were already
+      immediate via the child-param fallback and now classify as CON proper. KEY_SUFFIX.METER removed from
+      sysex-commands.js (the suffix no longer drives logic); the observed 0002 naming convention stays
+      documented in device-model.md §4/§5 (downgraded to [I]: naming convention, not a type guarantee) and
+      protocol.md. Tests: child-CON immediate + unknown-key coalesce pinned (the latter fails pre-C7).
+      VALUE_DUMP-coverage precondition was met by Batch 0.3's 0x2e characterization.
 - [ ] NEW Persist active DSP (A/B) app-side as view state (default A)
 HUMAN-GATE: none
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -198,7 +198,9 @@ Structural patterns on otherwise-dynamic keys:
 
 - `KEY_PREFIX.DSP_A` (`'4'`) / `KEY_PREFIX.DSP_B` (`'8'`) — first char selects the DSP.
 - `KEY_SUFFIX.PRESET` (`'000b'`) — a preset/DSP root key.
-- `KEY_SUFFIX.METER` (`'0002'`) — a meter parameter (immediate re-render).
+- Meter parameters are observed to end `'0002'` (see `device-model.md` §5), but
+  the app classifies meters by their `CON` type from loaded dumps, not by key
+  suffix — menu keys can end `0002` too (C7).
 
 ## Request/response tracking — the dump wave (app-side)
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -184,8 +184,10 @@ tracker B10g.3). The app still issues a value request after a put to reconcile
 rather than trusting an optimistic local write.
 
 `0x2e` response payload is ASCII `"<key> <value…>"`; `parser.js` caches it under
-the key. `CON` values and meter keys trigger an immediate re-render; others are
-coalesced.
+the key. Keys the loaded subs type `CON` (in the current menu or a stored child
+menu) trigger an immediate re-render, as do child-menu params already on screen;
+everything else — including keys absent from every loaded dump — is coalesced
+(C7; see "Key conventions" below for the `0002` naming note).
 
 ## Key conventions
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -177,20 +177,26 @@ export function parseResponse(data) {
         'debug',
         'general'
       );
-      const isChildParam = Object.keys(appState.childSubs || {}).some((childKey) => {
-        const childSubs = appState.childSubs[childKey] || [];
-        return childSubs.some((cs) => cs.key === key);
-      });
-      if (sub && sub.type === 'CON') {
+      // C7 (#43): meter detection is type-based — a key is a meter iff the
+      // loaded subs (current menu or a stored child menu) type it CON. The old
+      // endsWith('0002') key heuristic classified by naming convention and
+      // could misfire (menu keys can end 0002 too); a key the app has not
+      // loaded has no on-screen line an immediate render could update, so
+      // unknown keys take the coalesced path instead. The 0002 naming
+      // convention itself stays documented in docs/device-model.md §5.
+      const childSub = Object.values(appState.childSubs || {})
+        .flat()
+        .find((cs) => cs.key === key);
+      if ((sub || childSub)?.type === 'CON') {
         emit('value:received', { key, immediate: true });
         log(
           `Immediate re-rendered screen for CON value change on key ${key}`,
           'debug',
           'renderScreen'
         );
-      } else if (key.endsWith(KEY_SUFFIX.METER) || isChildParam) {
-        // Fallback for meter keys or child params
-        log(`Fallback triggered for meter or child key ${key}`, 'debug', 'general');
+      } else if (childSub) {
+        // Embedded child param: its line is already on screen, render now
+        log(`Fallback triggered for child param key ${key}`, 'debug', 'general');
         emit('value:received', { key, immediate: true });
         log(`Immediate re-rendered screen for VALUE_DUMP on key ${key}`, 'debug', 'renderScreen');
       } else {

--- a/src/sysex-commands.js
+++ b/src/sysex-commands.js
@@ -67,7 +67,9 @@ export const KEY_PREFIX = {
 };
 export const KEY_SUFFIX = {
   PRESET: '000b', // a preset/DSP root key ends with '000b'
-  METER: '0002', // meter parameter keys end with '0002'
+  // (the observed '0002' meter-key naming convention is documented in
+  // docs/device-model.md §5; the app detects meters by CON type, not by
+  // suffix — C7/#43)
 };
 
 // Root-level menus, in softkey order, used both as a "is this a top-level menu"

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -185,6 +185,15 @@ describe('parseResponse', () => {
     expect(emit).toHaveBeenCalledWith('value:received', { key: '10030002', immediate: false });
   });
 
+  test('VALUE_DUMP for a loaded non-CON key ending 0002 coalesces (C7/#43)', () => {
+    // Pre-C7 the suffix heuristic forced an immediate render even when the
+    // loaded sub said the key was not a meter. Menu/param keys can end 0002.
+    appState.currentSubs = [{ key: '10010002', type: 'COL' }];
+    appState.childSubs = {};
+    parseResponse(valueDump('10010002 5'));
+    expect(emit).toHaveBeenCalledWith('value:received', { key: '10010002', immediate: false });
+  });
+
   test('VALUE_DUMP for a non-CON child param takes the immediate fallback', () => {
     appState.currentSubs = [];
     appState.childSubs = { 10010071: [{ key: '10010711', type: 'NUM' }] };

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -157,24 +157,41 @@ describe('parseResponse', () => {
     );
   });
 
-  test('VALUE_DUMP for a meter key (endsWith 0002) takes the immediate fallback', () => {
-    appState.currentSubs = []; // no matching sub
-    parseResponse(valueDump('10030002 0.8'));
-    expect(emit).toHaveBeenCalledWith('value:received', { key: '10030002', immediate: true });
+  test('VALUE_DUMP for a CON sub stored in childSubs emits an immediate render (C7/#43)', () => {
+    appState.currentSubs = []; // meter lives in an embedded child menu, not the top level
+    appState.childSubs = {
+      4040002: [
+        { key: '4040002', type: 'COL' },
+        { key: '4070002', type: 'CON' },
+      ],
+    };
+    parseResponse(valueDump('4070002 0.5'));
+    expect(emit).toHaveBeenCalledWith('value:received', { key: '4070002', immediate: true });
     expect(mockLog).toHaveBeenCalledWith(
-      expect.stringContaining('Fallback triggered for meter or child key 10030002'),
+      expect.stringContaining('Immediate re-rendered screen for CON value change on key 4070002'),
       'debug',
-      'general'
+      'renderScreen'
     );
   });
 
-  test('VALUE_DUMP for a child param takes the immediate fallback', () => {
+  test('VALUE_DUMP for an unknown key coalesces — 0002 suffix alone is not a meter (C7/#43)', () => {
+    // Pre-C7 the endsWith('0002') heuristic forced an immediate render here.
+    // A key absent from every loaded dump has no on-screen line an immediate
+    // render could update, and menu keys can end 0002 too; type is the truth.
+    appState.currentSubs = [];
+    appState.childSubs = {};
+    parseResponse(valueDump('10030002 0.8'));
+    expect(appState.currentValues['10030002']).toBe('0.8');
+    expect(emit).toHaveBeenCalledWith('value:received', { key: '10030002', immediate: false });
+  });
+
+  test('VALUE_DUMP for a non-CON child param takes the immediate fallback', () => {
     appState.currentSubs = [];
     appState.childSubs = { 10010071: [{ key: '10010711', type: 'NUM' }] };
     parseResponse(valueDump('10010711 7'));
     expect(emit).toHaveBeenCalledWith('value:received', { key: '10010711', immediate: true });
     expect(mockLog).toHaveBeenCalledWith(
-      expect.stringContaining('Fallback triggered for meter or child key 10010711'),
+      expect.stringContaining('Fallback triggered for child param key 10010711'),
       'debug',
       'general'
     );


### PR DESCRIPTION
Closes #43

## Summary

Batch 3.2 / C7. The VALUE_DUMP immediate-render decision in `parser.js` is now type-based: the CON branch fires iff the loaded subs (current menu or any stored child menu) type the key `CON` — the type comes from OBJECTINFO, so it is what the device declares, not a naming convention. The `endsWith('0002')` heuristic is removed, along with `KEY_SUFFIX.METER` (the suffix no longer drives logic). Non-CON child params keep their separate immediate fallback unchanged.

Behavior delta (intended, narrow): keys that the heuristic classified as meters but the dumps do not type `CON` now take the coalesced render path —
- keys absent from every loaded dump (no on-screen line an immediate render could update), and
- a loaded top-level non-CON key ending `0002` (menu keys can end `0002`; the snapshot suite itself uses `10010002` as a COL key).

Loaded meters keep identical behavior: top-level CONs hit the CON branch as before; child-menu CONs were already immediate via the child-param fallback and now classify as CON proper (log line only).

Note on the first commit's message: its scoping sentence ("confined to keys absent from every loaded dump") was over-narrow — the correctness reviewer caught the loaded non-CON `0002` case above; the ledger entry and this PR body are the accurate record.

Docs: the observed `0002` naming convention stays documented in `device-model.md` §4/§5, downgraded to `[I]` (naming convention, not a type guarantee); `protocol.md`'s key-conventions and `0x2e` sections updated to the type-based rule.

## Review

Spawned reviewers per workflow:
- Correctness reviewer: **approve-with-nits** — traced every VALUE_DUMP producer (meter polling reads `currentSubs` live each tick; child value requests are sent after the child OBJECTINFO on an in-order link), bounded the race-window cost to at most one extra `RENDER_COALESCE_MS` on a menu's first paint, and confirmed the new unknown-key test fails on the parent commit (ran the suite in a worktree at `deb8747~1`).
- Docs reviewer: scope-precision fixes to the ledger entry, the `0x2e` paragraph rewrite, and the §5 confidence-marker fix — folded into the second commit, plus a test pinning the loaded non-CON `0002` delta both reviewers flagged.

## Testing

```
Test Suites: 12 passed, 12 total
Tests:       105 passed, 105 total
Snapshots:   10 passed, 10 total
```

`npm run lint` and `npm run format:check` clean. Fail-on-old verified for the unknown-key coalesce test.
