### PR TITLE
fix: detach prior sysex listener on re-registration (FB7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ index.html
 
 Data flow: user clicks → `controls.js` sends SysEx via `midi.js` → Orville responds → `midi.js` listener (`addSysexListener` reassembles multi-packet SysEx from `F0` to `F7` before parsing — see below) → `parser.js` parses, writes state via `store.setState`, and emits events on `events.js` → `event-bridge.js` coalesces and calls `renderer.renderScreen` → paints `#lcd`. Bitmap path: `0x17` SysEx → `parser.js` denibbles (`bitmap.js`) → emits `screen:received` → `event-bridge.js` → `renderBitmap` on the canvas.
 
-Inbound SysEx is not necessarily one WebMIDI event per message: a long dump (`0x17` screen, large `0x32` OBJECTINFO like the ~70-name bank list) can be split across packets, so `addSysexListener` buffers from `F0` until `F7` and calls `parseResponse` once per complete message — a pass-through when messages already arrive whole. Applies to every inbound type, not just screens. See `docs/protocol.md` §Framing "Inbound reassembly" and tracker FB6.
+Inbound SysEx is not necessarily one WebMIDI event per message: a long dump (`0x17` screen, large `0x32` OBJECTINFO like the ~70-name bank list) can be split across packets, so `addSysexListener` buffers from `F0` until `F7` and calls `parseResponse` once per complete message — a pass-through when messages already arrive whole. Applies to every inbound type, not just screens. Re-registration is safe: `addSysexListener` detaches the previously attached listener (from whichever input it was on) before adding a new one, so repeated port selection never stacks listeners. See `docs/protocol.md` §Framing "Inbound reassembly" and tracker FB6/FB7.
 
 ## Module structure (refactor complete)
 

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -157,12 +157,14 @@ reviewer agents swept all of src/; findings consolidated below.
       Covers every inbound SysEx type, not just the screen. Tested (complete pass-through, split reassembly,
       buffer reset on new F0, Uint8Array data). NOT yet verified whether Chrome actually chunks on this device
       (would need an in-browser test against the unit); the fix is correct either way (defensive + matches FB5).
-- [ ] FB7 (NEW, from FB6 review) midi.js addSysexListener can double-register: selectPorts() (main.js) is wired
-      to a button and also auto-runs on cached-config load, and nothing removes the prior 'sysex' listener, so
-      re-selecting ports attaches a second listener -> parseResponse fires twice per message (over-decrements
-      the dump-wave counter, can cause a premature all-received). PRE-EXISTING (the old one-line listener
-      double-fired too); FB6 only carried it forward. FIX: guard re-registration (track an attached flag, or
-      selectedInput.removeListener before re-adding). CODE, low priority.
+- [x] FB7 RESOLVED (branch fix/sysex-listener-reregister): midi.js addSysexListener now tracks the input +
+      handler it attached and removes the previous 'sysex' listener (from whichever input it was on) before
+      adding a new one, so repeated selectPorts runs (button + cached-config auto-run) and input switches
+      can no longer stack listeners -> parseResponse fires exactly once per message and the dump-wave
+      counter decrements once per response (no premature all-received). Done ahead of C1 because C1's
+      dumpComplete consumers depend on accurate wave counting. Tests: re-registration replaces (not stacks)
+      + input-switch detaches from the old input; both fail pre-fix (verified). midi.test mock input now
+      tracks add/removeListener.
 - [x] FB4 RESOLVED (branch fix/dump-watchdog-idle-reset): the midi.js dump watchdog was a fixed 1500ms hard
       ceiling that fired mid-response on large enumerations like the bank list (OBJECTINFO 10020012, ~70 names,
       ~4-6s). Replaced with an idle/silence watchdog (WATCHDOG_IDLE_MS 1500, rearmed on every send and receive)

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -41,8 +41,10 @@ likely to fragment. Both inbound paths therefore reassemble from `F0`
 (`SYSEX.START`) until the `F7` terminator before parsing, and feed the parser one
 complete message — start a new buffer on `F0`, append continuation packets, parse
 on `F7`. When a message already arrives whole this is a pass-through. The browser
-app does this in `midi.js:addSysexListener` (tracker FB6); the CLI capture tool
-does the same (tracker FB5; see **Capturing screens (HIL)** for the
+app does this in `midi.js:addSysexListener` (tracker FB6; exactly one such
+listener is ever attached — re-registration detaches the prior one first,
+tracker FB7); the CLI capture tool does the same (tracker FB5; see
+**Capturing screens (HIL)** for the
 hardware-specific chunk sizes/timing). This applies to *all* inbound types
 (`0x17`, `0x2e`, `0x32`), not just screens.
 
@@ -223,7 +225,11 @@ render-coalescing build on (see
 - Each matching `0x32` / `0x2e` response decrements `outstanding`, via
   `notifyResponse`, which `parser.js` calls at the top of each branch. The
   counter is a pure count — it does not yet correlate responses to requests by
-  key or type.
+  key or type. It therefore depends on each response being parsed exactly once:
+  `addSysexListener` detaches any previously attached `'sysex'` listener before
+  adding a new one, so re-selecting or switching ports cannot stack listeners
+  and double-decrement the counter toward a premature `all-received`
+  (tracker FB7).
 - A wave **ends** one of two ways, both emitting `dumpComplete` with a `reason`:
   - `all-received` — `outstanding` returns to `0` (the healthy path).
   - `watchdog` — the timeout fires (a stall or a runaway wave).

--- a/src/midi.js
+++ b/src/midi.js
@@ -10,6 +10,12 @@ import { TIMING } from './constants.js';
 let selectedOutput = null;
 let selectedInput = null;
 
+// FB7: the input + handler the current 'sysex' listener is attached to, so a
+// re-registration can detach the previous one (selectPorts runs both from the
+// button and from the cached-config auto-run, and may target a new input).
+let sysexListenerInput = null;
+let sysexListenerHandler = null;
+
 // Per-wave request counter and idle-reset watchdog. A wave begins when
 // outstanding transitions 0->1. The watchdog is an idle/silence timer:
 // it is rearmed for WATCHDOG_IDLE_MS on every send AND every received
@@ -152,6 +158,14 @@ export function addSysexListener() {
     log('Error: MIDI input not set; cannot add listener', 'error', 'error');
     return;
   }
+  // FB7: detach the previous listener (from whichever input it was attached
+  // to) before adding a new one. Without this, every selectPorts run stacked
+  // another listener, so parseResponse fired N times per message — each
+  // duplicate decremented the dump-wave counter again (premature
+  // 'all-received') and re-ran the full parse/state fan-out.
+  if (sysexListenerInput && sysexListenerHandler) {
+    sysexListenerInput.removeListener('sysex', sysexListenerHandler);
+  }
   // Reassemble multi-packet SysEx before parsing. Chrome's Web MIDI normally
   // delivers a complete F0..F7 message in one event, but a long SysEx can be
   // split across packets by the platform/driver (the ~3872-byte 0x17 screen
@@ -161,7 +175,7 @@ export function addSysexListener() {
   // this is a pass-through. (Matches the CLI capture tool; see
   // docs/protocol.md "Capturing screens (HIL)".)
   let sysexBuffer = [];
-  selectedInput.addListener('sysex', (e) => {
+  const handler = (e) => {
     const data = Array.from(e.data);
     if (data[0] === SYSEX.START) sysexBuffer = data;
     else sysexBuffer = sysexBuffer.concat(data);
@@ -171,7 +185,10 @@ export function addSysexListener() {
       parseResponse(sysexBuffer);
       sysexBuffer = [];
     }
-  });
+  };
+  selectedInput.addListener('sysex', handler);
+  sysexListenerInput = selectedInput;
+  sysexListenerHandler = handler;
 }
 
 /**

--- a/src/midi.js
+++ b/src/midi.js
@@ -155,6 +155,10 @@ export function setMidiPorts(output, input, devId) {
  */
 export function addSysexListener() {
   if (!selectedInput) {
+    // Deliberately does NOT detach the previous listener here: with no new
+    // input to serve, keeping the old one live is the lesser evil, and the
+    // tracked pair is not cleared, so the next successful registration still
+    // detaches it (no leak).
     log('Error: MIDI input not set; cannot add listener', 'error', 'error');
     return;
   }

--- a/tests/midi.test.js
+++ b/tests/midi.test.js
@@ -151,7 +151,7 @@ describe('midi.js SysEx byte contract', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     output = { sendSysex: jest.fn() };
-    setMidiPorts(output, { addListener: jest.fn() }, 0);
+    setMidiPorts(output, { addListener: jest.fn(), removeListener: jest.fn() }, 0);
   });
 
   afterEach(() => {
@@ -166,7 +166,7 @@ describe('midi.js SysEx byte contract', () => {
   });
 
   test('sendSysEx uses the configured device id', () => {
-    setMidiPorts(output, { addListener: jest.fn() }, 7);
+    setMidiPorts(output, { addListener: jest.fn(), removeListener: jest.fn() }, 7);
     sendSysEx(0x18, []);
     expect(output.sendSysex).toHaveBeenCalledWith([0x1c, 0x70], [0x07, 0x18]);
   });

--- a/tests/midi.test.js
+++ b/tests/midi.test.js
@@ -203,19 +203,32 @@ describe('midi.js SysEx byte contract', () => {
   });
 });
 
+// Listener-tracking input mock: stacks every added 'sysex' callback and
+// supports removal, so the FB7 re-registration guard is observable.
+const makeInput = () => {
+  const listeners = [];
+  return {
+    listeners,
+    addListener: (type, cb) => {
+      if (type === 'sysex') listeners.push(cb);
+    },
+    removeListener: (type, cb) => {
+      const i = listeners.indexOf(cb);
+      if (i !== -1) listeners.splice(i, 1);
+    },
+  };
+};
+
 describe('addSysexListener multi-packet reassembly', () => {
+  let input;
   let handler;
 
   beforeEach(() => {
     parseResponse.mockClear();
-    handler = null;
-    const input = {
-      addListener: (type, cb) => {
-        if (type === 'sysex') handler = cb;
-      },
-    };
+    input = makeInput();
     setMidiPorts({ sendSysex: jest.fn() }, input, 1);
     addSysexListener();
+    handler = input.listeners[0];
   });
 
   test('passes a complete single-packet SysEx straight through', () => {
@@ -262,5 +275,30 @@ describe('addSysexListener multi-packet reassembly', () => {
     handler({ data: [0xf0, 0x1c, 0x70, 1, 0x2e, 0x41, 0xf7] }); // then a real message
     expect(parseResponse).toHaveBeenCalledTimes(1);
     expect(parseResponse).toHaveBeenCalledWith([0xf0, 0x1c, 0x70, 1, 0x2e, 0x41, 0xf7]);
+  });
+
+  test('re-registration replaces the listener instead of stacking (FB7)', () => {
+    // selectPorts runs from both the button and the cached-config auto-run;
+    // pre-FB7 each run stacked another listener and parseResponse fired
+    // once per stacked copy, over-decrementing the dump-wave counter.
+    addSysexListener();
+    expect(input.listeners).toHaveLength(1);
+
+    const msg = [0xf0, 0x1c, 0x70, 1, 0x2e, 0x41, 0xf7];
+    input.listeners.forEach((cb) => cb({ data: msg }));
+    expect(parseResponse).toHaveBeenCalledTimes(1);
+  });
+
+  test('selecting a different input detaches the listener from the old one (FB7)', () => {
+    const newInput = makeInput();
+    setMidiPorts({ sendSysex: jest.fn() }, newInput, 1);
+    addSysexListener();
+
+    expect(input.listeners).toHaveLength(0); // detached from the old input
+    expect(newInput.listeners).toHaveLength(1);
+
+    const msg = [0xf0, 0x1c, 0x70, 1, 0x2e, 0x41, 0xf7];
+    newInput.listeners.forEach((cb) => cb({ data: msg }));
+    expect(parseResponse).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

Tracker item FB7 (from the FB6 review; no separate GitHub issue). `addSysexListener` attached a fresh `'sysex'` listener on every call with nothing removing the previous one. `selectPorts` runs from both the Select Ports button and the cached-config auto-run, so a second run stacked a second listener: `parseResponse` fired once per stacked copy for every inbound message, and each duplicate decremented the dump-wave counter again — over-decrementing toward a premature `all-received` and re-running the full parse/state fan-out per message. Switching inputs also left the old listener attached to the old input.

`midi.js` now tracks the (input, handler) pair it attached and removes that listener — from whichever input it was on — before adding a new one, so exactly one listener is live regardless of how many times ports are re-selected or switched. The missing-input error path deliberately keeps the old listener (no new input to serve); the tracked pair is not cleared, so the next successful registration still detaches it.

Done ahead of C1 (#37): the `dumpComplete` consumers C1 introduces depend on the wave counter decrementing exactly once per response. The exactly-once invariant is now recorded in `protocol.md`'s dump-wave section and CLAUDE.md's reassembly paragraph.

## Review

Spawned reviewers per workflow:
- Correctness reviewer: **approve** — verified webmidi v3 `removeListener(event, handler)` identity semantics against the installed package source (exact-callback filter; safe no-op when unregistered), ran the two new tests against the parent commit in a worktree (both fail pre-fix with the expected shapes), confirmed the in-flight-partial-message drop at re-registration is no worse than pre-fix, and found no cross-module stacking assumptions.
- Docs reviewer: single-listener guarantee + exactly-once counter invariant notes folded into the second commit; verified the ledger FB7 entry line-by-line against the diff.

## Testing

```
Test Suites: 13 passed, 13 total
Tests:       113 passed, 113 total
Snapshots:   10 passed, 10 total
```

`npm run lint` and `npm run format:check` clean. Fail-on-old verified for both new tests.
