### PR TITLE
docs: retract the RDP MIDI-visibility diagnosis (B10g.4)

### DIFF
--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -225,21 +225,18 @@ NOTE: Batch 1.4 (B10) complete.
         rapid probe open/close (recovers on its own). The HIL loop itself is already proven (drove A/B +
         read live; render-screen.js renders captured screens). For long live sessions use one long-lived
         process. Noted in device-model.md §12.
-- [x] B10g.4 HIL screenshot loop tool + RDP root-cause for "no MIDI devices":
+- [x] B10g.4 HIL screenshot loop tool:
       * build_tools/hil-screenshot.cjs (npm `screenshot`): single long-lived process — opens MIDI
         once, optional `--press k1,k2`, sends 0x18, captures 0x17, saves raw fixture, renders PNG via
         render-screen.js. Implemented + lint/`node --check` clean.
-      * PROVEN end-to-end live (after the RDP fix below): baseline capture (A: Black Hole / space
-        params), `--press ab` drive+capture (B: MetallicChamber / detune params), then restored A.
-        Renders faithful PNGs; A2 bitmap fix confirmed clean on real hardware. G2 live loop works.
-      * ROOT CAUSE of the intermittent "no MIDI input devices currently available": RDP, not USB
-        churn or the device. Proven: Get-PnpDevice (system-global) shows U6MIDI Pro + all 6 ports OK,
-        but BOTH node's @julusian/midi AND raw WinMM midiInGetNumDevs() (per-session) return 0 in/
-        1 out (GS Wavetable only). RDP redirects the audio/MIDI stack; the physical interface stays
-        bound to the CONSOLE session and is invisible to the remote session's WinMM. Captures worked
-        earlier because the active session was the console. => Live HIL (G2, hil-screenshot) must run
-        from the physical console, OR mstsc Remote audio = "Play on remote computer" (unreliable for
-        MIDI in). Offline work (replay fixtures) is unaffected by RDP.
+      * PROVEN end-to-end live: baseline capture (A: Black Hole / space params), `--press ab`
+        drive+capture (B: MetallicChamber / detune params), then restored A. Renders faithful PNGs;
+        A2 bitmap fix confirmed clean on real hardware. G2 live loop works.
+      * CORRECTION (maintainer-confirmed): an earlier diagnosis here blamed RDP session redirection
+        for intermittent "no MIDI input devices currently available" and claimed live HIL required
+        the physical console. That conclusion was wrong and has been retracted — live MIDI works
+        over RDP. If the no-devices symptom recurs, re-diagnose from scratch (the prior write-up is
+        in git history) rather than assuming a session-type cause.
 
 ---
 

--- a/tests/fixtures/golden/README.md
+++ b/tests/fixtures/golden/README.md
@@ -30,7 +30,7 @@ To regenerate a golden after an intentional decoder change:
 
     node build_tools/render-screen.js tests/fixtures/screen-<name>.txt tests/fixtures/golden/screen-<name>.png 1
 
-To recapture from hardware (must be on the physical console, not RDP — see
-issue-tracker.md B10g.4):
+To recapture from hardware (the HIL tool is documented in issue-tracker.md
+B10g.4):
 
     node build_tools/hil-screenshot.cjs --press <key> --name screen-<name> --png logs/<name>.png


### PR DESCRIPTION
## Summary

Maintainer-confirmed: live MIDI works over RDP. The ledger's B10g.4 root-cause write-up — which attributed intermittent 'no MIDI input devices' to RDP session redirection and claimed live HIL required the physical console — was wrong and is retracted. The entry keeps the still-valid HIL screenshot-tool documentation and proven live-capture record, and adds a CORRECTION note pointing to git history with guidance to re-diagnose from scratch if the symptom ever recurs.

Second commit (from review): the reviewer's repo sweep caught one straggler re-asserting the claim — tests/fixtures/golden/README.md's recapture instructions — now reworded to a plain B10g.4 tool pointer. The sweep confirmed everything else clean (device docs, protocol.md, CLAUDE.md, README, src/, build_tools/; package-lock hits are base64 false positives).

## Review

Reviewer pass: **request-changes** for the straggler, otherwise approve-quality — verified the retraction removes all console-only claims while preserving unrelated content, the CORRECTION wording is neutral and does not re-assert the retracted diagnosis, and the git-history pointer is accurate.

## Testing

Docs-only; no code paths affected.