### PR TITLE
docs: write the C2 landing design (timer- and flag-free connect flow)

### DIFF
--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -390,12 +390,12 @@ from the root dump (device boots into last-used preset). Cache is a provisional 
       rootDumpComplete -> active preset. NOTE: the race SYMPTOM (wrong landing menu) was eliminated by
       C1's synchronous root render (Batch 3.1), but the timer-driven mechanism it rode on is still in
       place — this item owns removing it.
-      NEXT: design the rootDumpComplete landing in phase3-state-model.md terms (connect -> request root ->
-      on the root wave's dumpComplete adopt DSP keys/names + land on the active preset, no timer, no
-      autoLoad flag), folding in the two C1-review items that C2 subsumes/validates: the
-      watchdog-mid-navigation autoload edge (Batch 3.1 NEW item) and, while on hardware for the throughput
-      gate, the wave-saturation smoke. Then implement on a branch with the startup characterization
-      updated in the same commit.
+      NEXT: implement per phase3-state-model.md "C2 design — connect/landing without timers" (design
+      written + reviewed): one-shot pendingLanding state replaces the PORT_INIT_MS timer AND the sticky
+      autoLoad flag (renderer autoload branch deleted; click handlers move to the same one-shot descend
+      state); folds in 3.2's persist-active-DSP and the watchdog-mid-nav item's landing case. Startup
+      characterization updated in the same commit. Hardware validation deferred to one consolidated
+      session after 3.3 (landing timing + wave-saturation smoke + eager-load throughput).
 - [ ] NEW Eager loader: traverse active preset tree (OBJECTINFO each COL + VALUE_DUMP each param), bounded by depth + visited set, completion via dumpComplete; show loading UX
 - [ ] NEW `eagerLoad` config flag (default on; persisted in midiConfig) toggles eager vs lazy
 - [ ] NEW Render guard enforcing the invariant: unconfirmed values render as a loading placeholder, never a stale cached number

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -380,14 +380,16 @@ HUMAN-GATE: none
       [I]: naming convention, not a type guarantee) and protocol.md. Tests: child-CON immediate +
       unknown-key coalesce pinned (the latter fails pre-C7). VALUE_DUMP-coverage precondition was met by
       Batch 0.3's 0x2e characterization.
-- [ ] NEW Persist active DSP (A/B) app-side as view state (default A)
+- [ ] NEW Persist active DSP (A/B) app-side as view state (default A) — FOLDED INTO C2 (Batch 3.3): the
+      landing chooses dspAKey/dspBKey by this view state; do not implement separately (see
+      phase3-state-model.md "C2 design"). Mark [x] when C2 ships.
 HUMAN-GATE: none
 
 ### Batch 3.3 — Connect handshake + eager loader + landing  (replaces the autoLoad timer mechanism)
 DECISION RESOLVED (see phase3-state-model.md): land on the last-active DSP's preset, read authoritatively
 from the root dump (device boots into last-used preset). Cache is a provisional structure-only pre-paint.
-- [~] C2  Remove the PORT_INIT_MS (500ms) timer + autoLoad flag mechanism (main.js); land via
-      rootDumpComplete -> active preset. NOTE: the race SYMPTOM (wrong landing menu) was eliminated by
+- [~] C2  Remove the PORT_INIT_MS (500ms) timer + autoLoad flag mechanism (main.js); land on the root
+      dump's arrival -> active preset. NOTE: the race SYMPTOM (wrong landing menu) was eliminated by
       C1's synchronous root render (Batch 3.1), but the timer-driven mechanism it rode on is still in
       place — this item owns removing it.
       NEXT: implement per phase3-state-model.md "C2 design — connect/landing without timers" (design

--- a/docs/refactor/phase3-state-model.md
+++ b/docs/refactor/phase3-state-model.md
@@ -148,6 +148,59 @@ the wave to drain. The replay test asserts the synchronous structure paint
 and deliberately leaves its wave open (wave state resets on the next fresh
 wave start).
 
+## C2 design — connect/landing without timers (next to implement)
+
+What C2 replaces (main.js `selectPorts` today): request root, then a
+`PORT_INIT_MS` (500ms) `setTimeout` that blindly flips `currentKey` to the
+*cached* preset and sets the sticky global `autoLoad=true` flag, which the
+renderer's autoload branch later consumes to descend one menu. C1 removed the
+wrong-landing symptom; C2 removes the mechanism — both the timer and the flag.
+
+**Landing flow (event-driven, one-shot):**
+
+1. `selectPorts`: set ports + listener, `showLoading`, request root
+   (`OBJECTINFO('0')` + `VALUE('0')`). Set a one-shot app-view landing state
+   (e.g. `pendingLanding = 'root'`). No timer, no `autoLoad` write.
+2. On `objectinfo:received` with `key === '0'` while `pendingLanding ===
+   'root'`: the parser has already adopted authoritative DSP keys/names from
+   the dump. Land: push the root keyStack entry
+   (`makeKeyStackEntry('0', currentSubs)`), set `currentKey` to the active
+   DSP's preset key **from the root dump** (`dspAKey`/`dspBKey`, chosen by the
+   app-side active-DSP view state — fold Batch 3.2's "persist active DSP
+   (default A)" item in here; the cached `presetKey` becomes a pre-paint hint
+   only), advance `pendingLanding = 'preset'`, `updateScreen()`. Then issue
+   the other-DSP prefetch and optional `0x18`, as today.
+3. On `objectinfo:received` for the preset while `pendingLanding ===
+   'preset'`: clear `pendingLanding`; if the preset top has no params and >1
+   short-tag COL menus, descend once into the first (exactly what the
+   autoload branch did, but triggered by explicit landing state, not a sticky
+   flag read by every render). The renderer autoload branch and the
+   `autoLoad` field are then deleted; the remaining `autoLoad=true` writers
+   (LCD click handlers) switch to the same one-shot descend-on-next-dump
+   state.
+4. Failure path (folds in the C1-review watchdog item): if `dumpComplete`
+   fires `reason='watchdog'` while a landing is pending, do NOT land from
+   stale state — clear `pendingLanding`, keep the "Connected. Fetching root…"
+   text, log the stall. Sync/reconnect retries. With no sticky `autoLoad`
+   flag there is nothing for a stall render to mis-consume; this subsumes the
+   "watchdog dumpComplete mid-navigation autoload" ledger item for the
+   navigation case too once the flag is gone.
+5. Out of scope for C2 (stays in 3.3): the cached structure-only pre-paint,
+   the eager loader, `eagerLoad` flag, and the unconfirmed-value render
+   guard.
+
+**Tests:** startup characterization updated in the same commit — its inline
+select-ports simulation loses the 500ms advance entirely (feed root → landing
+fires synchronously → feed preset → explicit descend → feed landed menu →
+`dumpComplete`); the `autoLoad` snapshot field in the recorder is replaced by
+the landing state. Renderer tests for the descend-state replacement of the
+autoload branch (fail-on-old via the deleted flag).
+
+**Hardware validation (one consolidated session, after 3.3 is also coded):**
+live connect on the real 31250-baud link (root dump arrival time vs the old
+500ms guess; landing correctness), the wave-saturation smoke (polling +
+bitmap-on-change vs the 10s watchdog ceiling), and eager-load throughput.
+
 ## Validation / open items
 
 - Eager-load throughput on real hardware (many `OBJECTINFO`/`VALUE` round

--- a/docs/refactor/phase3-state-model.md
+++ b/docs/refactor/phase3-state-model.md
@@ -47,8 +47,10 @@ connect already *is* the last-used preset — we read it rather than remember it
 1. **Connect** ports + listener.
 2. **Pre-paint (provisional)** from cached `presetKey` — structure only, to
    avoid a blank screen. Values render as loading until confirmed.
-3. **Request root.** On `rootDumpComplete`, adopt the device's real DSP A/B
-   keys + names as authoritative (discard the cache hint if it disagrees).
+3. **Request root.** Adopt the device's real DSP A/B keys + names as
+   authoritative (discard the cache hint if it disagrees). (The C2 design
+   below refines this: landing fires on the root dump's *arrival* — the
+   progressive paint — not on the wave's drain.)
 4. **Choose landing** = active preset for the app-side last-active DSP (default A).
 5. **Eager load (default):** traverse the active preset's tree —
    `OBJECTINFO` each child COL, `VALUE_DUMP` each param — bounded by depth and a
@@ -158,13 +160,21 @@ wrong-landing symptom; C2 removes the mechanism — both the timer and the flag.
 
 **Landing flow (event-driven, one-shot):**
 
-1. `selectPorts`: set ports + listener, `showLoading`, request root
-   (`OBJECTINFO('0')` + `VALUE('0')`). Set a one-shot app-view landing state
-   (e.g. `pendingLanding = 'root'`). No timer, no `autoLoad` write.
-2. On `objectinfo:received` with `key === '0'` while `pendingLanding ===
+1. `selectPorts`: set ports + listener, `showLoading`, then **reset the view
+   to root before requesting** — `currentKey = KEY.ROOT`, clear `keyStack` and
+   `currentSubs` — and request root (`OBJECTINFO(KEY.ROOT)` +
+   `VALUE(KEY.ROOT)`). Set a one-shot app-view landing state (e.g.
+   `pendingLanding = 'root'`). No timer, no `autoLoad` write. The reset
+   matters because `selectPorts` is re-runnable (button + cached-config
+   auto-run): without it, a reconnect while navigated deep would take the
+   parser's *background*-root branch — `currentSubs` never updated to root —
+   so the landing would pair key `KEY.ROOT` with the old menu's subs (wrong
+   breadcrumb/sibling list) and a stale settled render could overwrite the
+   connecting text. Resetting forces the full root branch every time.
+2. On `objectinfo:received` with `key === KEY.ROOT` while `pendingLanding ===
    'root'`: the parser has already adopted authoritative DSP keys/names from
    the dump. Land: push the root keyStack entry
-   (`makeKeyStackEntry('0', currentSubs)`), set `currentKey` to the active
+   (`makeKeyStackEntry(KEY.ROOT, currentSubs)`), set `currentKey` to the active
    DSP's preset key **from the root dump** (`dspAKey`/`dspBKey`, chosen by the
    app-side active-DSP view state — fold Batch 3.2's "persist active DSP
    (default A)" item in here; the cached `presetKey` becomes a pre-paint hint
@@ -175,16 +185,23 @@ wrong-landing symptom; C2 removes the mechanism — both the timer and the flag.
    short-tag COL menus, descend once into the first (exactly what the
    autoload branch did, but triggered by explicit landing state, not a sticky
    flag read by every render). The renderer autoload branch and the
-   `autoLoad` field are then deleted; the remaining `autoLoad=true` writers
-   (LCD click handlers) switch to the same one-shot descend-on-next-dump
-   state.
+   `autoLoad` field are then deleted — every writer migrates to the same
+   one-shot descend-on-next-current-key-dump state: the four renderer LCD
+   click handlers (dsp-toggle, sibling-softkey, descend, back-link), the
+   controls.js PARAMETER keypress handler, and the store.js default. The
+   migration is behavior-preserving because the flag's only reader is the
+   renderScreen autoload branch and every writer sets it immediately before
+   `updateScreen()`.
 4. Failure path (folds in the C1-review watchdog item): if `dumpComplete`
-   fires `reason='watchdog'` while a landing is pending, do NOT land from
-   stale state — clear `pendingLanding`, keep the "Connected. Fetching root…"
-   text, log the stall. Sync/reconnect retries. With no sticky `autoLoad`
-   flag there is nothing for a stall render to mis-consume; this subsumes the
-   "watchdog dumpComplete mid-navigation autoload" ledger item for the
-   navigation case too once the flag is gone.
+   fires `reason='watchdog'` while a landing — or a click handler's one-shot
+   descend — is pending, clear that one-shot state too; do NOT land/descend
+   from stale state (a pending descend surviving a stall would otherwise fire
+   on a much later, unrelated dump). On a stalled fresh boot the settled
+   render no-ops (step 1's reset left `currentSubs` empty), so the
+   "Connected. Fetching root…" text stays; log the stall; sync/reconnect
+   retries. With no sticky `autoLoad` flag there is nothing for a stall
+   render to mis-consume; this subsumes the "watchdog dumpComplete
+   mid-navigation autoload" ledger item once the flag is gone.
 5. Out of scope for C2 (stays in 3.3): the cached structure-only pre-paint,
    the eager loader, `eagerLoad` flag, and the unconfirmed-value render
    guard.


### PR DESCRIPTION
## Summary

Executes C2's NEXT step: the connect/landing design is now written in phase3-state-model.md ('C2 design — connect/landing without timers') so the implementation session starts from a reviewed plan. Core: a one-shot pendingLanding state replaces both the PORT_INIT_MS timer and the sticky autoLoad flag; landing fires on the root dump's arrival with the view reset to root first (the reset makes reconnect take the full root branch instead of the background branch); the renderer autoload branch is deleted with all six flag writers migrated to the same one-shot descend state; an explicit watchdog failure path subsumes the C1-review mid-nav item; 3.2's persist-active-DSP folds in. Hardware validation deferred to one consolidated session after 3.3.

## Review

Design reviewer: **request-changes** — caught the reconnect-through-the-background-branch gap (stale subs in the landing's keyStack entry), the omitted controls.js flag writer, the pending-descend-survives-stall edge, and two doc/ledger consistency holes. All folded into the second commit.

## Testing

Docs-only; no code paths affected. The design's test strategy specifies the startup-characterization rewrite for the implementation commit.