### PR TITLE
fix: no-op softkey re-click of the current menu (C3 review)

### DIFF
--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -335,12 +335,11 @@ HUMAN-GATE: none
       entry used to yield none) — pinned by an added renderer assertion; clicking the highlighted current
       softkey can now self-push at depth 1 (pre-existing flaw at depth >=2, reach widened; logged as the
       item below).
-- [ ] NEW (from C3 review) Softkey re-click of the CURRENT menu self-pushes a duplicate keyStack entry:
-      handleLcdClick's descend branch does not skip newKey === currentKey (the sibling branch does), so
-      re-clicking the highlighted softkey pushes {key: currentKey, ...} and renders the menu "inside
-      itself"; back-pop recovers. Pre-existing at depth >=2; C3 made it reachable at depth 1 (the old
-      raw-string entry made that click a dead TypeError instead). FIX: guard the descend branch with
-      newKey !== appState.currentKey (no-op the click). CODE, low priority.
+- [x] NEW (from C3 review; branch fix/softkey-self-push) Softkey re-click of the CURRENT menu used to
+      self-push a duplicate keyStack entry (descend branch did not skip newKey === currentKey) and render
+      the menu "inside itself". The softkey handler now no-ops on the current key before either branch
+      (also skips the pointless refetch). Renderer test pins no-self-push/no-refetch; fails pre-fix
+      (verified).
 - [x] C5  (branch fix/autoload-subs-param, GH #41, PR #82) renderer autoload-descend now sources the keyStack parent
       entry from the `subs` param it was invoked with, not the global appState.currentSubs. NOTE (from review):
       renderScreen re-pins currentSubs=subs at its top (render-pin), so global==param today and this was NOT an
@@ -387,7 +386,7 @@ HUMAN-GATE: none
 ### Batch 3.3 — Connect handshake + eager loader + landing  (replaces the autoLoad timer mechanism)
 DECISION RESOLVED (see phase3-state-model.md): land on the last-active DSP's preset, read authoritatively
 from the root dump (device boots into last-used preset). Cache is a provisional structure-only pre-paint.
-- [x] C2  (branch refactor/c2-landing, GH #38) Implemented per phase3-state-model.md "C2 design": the
+- [x] C2  (branch refactor/c2-landing, GH #38, PR #94) Implemented per phase3-state-model.md "C2 design": the
       PORT_INIT_MS timer and the sticky autoLoad flag are DELETED. selectPorts resets the view to root
       (re-runnable: forces the parser's full root branch on reconnect) and arms a one-shot
       pendingLanding='root'; the bridge lands when the root dump ARRIVES — keyStack root entry,

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -62,6 +62,11 @@ const handleLcdClick = (e) => {
     updateScreen();
   } else if (e.target.classList.contains('softkey')) {
     const newKey = e.target.dataset.key;
+    // Re-clicking the highlighted CURRENT softkey is a no-op: the sibling
+    // branch below excludes it, so it used to fall through to the descend
+    // branch and push a duplicate self-entry onto the keyStack, rendering
+    // the menu "inside itself" (C3 review finding).
+    if (newKey === appState.currentKey) return;
     if (appState.keyStack.length > 0) {
       const parentEntry = appState.keyStack[appState.keyStack.length - 1];
       if (

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -69,10 +69,8 @@ const handleLcdClick = (e) => {
     if (newKey === appState.currentKey) return;
     if (appState.keyStack.length > 0) {
       const parentEntry = appState.keyStack[appState.keyStack.length - 1];
-      if (
-        parentEntry.subs.some((s) => s.key === newKey && s.type === 'COL') &&
-        newKey !== appState.currentKey
-      ) {
+      // (newKey === currentKey is impossible here — the early return above.)
+      if (parentEntry.subs.some((s) => s.key === newKey && s.type === 'COL')) {
         log(
           `User clicked sibling softkey: ${newKey} - ${e.target.textContent.trim()}`,
           'info',

--- a/tests/renderer.test.js
+++ b/tests/renderer.test.js
@@ -368,6 +368,72 @@ describe('renderer.js', () => {
     expect(appState.childSubs).toEqual({});
   });
 
+  test('re-clicking the current softkey is a no-op, not a self-push (C3 review)', () => {
+    appState.currentKey = '10010010';
+    appState.keyStack = [
+      {
+        key: '10010000',
+        tag: 'setup',
+        subs: [
+          {
+            type: 'COL',
+            position: '0',
+            key: '10010000',
+            parent: '10010000',
+            statement: 'Setup',
+            tag: 'setup',
+          },
+          {
+            type: 'COL',
+            position: '1',
+            key: '10010010',
+            parent: '10010000',
+            statement: 'Input',
+            tag: 'input',
+          },
+          {
+            type: 'COL',
+            position: '2',
+            key: '10010020',
+            parent: '10010000',
+            statement: 'Output',
+            tag: 'output',
+          },
+        ],
+      },
+    ];
+    // Leaf menu: parent's COLs render as softkeys, current one highlighted.
+    const subs = [
+      {
+        type: 'COL',
+        position: '0',
+        key: '10010010',
+        parent: '10010010',
+        statement: 'Input',
+        tag: 'input',
+      },
+      {
+        type: 'NUM',
+        position: '1',
+        key: '10010011',
+        parent: '10010010',
+        statement: 'lvl %3.0f',
+        tag: '',
+        value: '5',
+      },
+    ];
+    renderScreen(subs, '', mockLog);
+    sendObjectInfoDump.mockClear();
+
+    const current = document.querySelector('.softkey[data-key="10010010"]');
+    expect(current).toBeTruthy();
+    current.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(appState.currentKey).toBe('10010010'); // unchanged
+    expect(appState.keyStack).toHaveLength(1); // no duplicate self-entry
+    expect(sendObjectInfoDump).not.toHaveBeenCalled(); // no refetch churn
+  });
+
   test('a confirmed-empty NUM value is not refetched on render (C1 refetch convergence)', () => {
     // The device can answer a VALUE request with an empty value, which the
     // parser caches as ''. The render-driven refetch must treat that as


### PR DESCRIPTION
Tracker item from the C3 review (no separate GH issue). The softkey handler now returns early on `newKey === currentKey`: previously the sibling branch excluded the current key, so a self-click fell through to the descend branch and pushed a duplicate self-entry onto the keyStack, rendering the menu inside itself (back-pop to recover); it also issued a pointless refetch. Reviewer: **approve** — verified the early return suppresses only the self-click, the old behavior was never a usable click-to-refresh (Sync/polling are the refresh paths), and the new test fails on the parent commit (run in a worktree). Second commit drops the now-dead sibling-guard clause the reviewer flagged. 127 passing, lint/format clean.