### PR TITLE
fix: keep position-0 COL softkeys on menus with params (R1)

### DIFF
--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -415,7 +415,7 @@ in logs/ (program-screen.png).
 - [x] R1  (branch fix/softkey-position-filter) CRITICAL UX FIXED (maintainer: "can't set the machine's
       program"): deleted the holdover that dropped ALL position-0 COL children from the softkey row
       whenever the menu had any param — 'program functions' (one TRG + 8 position-0 COLs) rendered with
-      no navigation at all. The embed flow's own embeddedKey filter is the only exclusion needed.
+      no access to its own children. The embed flow's own embeddedKey filter is the only exclusion needed.
       VERIFIED LIVE with the headless harness: program menu now shows load/save/update/card/delete/
       savebank/del bank/link (matching the physical PROGRAM screen capture), and descending into 'load
       new preset' renders BOTH SET dropdowns (70 banks / 28 programs) + the load-into-A/B TRGs — the

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -412,14 +412,15 @@ Discovered by running the REAL app module graph headless (jsdom + @julusian/midi
 real parser/bridge/renderer) against the powered Orville — no browser. Harness prototype:
 logs/live-app.mjs (gitignored); promote to build_tools/ as part of G2. Physical ground-truth captures
 in logs/ (program-screen.png).
-- [ ] R1  CRITICAL UX (maintainer: "can't set the machine's program"): renderScreen drops ALL
-      position-0 COL children from the softkey row when the menu has any param — the
-      `if (hasNonColParams) localSoftSubs.filter(s => s.position !== '0')` holdover. 'program functions'
-      (one TRG + 8 position-0 COLs) renders with NO load/save/update/... softkeys -> the load-new-preset
-      UI (bank/program SETs + LOAD TRGs, confirmed arriving in childSubs) is unreachable. GROUND TRUTH:
-      the physical PROGRAM screen shows the banks/programs selectors with load/save/update/delete
-      softkeys. FIX candidate: delete the filter — the embed flow already excludes the embedded key
-      explicitly; verify against snapshots, then live.
+- [x] R1  (branch fix/softkey-position-filter) CRITICAL UX FIXED (maintainer: "can't set the machine's
+      program"): deleted the holdover that dropped ALL position-0 COL children from the softkey row
+      whenever the menu had any param — 'program functions' (one TRG + 8 position-0 COLs) rendered with
+      no navigation at all. The embed flow's own embeddedKey filter is the only exclusion needed.
+      VERIFIED LIVE with the headless harness: program menu now shows load/save/update/card/delete/
+      savebank/del bank/link (matching the physical PROGRAM screen capture), and descending into 'load
+      new preset' renders BOTH SET dropdowns (70 banks / 28 programs) + the load-into-A/B TRGs — the
+      full program-set UI works end to end on hardware. Renderer test pins the shape (fails pre-fix);
+      no existing snapshot changed (none covered the mixed shape).
 - [ ] R2  Duplicate softkey row sets (maintainer report): the static bottom root softkeys take the
       DESCEND branch, so the keyStack grows without bound (2 -> 6 in one four-click walk) and the
       previous menu becomes the "parent" entry — its COL row set renders twice (once from stale

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,7 +3,7 @@ import globals from 'globals';
 import prettier from 'eslint-config-prettier';
 
 export default [
-  { ignores: ['node_modules/**', 'combine/**', 'dist/**', '**/__snapshots__/**'] },
+  { ignores: ['node_modules/**', 'combine/**', 'dist/**', '**/__snapshots__/**', 'logs/**'] },
   js.configs.recommended,
   {
     // Phase 1 cleanup is complete, so these are hard errors now. Prefix an

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,6 +1,6 @@
 // renderer.js
 import { appState } from './state.js';
-import { CMD, KEY, KEY_PREFIX, PARAM_TYPES, ROOT_SOFTKEYS } from './sysex-commands.js';
+import { CMD, KEY, KEY_PREFIX, ROOT_SOFTKEYS } from './sysex-commands.js';
 import { TIMING, LAYOUT } from './constants.js';
 import { setState } from './store.js';
 import { sendObjectInfoDump, sendValueDump, sendValuePut, sendSysEx } from './midi.js';
@@ -484,16 +484,17 @@ export function renderScreen(subs, ascii, logParam) {
         paramHtmlLines.push(fullHtml);
       }
     });
-    // Append only the first child sub-menu inline if available
-    const hasNonColParams = subs.slice(1).some((s) => PARAM_TYPES.includes(s.type));
+    // Append only the first child sub-menu inline if available.
+    // NOTE (R1, live-validated): an earlier filter here dropped ALL
+    // position-0 COLs from the softkeys whenever the menu had any param,
+    // which made mixed menus like 'program functions' (TRG + 8 position-0
+    // COL children) unnavigable — the physical PROGRAM screen shows those
+    // softkeys. Only the actually-embedded child is excluded, below.
     localSoftSubs = subs
       .slice(1)
       .filter(
         (s) => s.type === 'COL' && s.tag.trim().length <= LAYOUT.SHORT_TAG_MAX && s.tag.trim()
       );
-    if (hasNonColParams) {
-      localSoftSubs = localSoftSubs.filter((s) => s.position !== '0');
-    }
     let potentialEmbedSubs = subs
       .slice(1)
       .filter((s) => s.type === 'COL' && s.position === '0' && s.parent === appState.currentKey);

--- a/tests/renderer.test.js
+++ b/tests/renderer.test.js
@@ -434,6 +434,56 @@ describe('renderer.js', () => {
     expect(sendObjectInfoDump).not.toHaveBeenCalled(); // no refetch churn
   });
 
+  test('a menu with params keeps its position-0 COL softkeys (R1: program functions navigable)', () => {
+    // Live-validated bug: 'program functions' is one TRG + eight position-0
+    // COL children. A holdover filter dropped ALL position-0 COLs from the
+    // softkey row whenever any param was present, leaving the menu with no
+    // navigation at all — the load-new-preset UI (bank/program selection)
+    // was unreachable. The physical PROGRAM screen shows those softkeys
+    // (load/save/update/delete...). Embedding still excludes only the
+    // actually-embedded child, handled separately by the embeddedKey filter.
+    appState.currentKey = '10020000';
+    const subs = [
+      {
+        type: 'COL',
+        position: '0',
+        key: '10020000',
+        parent: '10020000',
+        statement: 'program functions',
+        tag: 'program',
+      },
+      {
+        type: 'COL',
+        position: '0',
+        key: '10020010',
+        parent: '10020000',
+        statement: 'load new preset',
+        tag: 'load',
+      },
+      {
+        type: 'COL',
+        position: '0',
+        key: '10020020',
+        parent: '10020000',
+        statement: 'save program',
+        tag: 'save',
+      },
+      {
+        type: 'TRG',
+        position: '0',
+        key: '10020090',
+        parent: '10020000',
+        statement: '<- compare program',
+        tag: 'compare',
+      },
+    ];
+    renderScreen(subs, '', mockLog);
+
+    expect(document.querySelector('.softkey[data-key="10020010"]')).toBeTruthy(); // load
+    expect(document.querySelector('.softkey[data-key="10020020"]')).toBeTruthy(); // save
+    expect(document.querySelector('.param-value[data-key="10020090"]')).toBeTruthy(); // TRG still renders
+  });
+
   test('a confirmed-empty NUM value is not refetched on render (C1 refetch convergence)', () => {
     // The device can answer a VALUE request with an empty value, which the
     // parser caches as ''. The render-driven refetch must treat that as


### PR DESCRIPTION
Tracker R1 (Batch 3.3b, live-loop findings; maintainer-reported 'can't set the machine's program'). Deletes the holdover filter that dropped all position-0 COL children from the softkey row whenever the menu had any param — mixed menus like 'program functions' (TRG + 8 position-0 COLs) rendered with no access to their own children, making the load-new-preset UI unreachable. The embed flow's embeddedKey filter is the only exclusion needed.

**Verified live** with the headless harness against the powered Orville: program menu renders all eight child softkeys (matching the captured physical PROGRAM screen), and 'load new preset' renders both SET dropdowns (70 banks / 28 programs) plus the load-into-A/B triggers — the full program-set flow works end to end.

Reviewer: **approve** — enumerated the gained-softkey scenarios (the single-position-0-COL wrapper case shows a navigable softkey for one wave before embedding: improvement, not regression), confirmed no existing snapshot ever pinned the old filter (the two near-miss scenarios use position '1' / have no params), and verified the new test fails pre-fix. Second commit applies its follow-ups: eslint now ignores gitignored logs/ prototypes; ledger wording precision.

128 passing / 14 suites; lint and format clean.