### PR TITLE
fix: deterministic first-child embed; root softkeys jump (R6, R2)

### DIFF
--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -421,11 +421,22 @@ in logs/ (program-screen.png).
       new preset' renders BOTH SET dropdowns (70 banks / 28 programs) + the load-into-A/B TRGs — the
       full program-set UI works end to end on hardware. Renderer test pins the shape (fails pre-fix);
       no existing snapshot changed (none covered the mixed shape).
-- [ ] R2  Duplicate softkey row sets (maintainer report): the static bottom root softkeys take the
-      DESCEND branch, so the keyStack grows without bound (2 -> 6 in one four-click walk) and the
-      previous menu becomes the "parent" entry — its COL row set renders twice (once from stale
-      currentSubs as the current row, once as the parent row). FIX: root-level jumps (ROOT_SOFTKEYS keys
-      and root children) should reset the stack like the Sync button, not push; pair with R3's guard.
+- [x] R2  (branch fix/deterministic-embed-root-jump) Duplicate softkey row sets FIXED: the static bottom
+      root softkeys now JUMP — reset the keyStack — instead of descending (which grew the stack without
+      bound, 2 -> 6 in one walk, and rendered the previous menu's COL row set twice). pendingDescend
+      stays set on the jump (matches the front panel: function keys land on a parameter page, not a bare
+      listing). NOTE (review): after a jump the root view has no breadcrumb — root is reachable via
+      Sync/reconnect and everything it offers stays docked (A/B tabs + static row); revisit if root
+      needs a first-class affordance. Test pins jump-resets-stack (fails pre-fix).
+- [x] R6  (same branch; maintainer screenshots) NONDETERMINISTIC EMBED FIXED: the embed loop took
+      whichever position-0 child's dump had arrived first — on 'program functions' the first child's
+      response (the giant bank list) is slowest, so 'link program' won the race and the embedded UI
+      varied run to run (sometimes nothing, sometimes the wrong child's selectors). Only the FIRST
+      position-0 child in subs order may embed now (the physical PROGRAM page shows 'load new preset' as
+      the menu's default view); while its dump is in flight the children stay navigable softkeys (R1).
+      Review hardening: the embed prefetch fires only when the parser's short-tag fan-out will NOT fetch
+      the candidate (long/empty tag) — the unconditional version duplicated the heaviest dump on the
+      wire once per navigation. Two-phase test pins arrival-order independence (fails pre-fix).
 - [ ] R3  Stale-menu render: clicking a menu renders the OLD menu under the NEW key (wrong title and
       breadcrumb, e.g. "[program] program functions" while currentKey=10030000) until the new dump
       lands — on a backed-up link that is seconds. This is the "never render an unconfirmed value"

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -533,12 +533,16 @@ export function renderScreen(subs, ascii, logParam) {
       .filter((s) => s.type === 'COL' && s.position === '0' && s.parent === appState.currentKey)
       .slice(0, 1);
     let embeddedKey = null;
-    // Proactively fetch the embed candidate (covers long/empty-tag children
-    // the parser's short-tag fan-out skips; a no-op when already cached).
-    if (potentialEmbedSubs.length === 1) {
-      const embedKey = potentialEmbedSubs[0].key;
-      if (!appState.childSubs[embedKey]) {
-        sendObjectInfoDump(embedKey, logParam);
+    // Proactively fetch the embed candidate ONLY when the parser's short-tag
+    // fan-out will not already fetch it (long/empty tag) — otherwise this
+    // duplicated the same request in the same wave on every navigation, and
+    // on 'program functions' the duplicated key is the giant bank list
+    // (R6 review).
+    if (potentialEmbedSubs.length > 0) {
+      const cand = potentialEmbedSubs[0];
+      const fanOutCovers = cand.tag.trim() && cand.tag.trim().length <= LAYOUT.SHORT_TAG_MAX;
+      if (!fanOutCovers && !appState.childSubs[cand.key]) {
+        sendObjectInfoDump(cand.key, logParam);
       }
     }
     for (let local of potentialEmbedSubs) {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -67,6 +67,31 @@ const handleLcdClick = (e) => {
     // branch and push a duplicate self-entry onto the keyStack, rendering
     // the menu "inside itself" (C3 review finding).
     if (newKey === appState.currentKey) return;
+    // The static bottom row (program/setup/levels/bypass) is a top-level
+    // JUMP, not a descend (R2, live-validated): descending pushed the
+    // previous menu as "parent", growing the keyStack without bound and
+    // rendering the old menu's COL row set twice (once stale-current, once
+    // as the parent row). Jumping resets the stack — these are root's own
+    // children; the static row itself is the way back around.
+    if (ROOT_SOFTKEYS.some((s) => s.key === newKey)) {
+      log(
+        `User clicked root softkey: ${newKey} - ${e.target.textContent.trim()}`,
+        'info',
+        'general'
+      );
+      setState(
+        {
+          keyStack: [],
+          currentKey: newKey,
+          paramOffset: 0,
+          pendingDescend: true,
+          currentSoftkeys: [],
+        },
+        'renderer:lcd-click-root-jump'
+      );
+      updateScreen();
+      return;
+    }
     if (appState.keyStack.length > 0) {
       const parentEntry = appState.keyStack[appState.keyStack.length - 1];
       // (newKey === currentKey is impossible here — the early return above.)
@@ -495,11 +520,21 @@ export function renderScreen(subs, ascii, logParam) {
       .filter(
         (s) => s.type === 'COL' && s.tag.trim().length <= LAYOUT.SHORT_TAG_MAX && s.tag.trim()
       );
+    // Deterministic embed (R6, live-validated): only ever the FIRST
+    // position-0 child in subs order may embed. The old loop embedded
+    // whichever child's dump happened to have arrived — on 'program
+    // functions' the first child's response (the giant bank list) is the
+    // slowest, so a later sibling like 'link program' would win the race
+    // and the embedded UI varied run to run. The physical PROGRAM page is
+    // the ground truth: the first child ('load new preset') is the menu's
+    // default view.
     let potentialEmbedSubs = subs
       .slice(1)
-      .filter((s) => s.type === 'COL' && s.position === '0' && s.parent === appState.currentKey);
+      .filter((s) => s.type === 'COL' && s.position === '0' && s.parent === appState.currentKey)
+      .slice(0, 1);
     let embeddedKey = null;
-    // Proactively fetch single position-0 child for embedding (wrappers)
+    // Proactively fetch the embed candidate (covers long/empty-tag children
+    // the parser's short-tag fan-out skips; a no-op when already cached).
     if (potentialEmbedSubs.length === 1) {
       const embedKey = potentialEmbedSubs[0].key;
       if (!appState.childSubs[embedKey]) {

--- a/tests/renderer.test.js
+++ b/tests/renderer.test.js
@@ -484,6 +484,129 @@ describe('renderer.js', () => {
     expect(document.querySelector('.param-value[data-key="10020090"]')).toBeTruthy(); // TRG still renders
   });
 
+  test('only the FIRST position-0 child may embed, regardless of arrival order (R6)', () => {
+    // Live-validated: on 'program functions' the first child's dump (the
+    // giant bank list) arrives last, so the old first-loaded-wins loop
+    // embedded a later sibling ('link program') and the embedded UI varied
+    // run to run. Pin: a later sibling with loaded childSubs must NOT embed
+    // while the first candidate's data is absent.
+    appState.currentKey = '10020000';
+    const subs = [
+      {
+        type: 'COL',
+        position: '0',
+        key: '10020000',
+        parent: '10020000',
+        statement: 'program functions',
+        tag: 'program',
+      },
+      {
+        type: 'COL',
+        position: '0',
+        key: '10020010',
+        parent: '10020000',
+        statement: 'load new preset',
+        tag: 'load',
+      },
+      {
+        type: 'COL',
+        position: '0',
+        key: '10020080',
+        parent: '10020000',
+        statement: 'link program',
+        tag: 'link',
+      },
+    ];
+    appState.childSubs = {
+      // Only the LATER sibling has arrived.
+      10020080: [
+        {
+          type: 'COL',
+          position: '0',
+          key: '10020080',
+          parent: '10020080',
+          statement: 'link program',
+          tag: 'link',
+        },
+        {
+          type: 'TRG',
+          position: '1',
+          key: '10020081',
+          parent: '10020080',
+          statement: '<- link',
+          tag: 'link',
+        },
+      ],
+    };
+    renderScreen(subs, '', mockLog);
+    const lcd = document.getElementById('lcd');
+    expect(lcd.textContent).not.toContain('<- link'); // later sibling must not embed
+    expect(document.querySelector('.softkey[data-key="10020080"]')).toBeTruthy(); // stays a softkey
+
+    // Once the FIRST candidate's data arrives, it embeds (and leaves the row).
+    appState.childSubs = {
+      10020010: [
+        {
+          type: 'COL',
+          position: '0',
+          key: '10020010',
+          parent: '10020010',
+          statement: 'load new preset',
+          tag: 'load',
+        },
+        {
+          type: 'TRG',
+          position: '1',
+          key: '1002001c',
+          parent: '10020010',
+          statement: '<- load program in A',
+          tag: 'load',
+        },
+      ],
+    };
+    renderScreen(subs, '', mockLog);
+    expect(lcd.textContent).toContain('<- load program in A'); // first candidate embeds
+    expect(document.querySelector('.softkey[data-key="10020010"]')).toBeFalsy(); // excluded from row
+  });
+
+  test('static root softkeys jump (reset the stack), never descend (R2)', () => {
+    // Live-validated: descending grew the keyStack without bound (2 -> 6 in
+    // one walk) and duplicated the previous menu's COL row set.
+    appState.currentKey = '10010010';
+    appState.keyStack = [
+      { key: '0', tag: 'ORVILLE', subs: [] },
+      { key: '10010000', tag: 'setup', subs: [] },
+    ];
+    const subs = [
+      {
+        type: 'COL',
+        position: '0',
+        key: '10010010',
+        parent: '10010010',
+        statement: 'MIDI configuration',
+        tag: 'midi',
+      },
+      {
+        type: 'NUM',
+        position: '1',
+        key: '10010011',
+        parent: '10010010',
+        statement: 'ch %2.0f',
+        tag: '',
+        value: '1',
+      },
+    ];
+    renderScreen(subs, '', mockLog);
+
+    const levels = document.querySelector('.softkey[data-key="10030000"]'); // static row
+    expect(levels).toBeTruthy();
+    levels.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(appState.currentKey).toBe('10030000');
+    expect(appState.keyStack).toEqual([]); // jump resets, not push to length 3
+    expect(appState.pendingDescend).toBe(true);
+  });
+
   test('a confirmed-empty NUM value is not refetched on render (C1 refetch convergence)', () => {
     // The device can answer a VALUE request with an empty value, which the
     // parser caches as ''. The render-driven refetch must treat that as

--- a/tests/startup.test.js
+++ b/tests/startup.test.js
@@ -448,7 +448,13 @@ describe('startup characterization (roadmap step 5.5)', () => {
       'state:parser:current-key-ascii:lastAscii',
       'state:parser:current-subs:currentSubs',
       `render:land=preset,desc=true,key=401000b,subsCount=${expected401.subsCount},subsFirst=401000b`,
-      'state:renderer:render-pin:currentSoftkeys,currentSubs',
+      // R6: the deterministic-embed prefetch for the preset's FIRST
+      // position-0 child fires mid-render (between the two render-pin
+      // writes, breaking their coalescing) — it warms the menu the descend
+      // lands on one beat later.
+      'state:renderer:render-pin:currentSubs',
+      `midi:objectinfo:${expected401.shortTagKeys[0]}`,
+      'state:renderer:render-pin:currentSoftkeys',
       'state:bridge:descend-consume:pendingDescend,pendingLanding',
       'log:general:info:Auto-loading first menu',
       'state:bridge:descend:currentKey,keyStack',

--- a/tests/startup.test.js
+++ b/tests/startup.test.js
@@ -448,13 +448,11 @@ describe('startup characterization (roadmap step 5.5)', () => {
       'state:parser:current-key-ascii:lastAscii',
       'state:parser:current-subs:currentSubs',
       `render:land=preset,desc=true,key=401000b,subsCount=${expected401.subsCount},subsFirst=401000b`,
-      // R6: the deterministic-embed prefetch for the preset's FIRST
-      // position-0 child fires mid-render (between the two render-pin
-      // writes, breaking their coalescing) — it warms the menu the descend
-      // lands on one beat later.
-      'state:renderer:render-pin:currentSubs',
-      `midi:objectinfo:${expected401.shortTagKeys[0]}`,
-      'state:renderer:render-pin:currentSoftkeys',
+      // R6 review: the embed prefetch is suppressed when the parser's
+      // short-tag fan-out already fetches the candidate (it does here:
+      // 'space'), so no duplicate request appears and the render-pins
+      // coalesce as before.
+      'state:renderer:render-pin:currentSoftkeys,currentSubs',
       'state:bridge:descend-consume:pendingDescend,pendingLanding',
       'log:general:info:Auto-loading first menu',
       'state:bridge:descend:currentKey,keyStack',


### PR DESCRIPTION
Tracker R6 + R2 (Batch 3.3b live-loop findings; maintainer screenshots + headless-harness reproduction).

**R6 — nondeterministic embed**: the embed loop took whichever position-0 child's dump had arrived first. On 'program functions' the first child's response (the ~3KB bank list) is the slowest, so 'link program' won the race — the embedded UI varied run to run (sometimes nothing, sometimes the wrong child's selectors; see the maintainer's screenshots). Only the FIRST position-0 child in subs order may embed now, matching the physical PROGRAM page where 'load new preset' is the menu's default view; while its dump is in flight the children remain navigable softkeys (R1). Review hardening: the embed prefetch fires only for long/empty-tag candidates the parser's short-tag fan-out skips — the unconditional version duplicated the heaviest dump on the wire once per navigation.

**R2 — duplicate softkey row sets**: the static bottom row (program/setup/levels/bypass) jumped through the descend branch, pushing the previous menu as 'parent' (keyStack 2 -> 6 in one live walk) and rendering its COL row set twice. Those clicks are now top-level JUMPS that reset the stack. pendingDescend stays set (matches front-panel behavior: function keys land on a parameter page). Review note recorded: post-jump root has no breadcrumb — root stays reachable via Sync; revisit if it needs a first-class affordance.

Reviewer: **approve-with-nits** — verified embed mechanics unchanged apart from candidate selection, the jump branch's ordering vs the self-click no-op and sibling check, pendingDescend behavior parity across all nav paths, and ran the new tests against the parent commit (exactly the intended failures). All nits applied in the second commit (prefetch complement condition, ledger entries, candidate-check readability).

130 passing / 14 suites; lint and format clean. Both fixes trace to live device sessions; the program-menu flow re-verifies live on the next harness run.