### PR TITLE
feat: tree auditor + headless live harness (T1a)

### DIFF
--- a/build_tools/live-app.mjs
+++ b/build_tools/live-app.mjs
@@ -53,7 +53,7 @@ await import('../src/main.js'); // connectMidi(null) fails harmlessly (no WebMID
 const { appState } = await import('../src/state.js');
 const { setState } = await import('../src/store.js');
 const { updateScreen } = await import('../src/renderer.js');
-const { KEY } = await import('../src/sysex-commands.js');
+const { KEY, SYSEX } = await import('../src/sysex-commands.js');
 const { log } = await import('../src/logger.js');
 
 // --- real MIDI via @julusian/midi, adapted to midi.js's port contract ----
@@ -87,7 +87,7 @@ input.on('message', (dt, msg) => {
   for (const cb of inAdapter.listeners) cb({ data: msg });
 });
 const outAdapter = {
-  sendSysex: (mfr, data) => output.sendMessage([0xf0, ...mfr, ...data, 0xf7]),
+  sendSysex: (mfr, data) => output.sendMessage([SYSEX.START, ...mfr, ...data, SYSEX.END]),
 };
 
 // --- connect: mirror main.js selectPorts (not exported) ------------------
@@ -102,7 +102,7 @@ setState(
     pendingLanding: 'root',
     pendingDescend: false,
   },
-  'main:select-ports-reset'
+  'live-app:select-ports-reset'
 );
 updateScreen(log);
 console.log('[live] connected; landing armed');

--- a/build_tools/live-app.mjs
+++ b/build_tools/live-app.mjs
@@ -1,0 +1,161 @@
+// Headless live-app harness (T1/G2 substrate).
+// Runs the REAL app module graph (main/bridge/parser/renderer) in jsdom
+// against the REAL Orville over @julusian/midi — no browser. The session
+// drives navigation by dispatching clicks on the rendered LCD and reads the
+// virtual render back. This is the G2 "live self-loop" substrate.
+//
+// Usage: node build_tools/live-app.mjs [walk|stay] [settleMs]
+
+import { JSDOM } from 'jsdom';
+import midi from '@julusian/midi';
+import fs from 'node:fs';
+
+const MODE = process.argv[2] || 'walk';
+const SETTLE = parseInt(process.argv[3] || '2500', 10);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// --- DOM up first: src modules touch document at import time -------------
+const html = fs.readFileSync('src/index.html', 'utf8');
+const dom = new JSDOM(html, { url: 'http://localhost/', pretendToBeVisual: true });
+globalThis.window = dom.window;
+globalThis.document = dom.window.document;
+Object.defineProperty(globalThis, 'navigator', {
+  value: dom.window.navigator,
+  configurable: true,
+});
+globalThis.localStorage = dom.window.localStorage;
+globalThis.MouseEvent = dom.window.MouseEvent;
+globalThis.Event = dom.window.Event;
+globalThis.prompt = () => null;
+globalThis.alert = () => {};
+
+// jsdom has no 2d canvas; minimal store so renderBitmap runs (same trick as
+// tests/helpers/replay.js).
+const canvas = document.getElementById('lcd-canvas');
+if (canvas) {
+  let store = { width: 0, height: 0, data: new Uint8ClampedArray(0) };
+  canvas.getContext = () => ({
+    getImageData: (x, y, w, h) => {
+      if (store.width !== w || store.height !== h) {
+        store = { width: w, height: h, data: new Uint8ClampedArray(w * h * 4) };
+      }
+      return store;
+    },
+    putImageData: (img) => {
+      store = img;
+    },
+  });
+}
+
+// --- real app modules (main.js wires DOM + registers the event bridge) ---
+const { setMidiPorts, addSysexListener } = await import('../src/midi.js');
+await import('../src/main.js'); // connectMidi(null) fails harmlessly (no WebMIDI in jsdom)
+const { appState } = await import('../src/state.js');
+const { setState } = await import('../src/store.js');
+const { updateScreen } = await import('../src/renderer.js');
+const { KEY } = await import('../src/sysex-commands.js');
+const { log } = await import('../src/logger.js');
+
+// --- real MIDI via @julusian/midi, adapted to midi.js's port contract ----
+const input = new midi.Input();
+const output = new midi.Output();
+const findPort = (dev, name) => {
+  for (let i = 0; i < dev.getPortCount(); i++) if (dev.getPortName(i).includes(name)) return i;
+  return -1;
+};
+const inIdx = findPort(input, 'MIDIIN3');
+const outIdx = findPort(output, 'MIDIOUT2');
+if (inIdx < 0 || outIdx < 0) {
+  console.error('U6MIDI Pro ports not found (in MIDIIN3 / out MIDIOUT2). Port busy?');
+  process.exit(1);
+}
+input.openPort(inIdx);
+output.openPort(outIdx);
+input.ignoreTypes(false, true, true); // sysex on, timing/active-sense off
+
+const inAdapter = {
+  listeners: [],
+  addListener(type, cb) {
+    if (type === 'sysex') this.listeners.push(cb);
+  },
+  removeListener(type, cb) {
+    const i = this.listeners.indexOf(cb);
+    if (i !== -1) this.listeners.splice(i, 1);
+  },
+};
+input.on('message', (dt, msg) => {
+  for (const cb of inAdapter.listeners) cb({ data: msg });
+});
+const outAdapter = {
+  sendSysex: (mfr, data) => output.sendMessage([0xf0, ...mfr, ...data, 0xf7]),
+};
+
+// --- connect: mirror main.js selectPorts (not exported) ------------------
+setMidiPorts(outAdapter, inAdapter, 1);
+addSysexListener();
+document.getElementById('lcd').innerText = 'Connected. Fetching root screen...';
+setState(
+  {
+    currentKey: KEY.ROOT,
+    keyStack: [],
+    currentSubs: [],
+    pendingLanding: 'root',
+    pendingDescend: false,
+  },
+  'main:select-ports-reset'
+);
+updateScreen(log);
+console.log('[live] connected; landing armed');
+
+const lcdText = () => document.getElementById('lcd').textContent;
+const dump = (label) => {
+  console.log(
+    `\n===== ${label} | key=${appState.currentKey} stack=${appState.keyStack.length} =====`
+  );
+  console.log(lcdText());
+};
+const click = (selector) => {
+  const el = document.querySelector(selector);
+  if (!el) return false;
+  el.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+  return true;
+};
+
+await sleep(SETTLE + 1500); // landing: root wave + preset wave + descend wave
+dump('LANDING');
+
+if (MODE === 'walk') {
+  for (const [key, name] of [
+    ['10020000', 'program'],
+    ['10010000', 'setup'],
+    ['10030000', 'levels'],
+    ['10030500', 'bypass'],
+  ]) {
+    const ok = click(`.softkey[data-key="${key}"]`);
+    if (!ok) {
+      console.log(`\n===== ${name}: NO SOFTKEY ${key} in current render =====`);
+      continue;
+    }
+    await sleep(SETTLE);
+    dump(name);
+  }
+} else if (MODE === 'load') {
+  // The "set the machine's program" flow: program menu -> load new preset.
+  // Long settles so the giant bank-list dump can drain the link.
+  click('.softkey[data-key="10020000"]');
+  await sleep(SETTLE);
+  dump('program');
+  const ok = click('.softkey[data-key="10020010"]');
+  console.log('[live] clicked load softkey:', ok);
+  await sleep(SETTLE * 2);
+  dump('load new preset');
+  const selects = document.querySelectorAll('select.param-select').length;
+  const trgs = [...document.querySelectorAll('.param-value')].map((e) => e.textContent.trim());
+  console.log(`[live] SET dropdowns rendered: ${selects}; TRGs: ${JSON.stringify(trgs)}`);
+}
+
+console.log('\n===== last dumpComplete =====');
+console.log(JSON.stringify(appState.lastDumpComplete));
+input.closePort();
+output.closePort();
+process.exit(0);

--- a/build_tools/tree-audit.mjs
+++ b/build_tools/tree-audit.mjs
@@ -54,7 +54,7 @@ const { appState } = await import('../src/state.js');
 const { setState } = await import('../src/store.js');
 const { updateScreen } = await import('../src/renderer.js');
 const { makeKeyStackEntry } = await import('../src/navigation.js');
-const { KEY } = await import('../src/sysex-commands.js');
+const { KEY, CMD, SYSEX } = await import('../src/sysex-commands.js');
 const { LAYOUT } = await import('../src/constants.js');
 const { log } = await import('../src/logger.js');
 
@@ -83,20 +83,27 @@ input.on('message', () => {
 const DEV = 1;
 function requestObjectinfo(key) {
   const ascii = key.split('').map((c) => c.charCodeAt(0));
-  output.sendMessage([0xf0, 0x1c, 0x70, DEV, 0x31, ...ascii, 0xf7]);
+  output.sendMessage([
+    SYSEX.START,
+    ...SYSEX.MANUFACTURER,
+    DEV,
+    CMD.OBJECTINFO_DUMP,
+    ...ascii,
+    SYSEX.END,
+  ]);
 }
 function awaitDump(forKey, timeoutMs = 12000) {
   return new Promise((resolve) => {
     let buf = [];
     const onMsg = (dt, msg) => {
       const data = Array.from(msg);
-      if (data[0] === 0xf0) buf = data;
+      if (data[0] === SYSEX.START) buf = data;
       else buf = buf.concat(data);
-      if (buf[0] === 0xf0 && buf[buf.length - 1] === 0xf7) {
+      if (buf[0] === SYSEX.START && buf[buf.length - 1] === SYSEX.END) {
         const frame = buf;
         buf = [];
-        if (frame[4] !== 0x32) return; // not an OBJECTINFO dump
-        const ascii = String.fromCharCode(...frame.slice(5, -1))
+        if (frame[4] !== CMD.OBJECTINFO) return; // not an OBJECTINFO dump
+        const ascii = String.fromCharCode(...frame.slice(SYSEX.FRAME_PREFIX_LEN, -1))
           .replace(/\0+$/, '')
           .trim();
         const subs = ascii
@@ -163,7 +170,7 @@ input.on('message', (dt, msg) => {
   for (const cb of inAdapter.listeners) cb({ data: msg });
 });
 const outAdapter = {
-  sendSysex: (mfr, data) => output.sendMessage([0xf0, ...mfr, ...data, 0xf7]),
+  sendSysex: (mfr, data) => output.sendMessage([SYSEX.START, ...mfr, ...data, SYSEX.END]),
 };
 setMidiPorts(outAdapter, inAdapter, DEV);
 addSysexListener();
@@ -200,6 +207,13 @@ const colNodes = [...tree.entries()].filter(
 console.log(`[audit] phase 2: auditing ${colNodes.length} COL nodes...`);
 
 for (const [key, node] of colNodes) {
+  // Drain the link BEFORE navigating so the previous node's backlog (e.g.
+  // the program fan-out's bank list, or a no-render timeout's stragglers)
+  // cannot starve this node's settle window (R5).
+  {
+    const t0 = Date.now();
+    while (Date.now() - lastMsgAt < QUIET_MS && Date.now() - t0 < CAP_MS) await sleep(150);
+  }
   // Navigate with TREE-computed ancestors (the T1 principle): the view we
   // audit is positioned exactly where the tree says the node lives.
   const keyStack = ancestorsOf(key).map((aKey) =>
@@ -247,7 +261,7 @@ for (const [key, node] of colNodes) {
     const textHit =
       (stmtFrag && mainText.includes(stmtFrag)) ||
       (p.type === 'INF' && valFrag && mainText.includes(valFrag)) || // INF renders its value
-      (tagFrag && mainText.includes(tagFrag)); // bar CONs render tag-only, no data-key
+      (tagFrag && mainText.includes(tagFrag)); // blanket short-text fallback (bar CONs render tag-only, no data-key)
     if (keyCount === 0 && !textHit) {
       flag(key, 'param-missing', `${p.type} ${p.key} '${p.statement}' not rendered`);
     } else if (keyCount > 1) {
@@ -259,13 +273,6 @@ for (const [key, node] of colNodes) {
   const softkeyKeys = [...(main?.querySelectorAll('.softkey') || [])].map((e) => e.dataset.key);
   const dupes = softkeyKeys.filter((k, i) => softkeyKeys.indexOf(k) !== i);
   if (dupes.length) flag(key, 'duplicate-softkeys', [...new Set(dupes)].join(','));
-
-  // Drain the link before the next node so one menu's backlog (e.g. the
-  // program fan-out's bank list) cannot starve the next audit (R5).
-  {
-    const t0 = Date.now();
-    while (Date.now() - lastMsgAt < QUIET_MS && Date.now() - t0 < CAP_MS) await sleep(150);
-  }
 
   // 4. Breadcrumb = real tree parent.
   const back = document.querySelector('.back-link');

--- a/build_tools/tree-audit.mjs
+++ b/build_tools/tree-audit.mjs
@@ -1,0 +1,301 @@
+// Tree auditor (T1). Validates the app render against the device tree.
+// Phase 1: fetch the device's object tree directly (sequential OBJECTINFO,
+//   one in flight, parsed with the real parseSubObject) — ground truth.
+// Phase 2: boot the REAL app headless (jsdom + midi adapters) and, for every
+//   COL node, navigate to it with tree-computed ancestors, wait for quiet,
+//   and diff the rendered LCD against the node's own dump.
+// Violations are emitted as JSON lines and summarized; report saved to
+// logs/tree-audit-report.json.
+//
+// Usage: node build_tools/tree-audit.mjs [maxDepth=2] [quietMs=1500] [capMs=15000]
+
+import { JSDOM } from 'jsdom';
+import midi from '@julusian/midi';
+import fs from 'node:fs';
+
+const MAX_DEPTH = parseInt(process.argv[2] || '2', 10);
+const QUIET_MS = parseInt(process.argv[3] || '1500', 10);
+const CAP_MS = parseInt(process.argv[4] || '15000', 10);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ---------- DOM + app boot (same recipe as live-app.mjs) ------------------
+const html = fs.readFileSync('src/index.html', 'utf8');
+const dom = new JSDOM(html, { url: 'http://localhost/', pretendToBeVisual: true });
+globalThis.window = dom.window;
+globalThis.document = dom.window.document;
+Object.defineProperty(globalThis, 'navigator', {
+  value: dom.window.navigator,
+  configurable: true,
+});
+globalThis.localStorage = dom.window.localStorage;
+globalThis.MouseEvent = dom.window.MouseEvent;
+globalThis.Event = dom.window.Event;
+globalThis.prompt = () => null;
+globalThis.alert = () => {};
+const canvas = document.getElementById('lcd-canvas');
+if (canvas) {
+  let store = { width: 0, height: 0, data: new Uint8ClampedArray(0) };
+  canvas.getContext = () => ({
+    getImageData: (x, y, w, h) => {
+      if (store.width !== w || store.height !== h)
+        store = { width: w, height: h, data: new Uint8ClampedArray(w * h * 4) };
+      return store;
+    },
+    putImageData: (img) => {
+      store = img;
+    },
+  });
+}
+
+const { parseSubObject } = await import('../src/parser.js');
+const { setMidiPorts, addSysexListener } = await import('../src/midi.js');
+await import('../src/main.js');
+const { appState } = await import('../src/state.js');
+const { setState } = await import('../src/store.js');
+const { updateScreen } = await import('../src/renderer.js');
+const { makeKeyStackEntry } = await import('../src/navigation.js');
+const { KEY } = await import('../src/sysex-commands.js');
+const { LAYOUT } = await import('../src/constants.js');
+const { log } = await import('../src/logger.js');
+
+// ---------- real MIDI ------------------------------------------------------
+const input = new midi.Input();
+const output = new midi.Output();
+const findPort = (dev, name) => {
+  for (let i = 0; i < dev.getPortCount(); i++) if (dev.getPortName(i).includes(name)) return i;
+  return -1;
+};
+const inIdx = findPort(input, 'MIDIIN3');
+const outIdx = findPort(output, 'MIDIOUT2');
+if (inIdx < 0 || outIdx < 0) {
+  console.error('U6MIDI Pro ports not found (MIDIIN3 in / MIDIOUT2 out). Port busy?');
+  process.exit(1);
+}
+input.openPort(inIdx);
+output.openPort(outIdx);
+input.ignoreTypes(false, true, true);
+let lastMsgAt = Date.now();
+input.on('message', () => {
+  lastMsgAt = Date.now();
+});
+
+// ---------- Phase 1: raw sequential tree fetch -----------------------------
+const DEV = 1;
+function requestObjectinfo(key) {
+  const ascii = key.split('').map((c) => c.charCodeAt(0));
+  output.sendMessage([0xf0, 0x1c, 0x70, DEV, 0x31, ...ascii, 0xf7]);
+}
+function awaitDump(forKey, timeoutMs = 12000) {
+  return new Promise((resolve) => {
+    let buf = [];
+    const onMsg = (dt, msg) => {
+      const data = Array.from(msg);
+      if (data[0] === 0xf0) buf = data;
+      else buf = buf.concat(data);
+      if (buf[0] === 0xf0 && buf[buf.length - 1] === 0xf7) {
+        const frame = buf;
+        buf = [];
+        if (frame[4] !== 0x32) return; // not an OBJECTINFO dump
+        const ascii = String.fromCharCode(...frame.slice(5, -1))
+          .replace(/\0+$/, '')
+          .trim();
+        const subs = ascii
+          .split('\n')
+          .map((l) => l.trim())
+          .filter(Boolean)
+          .map(parseSubObject);
+        if (subs[0]?.key === forKey) {
+          cleanup();
+          resolve(subs);
+        }
+      }
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve(null);
+    }, timeoutMs);
+    const cleanup = () => {
+      clearTimeout(timer);
+      input.off('message', onMsg);
+    };
+    input.on('message', onMsg);
+  });
+}
+
+console.log(`[audit] phase 1: fetching tree (depth <= ${MAX_DEPTH})...`);
+const tree = new Map(); // key -> { subs, depth, parentKey }
+const queue = [{ key: KEY.ROOT, depth: 0, parentKey: null }];
+const visited = new Set();
+while (queue.length) {
+  const { key, depth, parentKey } = queue.shift();
+  if (visited.has(key)) continue;
+  visited.add(key);
+  requestObjectinfo(key);
+  const subs = await awaitDump(key);
+  if (!subs) {
+    console.log(`[audit] WARN no dump for ${key} (timeout)`);
+    continue;
+  }
+  tree.set(key, { subs, depth, parentKey });
+  if (depth < MAX_DEPTH) {
+    for (const s of subs.slice(1)) {
+      if (s.type === 'COL' && !visited.has(s.key)) {
+        queue.push({ key: s.key, depth: depth + 1, parentKey: key });
+      }
+    }
+  }
+  await sleep(120); // polite gap; keeps the link drained between nodes
+}
+console.log(`[audit] phase 1 done: ${tree.size} nodes fetched`);
+
+// ---------- Phase 2: boot the app and audit each COL node ------------------
+const inAdapter = {
+  listeners: [],
+  addListener(type, cb) {
+    if (type === 'sysex') this.listeners.push(cb);
+  },
+  removeListener(type, cb) {
+    const i = this.listeners.indexOf(cb);
+    if (i !== -1) this.listeners.splice(i, 1);
+  },
+};
+input.on('message', (dt, msg) => {
+  for (const cb of inAdapter.listeners) cb({ data: msg });
+});
+const outAdapter = {
+  sendSysex: (mfr, data) => output.sendMessage([0xf0, ...mfr, ...data, 0xf7]),
+};
+setMidiPorts(outAdapter, inAdapter, DEV);
+addSysexListener();
+
+const ancestorsOf = (key) => {
+  const chain = [];
+  let cur = tree.get(key)?.parentKey;
+  while (cur !== null && cur !== undefined) {
+    chain.unshift(cur);
+    cur = tree.get(cur)?.parentKey;
+  }
+  return chain;
+};
+
+async function settleOn(key) {
+  const start = Date.now();
+  while (Date.now() - start < CAP_MS) {
+    const onNode = appState.currentSubs?.[0]?.key === key;
+    const quiet = Date.now() - lastMsgAt >= QUIET_MS;
+    if (onNode && quiet) return true;
+    await sleep(150);
+  }
+  return appState.currentSubs?.[0]?.key === key;
+}
+
+const violations = [];
+const flag = (nodeKey, type, detail) => {
+  violations.push({ nodeKey, name: tree.get(nodeKey)?.subs?.[0]?.statement || '', type, detail });
+};
+
+const colNodes = [...tree.entries()].filter(
+  ([k, n]) => n.subs[0]?.type === 'COL' && k !== KEY.ROOT
+);
+console.log(`[audit] phase 2: auditing ${colNodes.length} COL nodes...`);
+
+for (const [key, node] of colNodes) {
+  // Navigate with TREE-computed ancestors (the T1 principle): the view we
+  // audit is positioned exactly where the tree says the node lives.
+  const keyStack = ancestorsOf(key).map((aKey) =>
+    makeKeyStackEntry(aKey, tree.get(aKey)?.subs || [])
+  );
+  setState(
+    { currentKey: key, keyStack, currentSubs: [], pendingLanding: null, pendingDescend: false },
+    'audit:navigate'
+  );
+  updateScreen(log);
+  const settled = await settleOn(key);
+  if (!settled) {
+    flag(key, 'no-render', 'node dump never became the rendered menu within cap');
+    continue;
+  }
+
+  const main = document.querySelector('.main-content');
+  const mainText = main?.textContent || '';
+  const mainKeys = [...(main?.querySelectorAll('[data-key]') || [])].map((e) => e.dataset.key);
+  const children = node.subs.slice(1);
+
+  // 1. Child reachability: every COL child needs a UI affordance.
+  const embedCandidate = children.find((s) => s.type === 'COL' && s.position === '0');
+  for (const c of children.filter((s) => s.type === 'COL')) {
+    const tag = c.tag.trim();
+    const asSoftkey = mainKeys.includes(c.key);
+    const asEmbed = c.key === embedCandidate?.key && (appState.childSubs?.[c.key]?.length || 0) > 0;
+    if (!asSoftkey && !asEmbed) {
+      const why =
+        !tag || tag.length > LAYOUT.SHORT_TAG_MAX
+          ? `tag ${JSON.stringify(c.tag)} fails the softkey filter`
+          : 'absent despite passing filters';
+      flag(key, 'unreachable-child', `${c.key} '${c.statement}': ${why}`);
+    }
+  }
+
+  // 2. Params rendered exactly once.
+  for (const p of children.filter((s) => s.type !== 'COL' && s.type !== '8')) {
+    const keyCount = mainKeys.filter((k) => k === p.key).length;
+    const stmtFrag = p.statement ? p.statement.replace(/%.*$/, '').trim() : '';
+    const tagFrag = (p.tag || '').trim();
+    const valFrag = (p.value || '').trim().slice(0, 20);
+    if (!stmtFrag && !tagFrag && !valFrag) continue; // blank spacers: render-skip by design
+    if (p.type === 'INF' && !stmtFrag && !valFrag) continue; // pure-format INF, value arrives later
+    const textHit =
+      (stmtFrag && mainText.includes(stmtFrag)) ||
+      (p.type === 'INF' && valFrag && mainText.includes(valFrag)) || // INF renders its value
+      (tagFrag && mainText.includes(tagFrag)); // bar CONs render tag-only, no data-key
+    if (keyCount === 0 && !textHit) {
+      flag(key, 'param-missing', `${p.type} ${p.key} '${p.statement}' not rendered`);
+    } else if (keyCount > 1) {
+      flag(key, 'param-duplicated', `${p.type} ${p.key} rendered ${keyCount}x`);
+    }
+  }
+
+  // 3. No duplicate softkeys inside main-content (R2's signature).
+  const softkeyKeys = [...(main?.querySelectorAll('.softkey') || [])].map((e) => e.dataset.key);
+  const dupes = softkeyKeys.filter((k, i) => softkeyKeys.indexOf(k) !== i);
+  if (dupes.length) flag(key, 'duplicate-softkeys', [...new Set(dupes)].join(','));
+
+  // Drain the link before the next node so one menu's backlog (e.g. the
+  // program fan-out's bank list) cannot starve the next audit (R5).
+  {
+    const t0 = Date.now();
+    while (Date.now() - lastMsgAt < QUIET_MS && Date.now() - t0 < CAP_MS) await sleep(150);
+  }
+
+  // 4. Breadcrumb = real tree parent.
+  const back = document.querySelector('.back-link');
+  const treeParent = node.parentKey;
+  if (treeParent && back && back.dataset.key !== treeParent) {
+    flag(key, 'wrong-breadcrumb', `back-link -> ${back.dataset.key}, tree parent is ${treeParent}`);
+  } else if (treeParent && !back) {
+    flag(key, 'no-breadcrumb', `expected back-link to ${treeParent}`);
+  }
+}
+
+// ---------- report ----------------------------------------------------------
+const byType = {};
+for (const v of violations) byType[v.type] = (byType[v.type] || 0) + 1;
+fs.writeFileSync(
+  'logs/tree-audit-report.json',
+  JSON.stringify(
+    { depth: MAX_DEPTH, nodes: tree.size, audited: colNodes.length, byType, violations },
+    null,
+    2
+  )
+);
+console.log(`\n[audit] ===== REPORT (depth ${MAX_DEPTH}) =====`);
+console.log(`[audit] nodes fetched: ${tree.size}; COL nodes audited: ${colNodes.length}`);
+console.log(`[audit] violations by type: ${JSON.stringify(byType)}`);
+for (const v of violations.slice(0, 40)) {
+  console.log(`  ${v.type} @ ${v.nodeKey} '${v.name}': ${v.detail}`);
+}
+if (violations.length > 40) console.log(`  ... +${violations.length - 40} more (see report json)`);
+console.log('[audit] full report -> logs/tree-audit-report.json');
+input.closePort();
+output.closePort();
+process.exit(0);

--- a/docs/device-model.md
+++ b/docs/device-model.md
@@ -129,6 +129,7 @@ The object's **own** line ends with its **child count in hex**; child lines show
 | `CON` | continuous / meter   |
 | `TRG` | trigger / action     |
 | `INF` | info / read-only     |
+| `STR` | **string-edit field** `[V]` — observed live (2026-06-10) under 'save program'/'save bank': `STR 0 10020023 10020020 name:%-19s name <value>`. The name editor for saves. The app's parser handles it via the default branch (value = field 7); the renderer has NO branch for it yet (tracker R8), so save-name editing is not rendered. |
 | `8`   | **empty / nonexistent object** `[V]` — returned for an unknown key and for empty slots (e.g. root's `10040000`); empty statement/tag. Probed live: `OBJECTINFO ffffffff` → `8 0 ffffffff ffffffff '' ''`. The app filters it. |
 
 ### POSITION `[V/I]`

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -409,16 +409,31 @@ unit" — not one-off handler fixes. R1/R2/R6 were symptoms of view state assemb
 and arrival races; the cure is view DERIVED from the device tree.
 - [~] T1  Tree audit + tree-derived navigation (the maintainer's audit ask: "render the html and audit
       whether we have odd behavior that doesn't get us the full state of a tree and its leaves").
-      NEXT: (a) build the TREE AUDITOR on the headless live harness (logs/live-app.mjs -> promote to
-      build_tools/): walk every COL node bounded by depth + a visited set; at each node compare the
-      rendered LCD against the node's own dump — every tagged COL child present as a softkey or the
-      embed, every param rendered exactly once, no duplicated row sets, breadcrumb = the real ancestor
-      chain; emit violations as a machine-readable report. Run it against the device; file each
-      violation as an R-item. (b) Fold the audit invariants into the eager loader below: navigation
-      state becomes a KEY into the loaded tree; ancestors are COMPUTED from tree parent relations, not
-      recorded click history (keyStack becomes a derived view or is deleted); softkeys, embed, and
-      breadcrumb all derive from tree relations. The auditor then becomes the standing regression
-      harness (merges with G2).
+      (a) DONE — TREE AUDITOR SHIPPED: build_tools/tree-audit.mjs (npm run tree-audit) on the headless
+      harness build_tools/live-app.mjs (both promoted from prototypes). Phase 1 fetches the ground-truth
+      tree raw (sequential OBJECTINFO, one in flight); phase 2 navigates the real app to every COL node
+      with TREE-COMPUTED ancestors and diffs the DOM against the node's dump (child reachability, params
+      rendered exactly once, duplicate softkeys, breadcrumb vs tree parent), draining the link between
+      nodes so backlog can't starve the next audit. Detector exceptions: blank spacers skipped;
+      pure-format INFs match on value; bar CONs match on tag. FIRST FULL RUN (depth 2, 42 nodes,
+      41 audited): 4 violations, all real, 0 false positives -> R8 + R9 below. Report:
+      logs/tree-audit-report.json (gitignored; rerun to regenerate).
+      NEXT: (b) Fold the audit invariants into the eager loader below: navigation state becomes a KEY
+      into the loaded tree; ancestors are COMPUTED from tree parent relations, not recorded click
+      history (keyStack becomes a derived view or is deleted); softkeys, embed, and breadcrumb all
+      derive from tree relations. The auditor is the acceptance harness for that refactor and the
+      standing regression loop afterward (merges with G2).
+- [ ] R8  (from the tree audit; upgrades R4's rendering half) STR string-edit fields are not rendered:
+      'save program' name field (STR 10020023 'name:%-19s') and 'save bank' name field (STR 10020052) —
+      users cannot name anything when saving. Renderer needs an STR branch (text input -> VALUE_PUT of
+      the string; confirm put semantics on hardware first). Spec updated: device-model §3 TYPE table now
+      documents STR.
+- [ ] R9  (from the tree audit) Empty-tag children are UNREACHABLE: setup's unnamed 100100d0 and
+      'Post D/A Gain' wrapper 10030601 (single empty-tag position-0 child wrapping the actual gain
+      params — the likely home of the missing level meters the maintainer reported). The softkey filter
+      requires a nonempty tag and the embed didn't trigger for 10030601 during the audit (investigate:
+      embed prefetch fired? childSubs arrival timing?). FIX direction: empty-tag single-child wrappers
+      should reliably embed (or get a derived label); audit rerun is the acceptance check.
 - [ ] NEW Eager loader: traverse active preset tree (OBJECTINFO each COL + VALUE_DUMP each param), bounded by depth + visited set, completion via dumpComplete; show loading UX. Subordinate to T1's tree model; R5's pacing data (bitmap-in-wave stalls; bank-list fan-out starvation) constrains the request scheduling.
 - [ ] NEW `eagerLoad` config flag (default on; persisted in midiConfig) toggles eager vs lazy
 - [ ] NEW Render guard enforcing the invariant: unconfirmed values render as a loading placeholder, never a stale cached number

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -480,9 +480,9 @@ in logs/ (program-screen.png).
       breadcrumb, e.g. "[program] program functions" while currentKey=10030000) until the new dump
       lands — on a backed-up link that is seconds. This is the "never render an unconfirmed value"
       invariant violation the 3.3 render guard owns; live evidence captured.
-- [ ] R4  NEW PROTOCOL TYPE observed live: `STR` (string-edit field) — `STR 0 10020052 10020050
-      name:%-22s name Favorites` under 'save bank'. Not in device-model §3's TYPE table; parser's
-      default branch treats it INF-like (value=parts[6]). Add to the spec + decide rendering.
+- [x] R4  NEW PROTOCOL TYPE observed live: `STR` (string-edit field) — `STR 0 10020052 10020050
+      name:%-22s name Favorites` under 'save bank'. SPEC HALF DONE: device-model §3 TYPE table documents
+      STR (shipped with the T1a harness PR). The rendering half is R8 below.
 - [ ] R5  Link-contention data (feeds the 3.3 eager-loader design): (a) a 0x18 bitmap fetch mid-wave
       stalls the wave past WATCHDOG_IDLE_MS (observed watchdog dumpComplete send=21 recv=13 dur=2489ms
       at connect with fetchBitmap on) — bitmap transfer is ~1.2s of link time; (b) the parser's

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -36,13 +36,21 @@ export default [
     },
   },
   {
-    files: ['build_tools/**/*.js', 'vite.config.js'],
+    files: ['build_tools/**/*.js', 'build_tools/**/*.mjs', 'vite.config.js'],
     languageOptions: {
       ecmaVersion: 2022,
       sourceType: 'module',
       globals: { ...globals.node },
     },
     rules: { 'no-console': 'off' },
+  },
+  {
+    // The headless live harness + tree auditor create a jsdom document and
+    // publish it on globalThis before importing the app module graph.
+    files: ['build_tools/live-app.mjs', 'build_tools/tree-audit.mjs'],
+    languageOptions: {
+      globals: { ...globals.node, document: 'writable' },
+    },
   },
   {
     files: ['**/*.cjs'],

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "test": "jest",
     "lint": "eslint .",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "tree-audit": "node build_tools/tree-audit.mjs",
+    "live-app": "node build_tools/live-app.mjs"
   },
   "repository": {
     "type": "git",

--- a/src/main.js
+++ b/src/main.js
@@ -139,6 +139,9 @@ function selectPorts() {
   log('Ports selected and listener added. Device ID set to ' + devId, 'info', 'general');
   lcdEl.innerText = 'Connected. Fetching root screen...';
   showLoading();
+  // NOTE: this reset block is hand-mirrored in build_tools/live-app.mjs and
+  // build_tools/tree-audit.mjs (selectPorts is not exported) - update those
+  // when changing it.
   // C2 (#38): reset the view to root BEFORE requesting, then arm the one-shot
   // landing. selectPorts is re-runnable (button + cached-config auto-run);
   // the reset forces the parser's full root branch on reconnect (background


### PR DESCRIPTION
Tracker T1(a) — the maintainer's directive made executable: "render the html and audit whether we have odd behavior that doesn't get us the full state of a tree and its leaves."

Two tools promoted from session-proven prototypes:
- **build_tools/live-app.mjs** (`npm run live-app`): the real app module graph headless — jsdom + `@julusian/midi` adapters into `setMidiPorts` — against the powered Orville, no browser.
- **build_tools/tree-audit.mjs** (`npm run tree-audit`): phase 1 fetches the ground-truth tree raw (sequential OBJECTINFO, one in flight, real `parseSubObject`); phase 2 navigates the real app to every COL node with **tree-computed ancestors** and diffs the DOM against the node's own dump — child reachability (softkey/embed/unreachable), params rendered exactly once (blank spacers, pure-format INFs, bar CONs handled), duplicate softkeys (R2's signature), breadcrumb vs tree parent — draining the link before each node so backlog can't starve audits (R5).

**First full run (depth 2): 42 nodes, 41 audited, 4 violations, all real, zero false positives** → new ledger items **R8** (STR string-edit fields unrendered: the save program/bank name editors) and **R9** (empty-tag children unreachable: setup's unnamed `100100d0`; the Post D/A Gain wrapper hiding the gain params — the likely home of the missing level meters). device-model §3 now documents the live-discovered **STR** type (R4's spec half).

Reviewer: **request-changes → fixed** — raw SysEx framing bytes replaced with `SYSEX`/`CMD` named constants (the repo's flagship rule; verified the tools are strictly read-only: no click dispatch on params/TRGs, the only autonomous VALUE_PUT path is gated on a never-written field), the drain repositioned to cover the no-render path, the selectPorts hand-mirror got its reciprocal pointer, R4 folded into R8. Re-verified live post-refactor.

131 tests / 14 suites; lint (now covering build_tools .mjs) and format clean; both tools `node --check` clean and re-run against the device after every change.