### PR TITLE
fix: derive softkey labels for empty-tag children (R9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ index.html
       ├─ event-bridge.js    subscribes to parser/midi events, renders on dumpComplete
       ├─ renderer.js        subs → LCD HTML, event handlers
       ├─ bitmap.js          screen-capture denibble + canvas render
-      ├─ navigation.js      toggleDspKey, makeKeyStackEntry
+      ├─ navigation.js      toggleDspKey, makeKeyStackEntry, softkeyLabel
       ├─ events.js          tiny pub/sub bus (emit / on)
       ├─ store.js           setState façade over appState (audited writes)
       ├─ state.js           appState singleton (re-exported from store.js)

--- a/docs/device-model.md
+++ b/docs/device-model.md
@@ -136,7 +136,9 @@ The object's **own** line ends with its **child count in hex**; child lines show
 
 A hex digit giving ordering, with special codes seen in captures: `'a'` marks
 graphic-EQ band NUMs that the UI groups onto one line `[V]`; `'e'` appears on the
-`info` child of presets `[V]`. Other hex values `[I]`.
+`info` child of presets `[V]`; `'c'` appears on empty-tag page/wrapper COLs
+(probed live 2026-06-10: the `Post D/A Gain` chain `10030601` -> `1003006b`/
+`1003006c`, whose statements carry the page names) `[V]`. Other hex values `[I]`.
 
 ### STATEMENT / TAG `[V]`
 

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -428,12 +428,19 @@ and arrival races; the cure is view DERIVED from the device tree.
       users cannot name anything when saving. Renderer needs an STR branch (text input -> VALUE_PUT of
       the string; confirm put semantics on hardware first). Spec updated: device-model §3 TYPE table now
       documents STR.
-- [ ] R9  (from the tree audit) Empty-tag children are UNREACHABLE: setup's unnamed 100100d0 and
-      'Post D/A Gain' wrapper 10030601 (single empty-tag position-0 child wrapping the actual gain
-      params — the likely home of the missing level meters the maintainer reported). The softkey filter
-      requires a nonempty tag and the embed didn't trigger for 10030601 during the audit (investigate:
-      embed prefetch fired? childSubs arrival timing?). FIX direction: empty-tag single-child wrappers
-      should reliably embed (or get a derived label); audit rerun is the acceptance check.
+- [x] R9  (branch fix/empty-tag-softkey-labels) Empty-tag children UNREACHABLE — FIXED with derived
+      labels: probing showed 10030601 is position 'c' (a new position code, like 'e'), so it was never
+      an embed candidate, and the tag-only softkey filter dropped it; its children (the per-output gain
+      NUM pages, 1003006b/1003006c) were unreachable — the maintainer's missing level params. PHYSICAL
+      GROUND TRUTH: the LEVELS and SETUP screens both show these pages as softkeys (the device derives
+      labels). New navigation.js:softkeyLabel — tag, else first statement word ('Post D/A Gain' ->
+      'Post'); used by the renderer's softkey filters/labels, the bridge descend predicate, the parser
+      fan-out (lockstep: prefetch = navigability), and the fixture helper (Option B expectations track
+      the rule). Side effect: root's fan-out now also prefetches the two presets (statement-labeled).
+      ACCEPTANCE: tree audit rerun — the 10030601 violation is GONE (4 -> 3 violations). RESIDUAL:
+      fully-blank nodes (setup's 100100d0 — statement AND tag empty, children are DSP A/B i/p routing)
+      stay unlabeled and audit-flagged; label policy (derive from children? device shows 'dsp B') is a
+      T1b question. Position 'c' added to device-model §3.
 - [ ] NEW Eager loader: traverse active preset tree (OBJECTINFO each COL + VALUE_DUMP each param), bounded by depth + visited set, completion via dumpComplete; show loading UX. Subordinate to T1's tree model; R5's pacing data (bitmap-in-wave stalls; bank-list fan-out starvation) constrains the request scheduling.
 - [ ] NEW `eagerLoad` config flag (default on; persisted in midiConfig) toggles eager vs lazy
 - [ ] NEW Render guard enforcing the invariant: unconfirmed values render as a loading placeholder, never a stale cached number

--- a/src/event-bridge.js
+++ b/src/event-bridge.js
@@ -46,9 +46,8 @@ import { renderBitmap } from './bitmap.js';
 import { appState } from './state.js';
 import { setState } from './store.js';
 import { sendObjectInfoDump, sendSysEx } from './midi.js';
-import { makeKeyStackEntry } from './navigation.js';
+import { makeKeyStackEntry, softkeyLabel } from './navigation.js';
 import { CMD, KEY, KEY_PREFIX, PARAM_TYPES } from './sysex-commands.js';
-import { LAYOUT } from './constants.js';
 import { log } from './logger.js';
 
 export function registerEventBridge({ hideLoading }) {
@@ -111,9 +110,7 @@ export function registerEventBridge({ hideLoading }) {
         setState({ pendingDescend: false, pendingLanding: null }, 'bridge:descend-consume');
         const children = subs.slice(1);
         const hasParams = children.some((s) => PARAM_TYPES.includes(s.type));
-        const softSubsLocal = children.filter(
-          (s) => s.type === 'COL' && s.tag.trim().length <= LAYOUT.SHORT_TAG_MAX && s.tag.trim()
-        );
+        const softSubsLocal = children.filter((s) => s.type === 'COL' && softkeyLabel(s));
         if (!hasParams && softSubsLocal.length > 1) {
           log(
             `Auto-loading first menu: ${softSubsLocal[0].key} - ${softSubsLocal[0].tag}`,

--- a/src/event-bridge.js
+++ b/src/event-bridge.js
@@ -113,7 +113,7 @@ export function registerEventBridge({ hideLoading }) {
         const softSubsLocal = children.filter((s) => s.type === 'COL' && softkeyLabel(s));
         if (!hasParams && softSubsLocal.length > 1) {
           log(
-            `Auto-loading first menu: ${softSubsLocal[0].key} - ${softSubsLocal[0].tag}`,
+            `Auto-loading first menu: ${softSubsLocal[0].key} - ${softkeyLabel(softSubsLocal[0])}`,
             'info',
             'general'
           );

--- a/src/navigation.js
+++ b/src/navigation.js
@@ -1,3 +1,5 @@
+import { LAYOUT } from './constants.js';
+
 /**
  * Toggles a DSP key between '4' (A) and '8' (B) prefixes.
  *
@@ -27,6 +29,25 @@ export function toggleDspKey(key) {
  * makeKeyStackEntry('10010000', setupSubs); // { key: '10010000', tag: 'setup', subs: [...] }
  * makeKeyStackEntry('0', []); // { key: '0', tag: '0', subs: [] }
  */
+/**
+ * Softkey label for a COL child (R9, live-validated): its tag, else the
+ * first word of its statement. Empty-tag children are real, navigable pages
+ * on the device — the physical LEVELS screen shows the Post D/A Gain pages
+ * the old tag-only filter dropped, which made the gain params unreachable in
+ * the app. A long tag (over the softkey column budget) still excludes the
+ * child, as before. Returns '' when nothing can be derived (fully blank
+ * nodes like setup's 100100d0 — a T1b policy question; the tree audit keeps
+ * flagging those).
+ *
+ * @param {Object} s - A parsed sub-object.
+ * @returns {string} Display label, or '' when the child has no usable label.
+ */
+export function softkeyLabel(s) {
+  const tag = (s.tag || '').trim();
+  if (tag) return tag.length <= LAYOUT.SHORT_TAG_MAX ? tag : '';
+  return ((s.statement || '').trim().split(' ')[0] || '').slice(0, LAYOUT.SHORT_TAG_MAX);
+}
+
 export function makeKeyStackEntry(key, subs) {
   const main = (subs && subs[0]) || null;
   const tag =

--- a/src/parser.js
+++ b/src/parser.js
@@ -66,9 +66,19 @@ export function parseResponse(data) {
         // Fetch child sub-menus for navigable COLs if not already fetched
         // (softkeyLabel keeps the fan-out in lockstep with what the renderer
         // shows — R9 made empty-tag, statement-labeled children navigable).
+        // At ROOT the presets are excluded: they render as header tabs, not
+        // softkeys, and the connect landing fetches the active one itself —
+        // prefetching here only duplicated both presets' requests at connect
+        // and re-fired their child fan-outs (R9 review).
         const localSoftSubs = subs
           .slice(1)
-          .filter((s) => s.type === 'COL' && softkeyLabel(s) && !appState.childSubs[s.key]);
+          .filter(
+            (s) =>
+              s.type === 'COL' &&
+              softkeyLabel(s) &&
+              !appState.childSubs[s.key] &&
+              !(main.key === KEY.ROOT && s.key.endsWith(KEY_SUFFIX.PRESET))
+          );
         localSoftSubs.forEach((s) => {
           sendObjectInfoDump(s.key);
           sendValueDump(s.key);

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,9 +1,10 @@
 // parser.js
 import { appState } from './state.js';
 import { CMD, KEY, KEY_PREFIX, KEY_SUFFIX, SYSEX } from './sysex-commands.js';
-import { TIMING, LAYOUT } from './constants.js';
+import { TIMING } from './constants.js';
 import { setState } from './store.js';
 import { sendValuePut, sendValueDump, sendObjectInfoDump, notifyResponse } from './midi.js';
+import { softkeyLabel } from './navigation.js';
 import { log } from './logger.js';
 import { denibble } from './bitmap.js';
 import { emit } from './events.js';
@@ -62,16 +63,12 @@ export function parseResponse(data) {
         }
       }
       if (main.key === appState.currentKey) {
-        // Fetch child sub-menus for local COLs if not already fetched
+        // Fetch child sub-menus for navigable COLs if not already fetched
+        // (softkeyLabel keeps the fan-out in lockstep with what the renderer
+        // shows — R9 made empty-tag, statement-labeled children navigable).
         const localSoftSubs = subs
           .slice(1)
-          .filter(
-            (s) =>
-              s.type === 'COL' &&
-              s.tag.trim().length <= LAYOUT.SHORT_TAG_MAX &&
-              s.tag.trim() &&
-              !appState.childSubs[s.key]
-          );
+          .filter((s) => s.type === 'COL' && softkeyLabel(s) && !appState.childSubs[s.key]);
         localSoftSubs.forEach((s) => {
           sendObjectInfoDump(s.key);
           sendValueDump(s.key);

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -529,14 +529,14 @@ export function renderScreen(subs, ascii, logParam) {
       .filter((s) => s.type === 'COL' && s.position === '0' && s.parent === appState.currentKey)
       .slice(0, 1);
     let embeddedKey = null;
-    // Proactively fetch the embed candidate ONLY when the parser's short-tag
-    // fan-out will not already fetch it (long/empty tag) — otherwise this
+    // Proactively fetch the embed candidate ONLY when the parser's fan-out
+    // will not already fetch it (no derivable label) — otherwise this
     // duplicated the same request in the same wave on every navigation, and
     // on 'program functions' the duplicated key is the giant bank list
-    // (R6 review).
+    // (R6 review; predicate kept in lockstep with softkeyLabel per R9).
     if (potentialEmbedSubs.length > 0) {
       const cand = potentialEmbedSubs[0];
-      const fanOutCovers = cand.tag.trim() && cand.tag.trim().length <= LAYOUT.SHORT_TAG_MAX;
+      const fanOutCovers = Boolean(softkeyLabel(cand));
       if (!fanOutCovers && !appState.childSubs[cand.key]) {
         sendObjectInfoDump(cand.key, logParam);
       }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -5,7 +5,7 @@ import { TIMING, LAYOUT } from './constants.js';
 import { setState } from './store.js';
 import { sendObjectInfoDump, sendValueDump, sendValuePut, sendSysEx } from './midi.js';
 import { showLoading } from './main.js';
-import { makeKeyStackEntry } from './navigation.js';
+import { makeKeyStackEntry, softkeyLabel } from './navigation.js';
 import { log } from './logger.js';
 
 /**
@@ -373,7 +373,7 @@ export function renderScreen(subs, ascii, logParam) {
     const softSubsUsed = subs.filter(
       (s) =>
         s.type === 'COL' &&
-        s.tag.trim() &&
+        softkeyLabel(s) &&
         s.key !== KEY.DSP_A_PRESET &&
         s.key !== KEY.DSP_B_PRESET &&
         s.key !== KEY.ROOT_META &&
@@ -385,7 +385,7 @@ export function renderScreen(subs, ascii, logParam) {
       const slice = softSubsUsed.slice(i, i + itemsPerLine);
       const columnWidth = Math.floor(LAYOUT.LCD_COLUMNS / slice.length);
       const softTags = slice.map((s) => {
-        const t = s.tag.trim();
+        const t = softkeyLabel(s);
         const text = (s.key === appState.currentKey ? `[${t}]` : t).padEnd(columnWidth);
         return text;
       });
@@ -399,7 +399,7 @@ export function renderScreen(subs, ascii, logParam) {
       const slice = softSubsUsed.slice(i, i + itemsPerLine);
       const columnWidth = Math.floor(LAYOUT.LCD_COLUMNS / slice.length);
       slice.forEach((s, idx) => {
-        const t = s.tag.trim();
+        const t = softkeyLabel(s);
         const text = (s.key === appState.currentKey ? `[${t}]` : t).padEnd(columnWidth);
         softHtml += `<span class="softkey" data-key="${s.key}" data-idx="${idx}">${text}</span>`;
       });
@@ -515,11 +515,7 @@ export function renderScreen(subs, ascii, logParam) {
     // which made mixed menus like 'program functions' (TRG + 8 position-0
     // COL children) unnavigable — the physical PROGRAM screen shows those
     // softkeys. Only the actually-embedded child is excluded, below.
-    localSoftSubs = subs
-      .slice(1)
-      .filter(
-        (s) => s.type === 'COL' && s.tag.trim().length <= LAYOUT.SHORT_TAG_MAX && s.tag.trim()
-      );
+    localSoftSubs = subs.slice(1).filter((s) => s.type === 'COL' && softkeyLabel(s));
     // Deterministic embed (R6, live-validated): only ever the FIRST
     // position-0 child in subs order may embed. The old loop embedded
     // whichever child's dump happened to have arrived — on 'program
@@ -638,7 +634,7 @@ export function renderScreen(subs, ascii, logParam) {
       const parentEntry = appState.keyStack[appState.keyStack.length - 1];
       const parentColSubs = (parentEntry.subs || [])
         .slice(1)
-        .filter((s) => s.type === 'COL' && s.tag.trim());
+        .filter((s) => s.type === 'COL' && softkeyLabel(s));
       softSubs = localSoftSubs.length > 0 ? localSoftSubs : parentColSubs;
     } else {
       softSubs = localSoftSubs;
@@ -653,7 +649,7 @@ export function renderScreen(subs, ascii, logParam) {
       const slice = softSubs.slice(i, i + itemsPerLine);
       const columnWidth = Math.floor(LAYOUT.LCD_COLUMNS / slice.length) || 10;
       const softTags = slice.map((s) => {
-        const t = s.tag.trim();
+        const t = softkeyLabel(s);
         const text = (s.key === appState.currentKey ? `[${t}]` : t).padEnd(columnWidth);
         return text;
       });
@@ -680,14 +676,14 @@ export function renderScreen(subs, ascii, logParam) {
         }
         const parentSoftSubs = (parentEntry.subs || [])
           .slice(1)
-          .filter((s) => s.type === 'COL' && s.tag.trim());
+          .filter((s) => s.type === 'COL' && softkeyLabel(s));
         const parentHighlightKey = appState.currentKey;
         let parentSoftTextLines = [];
         for (let i = 0; i < parentSoftSubs.length; i += itemsPerLine) {
           const slice = parentSoftSubs.slice(i, i + itemsPerLine);
           const columnWidth = Math.floor(LAYOUT.LCD_COLUMNS / slice.length) || 10;
           const softTags = slice.map((s) => {
-            const t = s.tag.trim();
+            const t = softkeyLabel(s);
             const text = (s.key === parentHighlightKey ? `[${t}]` : t).padEnd(columnWidth);
             return text;
           });
@@ -714,14 +710,14 @@ export function renderScreen(subs, ascii, logParam) {
         // Skip if grandparent is preset
         const upperSoftSubs = (upperEntry.subs || [])
           .slice(1)
-          .filter((s) => s.type === 'COL' && s.tag.trim());
+          .filter((s) => s.type === 'COL' && softkeyLabel(s));
         const upperHighlightKey = appState.keyStack[appState.keyStack.length - 1].key;
         let upperSoftTextLines = [];
         for (let i = 0; i < upperSoftSubs.length; i += itemsPerLine) {
           const slice = upperSoftSubs.slice(i, i + itemsPerLine);
           const columnWidth = Math.floor(LAYOUT.LCD_COLUMNS / slice.length) || 10;
           const softTags = slice.map((s) => {
-            const t = s.tag.trim();
+            const t = softkeyLabel(s);
             const text = (s.key === upperHighlightKey ? `[${t}]` : t).padEnd(columnWidth);
             return text;
           });
@@ -763,7 +759,7 @@ export function renderScreen(subs, ascii, logParam) {
       const slice = softSubs.slice(i, i + itemsPerLine);
       const columnWidth = Math.floor(LAYOUT.LCD_COLUMNS / slice.length) || 10;
       slice.forEach((s, idx) => {
-        const t = (s.tag || '').trim();
+        const t = softkeyLabel(s);
         const text = (s.key === appState.currentKey ? `[${t}]` : t).padEnd(columnWidth);
         softHtml += `<span class="softkey" data-key="${s.key}" data-idx="${idx}">${text}</span>`;
       });
@@ -784,7 +780,7 @@ export function renderScreen(subs, ascii, logParam) {
         }
         const parentSoftSubs = (parentEntry.subs || [])
           .slice(1)
-          .filter((s) => s.type === 'COL' && s.tag.trim());
+          .filter((s) => s.type === 'COL' && softkeyLabel(s));
         const parentHighlightKey = appState.currentKey;
         let parentSoftHtmlLines = [];
         for (let i = 0; i < parentSoftSubs.length; i += itemsPerLine) {
@@ -792,7 +788,7 @@ export function renderScreen(subs, ascii, logParam) {
           const slice = parentSoftSubs.slice(i, i + itemsPerLine);
           const columnWidth = Math.floor(LAYOUT.LCD_COLUMNS / slice.length) || 10;
           slice.forEach((s, idx) => {
-            const t = s.tag.trim();
+            const t = softkeyLabel(s);
             const text = (s.key === parentHighlightKey ? `[${t}]` : t).padEnd(columnWidth);
             softHtml += `<span class="softkey" data-key="${s.key}" data-idx="${idx}">${text}</span>`;
           });
@@ -823,7 +819,7 @@ export function renderScreen(subs, ascii, logParam) {
         // Skip if grandparent is preset
         const upperSoftSubs = (upperEntry.subs || [])
           .slice(1)
-          .filter((s) => s.type === 'COL' && s.tag.trim());
+          .filter((s) => s.type === 'COL' && softkeyLabel(s));
         const upperHighlightKey = appState.keyStack[appState.keyStack.length - 1].key;
         let upperSoftHtmlLines = [];
         for (let i = 0; i < upperSoftSubs.length; i += itemsPerLine) {
@@ -831,7 +827,7 @@ export function renderScreen(subs, ascii, logParam) {
           const slice = upperSoftSubs.slice(i, i + itemsPerLine);
           const columnWidth = Math.floor(LAYOUT.LCD_COLUMNS / slice.length) || 10;
           slice.forEach((s, idx) => {
-            const t = s.tag.trim();
+            const t = softkeyLabel(s);
             const text = (s.key === upperHighlightKey ? `[${t}]` : t).padEnd(columnWidth);
             softHtml += `<span class="softkey" data-key="${s.key}" data-idx="${idx}">${text}</span>`;
           });

--- a/tests/helpers/sysex-fixture.js
+++ b/tests/helpers/sysex-fixture.js
@@ -6,6 +6,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { splitLine } from '../../src/sysex-split.js';
+import { softkeyLabel } from '../../src/navigation.js';
 
 const FIXTURES_DIR = path.join(process.cwd(), 'tests', 'fixtures');
 
@@ -56,9 +57,9 @@ export function extractExpectedFromRoot(rootBytes) {
   const children = subs.slice(1);
   const dspASub = children.find((s) => s.key.startsWith('4'));
   const dspBSub = children.find((s) => s.key.startsWith('8'));
-  const shortTagCols = children.filter(
-    (s) => s.type === 'COL' && s.tag.trim().length <= 10 && s.tag.trim()
-  );
+  // Mirrors the production navigability rule (navigation.js:softkeyLabel),
+  // so fixture-derived expectations track R9's empty-tag label derivation.
+  const shortTagCols = children.filter((s) => s.type === 'COL' && softkeyLabel(s));
   return {
     dspAKey: dspASub?.key,
     dspBKey: dspBSub?.key,
@@ -88,9 +89,9 @@ export function extractExpectedFromPreset(presetBytes) {
   const subs = decodeSubs(presetBytes);
   const children = subs.slice(1);
   const menusCols = children.filter((s) => s.type === 'COL');
-  const shortTagCols = children.filter(
-    (s) => s.type === 'COL' && s.tag.trim().length <= 10 && s.tag.trim()
-  );
+  // Mirrors the production navigability rule (navigation.js:softkeyLabel),
+  // so fixture-derived expectations track R9's empty-tag label derivation.
+  const shortTagCols = children.filter((s) => s.type === 'COL' && softkeyLabel(s));
   return {
     mainKey: subs[0]?.key,
     mainStatement: subs[0]?.statement,

--- a/tests/helpers/sysex-fixture.js
+++ b/tests/helpers/sysex-fixture.js
@@ -67,6 +67,9 @@ export function extractExpectedFromRoot(rootBytes) {
     dspBName: dspBSub?.statement,
     firstShortTagCOLKey: shortTagCols[0]?.key,
     rootShortTagKeys: shortTagCols.map((s) => s.key),
+    // The parser's ROOT fan-out additionally excludes the presets (header
+    // tabs; the connect landing fetches the active one itself — R9 review).
+    rootFanOutKeys: shortTagCols.filter((s) => !s.key.endsWith('000b')).map((s) => s.key),
     // Full subs array length including main and any non-COL entries (e.g.,
     // the type=8 sub in the current Black Hole/MetallicChamber capture).
     // This is what parser.js passes to renderScreen, so it matches the

--- a/tests/navigation.test.js
+++ b/tests/navigation.test.js
@@ -1,12 +1,30 @@
 // tests/navigation.test.js
 // Covers toggleDspKey and the C3/#39 keyStack-entry normalization helper.
 
-import { toggleDspKey, makeKeyStackEntry } from '../src/navigation.js';
+import { toggleDspKey, makeKeyStackEntry, softkeyLabel } from '../src/navigation.js';
 
 describe('toggleDspKey', () => {
   test('flips the DSP prefix both ways', () => {
     expect(toggleDspKey('401000b')).toBe('801000b');
     expect(toggleDspKey('801000b')).toBe('401000b');
+  });
+});
+
+describe('softkeyLabel', () => {
+  test('uses the tag when present and within the column budget', () => {
+    expect(softkeyLabel({ tag: 'space', statement: 'space parameters' })).toBe('space');
+  });
+  test('long tags still exclude the child (returns empty)', () => {
+    expect(softkeyLabel({ tag: 'a-very-long-tag', statement: 'x' })).toBe('');
+  });
+  test('derives from the first statement word when the tag is blank (R9)', () => {
+    // Live-validated: the Post D/A Gain wrapper pages have empty tags but
+    // real statements; the device shows them, the old filter dropped them.
+    expect(softkeyLabel({ tag: '', statement: 'Post D/A Gain' })).toBe('Post');
+    expect(softkeyLabel({ tag: '  ', statement: 'MetallicChamber' })).toBe('MetallicCh'); // clipped
+  });
+  test('fully blank nodes stay unlabeled', () => {
+    expect(softkeyLabel({ tag: '', statement: '' })).toBe('');
   });
 });
 

--- a/tests/startup.test.js
+++ b/tests/startup.test.js
@@ -413,7 +413,7 @@ describe('startup characterization (roadmap step 5.5)', () => {
 
       // Root fan-out (short-tag COLs × 2 MIDI calls each). Order follows
       // fixture order; derived from rootShortTagKeys for Option B robustness.
-      ...expectedRoot.rootShortTagKeys.flatMap((k) => [
+      ...expectedRoot.rootFanOutKeys.flatMap((k) => [
         `midi:objectinfo:${k}`,
         `midi:valuedump:${k}`,
       ]),


### PR DESCRIPTION
Tracker R9 (tree-audit finding; the maintainer's missing level params). Probing showed the Post D/A Gain wrapper (10030601) is position **'c'** — a new position code, now documented in device-model §3 — so it was never an embed candidate, and the tag-only softkey filter dropped it: the per-output gain NUM pages were unreachable. The physical LEVELS and SETUP captures are the ground truth: the device shows these pages as softkeys.

New `navigation.js:softkeyLabel` (tag, else first statement word; long tags still excluded) used by every consumer: renderer softkey filters + label sites, the bridge descend predicate, the parser fan-out (prefetch in lockstep with navigability), and the fixture helper so Option B expectations track the same rule.

**Acceptance: live tree-audit rerun — the 10030601 violation is gone (4 → 3 violations);** remaining are the fully-blank-node policy question (T1b) and the two R8 STR items.

Reviewer: **request-changes → fixed** — caught (1) the embed-prefetch guard still using the old tag-only rule (latent same-wave duplication), and (2) the root fan-out's preset prefetch being cost-only at connect (the landing re-requests and re-fires the preset's child fan-out); presets are now excluded from the ROOT fan-out, with the characterization deriving the exclusion from the helper. Duplicate derived labels ('Post'/'Post') and clipped-label padding noted for T1b. Its device-model 'c' plural question resolved from the probe output (all three nodes are 'c').

135 passing / 14 suites; lint and format clean; audit re-verified live after the review fixes.