### PR TITLE
feat: render and edit STR string fields (R8)

### DIFF
--- a/docs/device-model.md
+++ b/docs/device-model.md
@@ -129,7 +129,7 @@ The object's **own** line ends with its **child count in hex**; child lines show
 | `CON` | continuous / meter   |
 | `TRG` | trigger / action     |
 | `INF` | info / read-only     |
-| `STR` | **string-edit field** `[V]` — observed live (2026-06-10) under 'save program'/'save bank': `STR 0 10020023 10020020 name:%-19s name <value>`. The name editor for saves. The app's parser handles it via the default branch (value = field 7); the renderer has NO branch for it yet (tracker R8), so save-name editing is not rendered. |
+| `STR` | **string-edit field** `[V]` — observed live (2026-06-10) under 'save program'/'save bank': `STR 0 10020023 10020020 name:%-19s name <value>`. The name editor for saves. Parser: default branch (value = field 7). Renderer: clickable editor; a string `VALUE_PUT` is echoed as a `0x2e` (confirmed live, single-token; multi-word puts and empty-string/clear puts untested — ledger R8). |
 | `8`   | **empty / nonexistent object** `[V]` — returned for an unknown key and for empty slots (e.g. root's `10040000`); empty statement/tag. Probed live: `OBJECTINFO ffffffff` → `8 0 ffffffff ffffffff '' ''`. The app filters it. |
 
 ### POSITION `[V/I]`

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -429,7 +429,9 @@ and arrival races; the cure is view DERIVED from the device tree.
       prompts for free text and PUTs the string (mirrors the NUM edit flow). STR added to PARAM_TYPES
       (descend predicate counts it). ACCEPTANCE: tree audit rerun — both STR param-missing violations
       GONE; the board is down to ONE violation (the fully-blank 100100d0 label policy, T1b).
-      needs-hardware NOTE: multi-word strings untested on the wire (PUT payload is key SPACE value;
+      needs-hardware NOTE: multi-word strings untested on the PUT wire (readback is safe — splitLine
+      keeps quoted names one token) and empty-string puts (clear semantics) untested; the handler
+      rejects empty + non-ASCII and clamps to the declared field width. (PUT payload is key SPACE value;
       single tokens verified) — try a two-word name on the unit when convenient.
 - [x] R9  (branch fix/empty-tag-softkey-labels) Empty-tag children UNREACHABLE — FIXED with derived
       labels: probing showed 10030601 is position 'c' (a new position code, like 'e'), so it was never

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -423,11 +423,14 @@ and arrival races; the cure is view DERIVED from the device tree.
       history (keyStack becomes a derived view or is deleted); softkeys, embed, and breadcrumb all
       derive from tree relations. The auditor is the acceptance harness for that refactor and the
       standing regression loop afterward (merges with G2).
-- [ ] R8  (from the tree audit; upgrades R4's rendering half) STR string-edit fields are not rendered:
-      'save program' name field (STR 10020023 'name:%-19s') and 'save bank' name field (STR 10020052) —
-      users cannot name anything when saving. Renderer needs an STR branch (text input -> VALUE_PUT of
-      the string; confirm put semantics on hardware first). Spec updated: device-model §3 TYPE table now
-      documents STR.
+- [x] R8  (branch feat/str-rendering) STR string-edit fields RENDERED + EDITABLE: put semantics
+      confirmed live first (put 10020052 'TestName' -> 0x2e echo + readback; restored after). Renderer
+      STR branches (top-level + embedded child): formatted value as a clickable param-value; click
+      prompts for free text and PUTs the string (mirrors the NUM edit flow). STR added to PARAM_TYPES
+      (descend predicate counts it). ACCEPTANCE: tree audit rerun — both STR param-missing violations
+      GONE; the board is down to ONE violation (the fully-blank 100100d0 label policy, T1b).
+      needs-hardware NOTE: multi-word strings untested on the wire (PUT payload is key SPACE value;
+      single tokens verified) — try a two-word name on the unit when convenient.
 - [x] R9  (branch fix/empty-tag-softkey-labels) Empty-tag children UNREACHABLE — FIXED with derived
       labels: probing showed 10030601 is position 'c' (a new position code, like 'e'), so it was never
       an embed candidate, and the tag-only softkey filter dropped it; its children (the per-output gain

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -277,8 +277,20 @@ const handleParamClick = (e) => {
         // payload is key SPACE value — see the ledger R8 note).
         const title = sub.statement.replace(/%.*s/, '').trim() || sub.tag;
         const currentValue = appState.currentValues[key] ?? sub.value ?? '';
-        const newValue = prompt(`Enter new value for ${title}:`, currentValue);
-        if (newValue !== null && newValue !== '') {
+        const rawValue = prompt(`Enter new value for ${title}:`, currentValue);
+        // Empty string is rejected like prompt-cancel: whether the device
+        // accepts an empty-string PUT (clear semantics) is untested — see
+        // the ledger R8 needs-hardware note.
+        if (rawValue !== null && rawValue !== '') {
+          // SysEx data bytes must be 7-bit: reject non-ASCII rather than
+          // throwing mid-flow with the loading overlay up. Clamp to the
+          // field width from the format (e.g. %-22s) when one is declared.
+          if (!/^[\x20-\x7e]*$/.test(rawValue)) {
+            alert('Only printable ASCII characters can be sent to the device.');
+            return;
+          }
+          const widthMatch = (sub.statement || '').match(/%-?(\d+)s/);
+          const newValue = widthMatch ? rawValue.slice(0, parseInt(widthMatch[1], 10)) : rawValue;
           showLoading();
           sendValuePut(key, newValue);
           setState(

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -270,6 +270,30 @@ const handleParamClick = (e) => {
             log('Triggered bitmap update after TRG.', 'debug', 'bitmap');
           }
         }, TIMING.DEVICE_LOAD_MS); // Increased delay for device to process load
+      } else if (sub.type === 'STR') {
+        // String-edit (R8): free-text put, confirmed live (the device echoes
+        // the new value as a 0x2e). Single-token strings verified on
+        // hardware; multi-word strings are untested on the wire (the PUT
+        // payload is key SPACE value — see the ledger R8 note).
+        const title = sub.statement.replace(/%.*s/, '').trim() || sub.tag;
+        const currentValue = appState.currentValues[key] ?? sub.value ?? '';
+        const newValue = prompt(`Enter new value for ${title}:`, currentValue);
+        if (newValue !== null && newValue !== '') {
+          showLoading();
+          sendValuePut(key, newValue);
+          setState(
+            { currentValues: { ...appState.currentValues, [key]: newValue } },
+            'renderer:param-click-str-value-cache'
+          );
+          renderScreen(appState.currentSubs, appState.lastAscii); // Immediate local update
+          setTimeout(() => {
+            updateScreen();
+            if (appState.updateBitmapOnChange) {
+              sendSysEx(CMD.GET_SCREEN, []);
+              log('Triggered bitmap update after value change.', 'debug', 'bitmap');
+            }
+          }, TIMING.MIDI_SETTLE_MS);
+        }
       }
     }
   }
@@ -503,6 +527,14 @@ export function renderScreen(subs, ascii, logParam) {
       } else if (s.type === 'TRG') {
         fullHtml = `<span class="param-value" data-key="${s.key}">${s.statement}</span>`;
         fullText = s.statement;
+      } else if (s.type === 'STR') {
+        // String-edit field (R8; live-discovered type, device-model §3):
+        // formatted value rendered as a clickable editor — the save
+        // program/bank name fields.
+        const value = appState.currentValues[s.key] ?? s.value ?? '';
+        if (appState.currentValues[s.key] === undefined && !s.value) sendValueDump(s.key, logParam);
+        fullText = formatValue(s.statement || '%s', value);
+        fullHtml = `<span class="param-value" data-key="${s.key}">${fullText}</span>`;
       }
       if (fullText) {
         paramLines.push(fullText);
@@ -617,6 +649,12 @@ export function renderScreen(subs, ascii, logParam) {
           } else if (cs.type === 'TRG') {
             childFullHtml = `<span class="param-value" data-key="${cs.key}">${cs.statement}</span>`;
             childFullText = cs.statement;
+          } else if (cs.type === 'STR') {
+            const value = appState.currentValues[cs.key] ?? cs.value ?? '';
+            if (appState.currentValues[cs.key] === undefined && !cs.value)
+              sendValueDump(cs.key, logParam);
+            childFullText = formatValue(cs.statement || '%s', value);
+            childFullHtml = `<span class="param-value" data-key="${cs.key}">${childFullText}</span>`;
           }
           if (childFullText) {
             paramLines.push(childFullText);

--- a/src/sysex-commands.js
+++ b/src/sysex-commands.js
@@ -74,7 +74,8 @@ export const KEY_SUFFIX = {
 
 // Sub-object types that render as parameters (vs COL menus / type-8 empties).
 // Shared by the renderer's param loops and the bridge's descend predicate (C2).
-export const PARAM_TYPES = ['NUM', 'SET', 'CON', 'TRG', 'INF'];
+// STR = string-edit field, observed live under save program/bank (R8).
+export const PARAM_TYPES = ['NUM', 'SET', 'CON', 'TRG', 'INF', 'STR'];
 
 // Root-level menus, in softkey order, used both as a "is this a top-level menu"
 // set and as the static bottom softkey row.

--- a/tests/renderer.test.js
+++ b/tests/renderer.test.js
@@ -203,6 +203,46 @@ describe('renderer.js', () => {
     jest.useRealTimers();
   });
 
+  test('STR field renders the formatted value and edits via prompt -> string PUT (R8)', () => {
+    // Live-discovered type (device-model §3): the save program/bank name
+    // editors. String PUTs verified on hardware (echoed as a 0x2e).
+    window.prompt = jest.fn(() => 'NewName');
+    appState.currentKey = '10020050';
+    const subs = [
+      {
+        type: 'COL',
+        position: '0',
+        key: '10020050',
+        parent: '10020050',
+        statement: 'save bank',
+        tag: 'savebank',
+      },
+      {
+        type: 'STR',
+        position: '0',
+        key: '10020052',
+        parent: '10020050',
+        statement: 'name:%-22s',
+        tag: 'name',
+        value: 'Favorites',
+      },
+    ];
+    renderScreen(subs, '', mockLog);
+
+    const field = document.querySelector('.param-value[data-key="10020052"]');
+    expect(field).toBeTruthy();
+    expect(field.textContent).toContain('Favorites');
+
+    appState.currentSubs = subs;
+    jest.useFakeTimers();
+    field.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(window.prompt).toHaveBeenCalledWith(expect.stringContaining('name'), 'Favorites');
+    expect(sendValuePut).toHaveBeenCalledWith('10020052', 'NewName');
+    expect(appState.currentValues['10020052']).toBe('NewName');
+    jest.useRealTimers();
+  });
+
   test('lcd click on back-link pops keyStack and refreshes', () => {
     appState.currentKey = '10010001';
     appState.keyStack = [


### PR DESCRIPTION
Tracker R8 (tree-audit finding; upgrades R4's rendering half). The live-discovered STR string-edit type — the save program/bank name editors — now renders as a clickable field in both param loops and edits via prompt -> string VALUE_PUT, mirroring the NUM flow. **Put semantics confirmed on hardware first**: `put 10020052 'TestName'` echoed a `0x2e` and read back correctly (value restored after). STR joins PARAM_TYPES, so COL+STR-only menus (exactly the save screens) no longer auto-descend past the field the user came to edit.

**Acceptance: live tree-audit rerun — both STR param-missing violations gone. The audit board is down to ONE violation** (the fully-blank `100100d0` label policy, a T1b question).

Reviewer: **approve-with-nits**, all applied — input sanitization (non-ASCII would throw mid-flow with the spinner up; now rejected, and values clamp to the declared `%-Ns` width), the empty-string/clear-semantics unknown documented in code + ledger needs-hardware note, and the device-model STR row refreshed. Its A3-consistency analysis confirmed the optimistic cache write is sound post-B10g.3 (the put echo reconciles).

136 passing / 14 suites; lint and format clean; audit re-verified live.