### PR TITLE
docs: STR put semantics resolved on hardware

### DIFF
--- a/docs/device-model.md
+++ b/docs/device-model.md
@@ -129,7 +129,7 @@ The object's **own** line ends with its **child count in hex**; child lines show
 | `CON` | continuous / meter   |
 | `TRG` | trigger / action     |
 | `INF` | info / read-only     |
-| `STR` | **string-edit field** `[V]` — observed live (2026-06-10) under 'save program'/'save bank': `STR 0 10020023 10020020 name:%-19s name <value>`. The name editor for saves. Parser: default branch (value = field 7). Renderer: clickable editor; a string `VALUE_PUT` is echoed as a `0x2e` (confirmed live, single-token; multi-word puts and empty-string/clear puts untested — ledger R8). |
+| `STR` | **string-edit field** `[V]` — observed live (2026-06-10) under 'save program'/'save bank': `STR 0 10020023 10020020 name:%-19s name <value>`. The name editor for saves. Parser: default branch (value = field 7). Renderer: clickable editor; a string `VALUE_PUT` is echoed as a `0x2e` (confirmed live; multi-word values work and come back QUOTED in dumps; an empty-string put is ignored — no clear-to-empty semantic). |
 | `8`   | **empty / nonexistent object** `[V]` — returned for an unknown key and for empty slots (e.g. root's `10040000`); empty statement/tag. Probed live: `OBJECTINFO ffffffff` → `8 0 ffffffff ffffffff '' ''`. The app filters it. |
 
 ### POSITION `[V/I]`

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -429,10 +429,11 @@ and arrival races; the cure is view DERIVED from the device tree.
       prompts for free text and PUTs the string (mirrors the NUM edit flow). STR added to PARAM_TYPES
       (descend predicate counts it). ACCEPTANCE: tree audit rerun — both STR param-missing violations
       GONE; the board is down to ONE violation (the fully-blank 100100d0 label policy, T1b).
-      needs-hardware NOTE: multi-word strings untested on the PUT wire (readback is safe — splitLine
-      keeps quoted names one token) and empty-string puts (clear semantics) untested; the handler
-      rejects empty + non-ASCII and clamps to the declared field width. (PUT payload is key SPACE value;
-      single tokens verified) — try a two-word name on the unit when convenient.
+      HARDWARE QUESTIONS RESOLVED (probed live, same session): multi-word puts WORK — put 'Two Words'
+      echoed "10020052 'Two Words'" (the device quotes multi-word values in the dump, so splitLine
+      readback is safe end to end); empty-string puts are IGNORED by the device (value unchanged), so
+      the handler's empty-rejection matches hardware semantics exactly. The handler also rejects
+      non-ASCII (7-bit SysEx) and clamps to the declared field width.
 - [x] R9  (branch fix/empty-tag-softkey-labels) Empty-tag children UNREACHABLE — FIXED with derived
       labels: probing showed 10030601 is position 'c' (a new position code, like 'e'), so it was never
       an embed candidate, and the tag-only softkey filter dropped it; its children (the per-output gain


### PR DESCRIPTION
Ledger/spec-only. Live probes (same session as R8): multi-word string puts WORK — the device echoes the value quoted in the 0x2e dump, so splitLine readback is safe end to end; empty-string puts are IGNORED (no clear-to-empty semantic), so the R8 handler's empty-rejection matches hardware behavior exactly. Field restored to 'Favorites' after probing. Closes the R8 needs-hardware note. Reviewer not spawned: records probe output verbatim; no code changes.