### PR TITLE
docs: session closeout — STR in wire docs, harness tooling, GH issue mirrors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ Wire format in [`docs/protocol.md`](docs/protocol.md); how the device behaves (o
 
 Keypress masks are hex-encoded button state; `system_commands.txt` at the repo root is the canonical source — `controls.js:keypressMasks` must match it. If they diverge, `system_commands.txt` wins.
 
-Sub-object types in the ASCII dump: `COL` (column/menu), `NUM`, `SET`, `CON` (continuous/meter), `TRG`, `INF`. See `parseSubObject` for field order.
+Sub-object types in the ASCII dump: `COL` (column/menu), `NUM`, `SET`, `CON` (continuous/meter), `TRG`, `INF`, `STR` (string-edit, live-discovered). See `parseSubObject` for field order and `docs/device-model.md` §3 for semantics.
 
 ## Conventions
 
@@ -102,6 +102,8 @@ Sub-object types in the ASCII dump: `COL` (column/menu), `NUM`, `SET`, `CON` (co
 - `build_tools/combine.cjs` — concatenates `src/*.js` (no CSS) into 20KB chunks under `combine/`. Output is for pasting into LLM contexts.
 - `build_tools/zip.js` — archives the working tree (minus `.git`, `node_modules`, zips) via `archiver`. Used by `npm run push`.
 - `build_tools/apply_diff.js` — applies a named `.diff` with `git apply --reject`; falls back to a hand-rolled hunk parser. Creates a `.bak` before applying.
+- `build_tools/live-app.mjs` (`npm run live-app`) — runs the REAL app module graph headless (jsdom + `@julusian/midi` adapters into `setMidiPorts`) against the powered Orville. No browser, no WebMIDI permission, no port contention with Chrome (close any app tab first — WinMM is single-client). The substrate for session-driven live validation.
+- `build_tools/tree-audit.mjs` (`npm run tree-audit [depth] [quietMs] [capMs]`) — fetches the device object tree raw (ground truth), then audits every COL node's render against its own dump: child reachability (softkey/embed/unreachable), params rendered exactly once, duplicate softkeys, breadcrumb vs tree parent. Machine-readable report at `logs/tree-audit-report.json`. The acceptance gate for T1b (#105) and the standing render-regression loop.
 
 ## Where state lives
 

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -303,7 +303,7 @@ config toggles lazy) -> render on dumpComplete.
       every dumpComplete let value-only meter-poll waves (every METER_POLL_MS) clear the loading
       indicator mid-navigation; midi.js now counts OBJECTINFO sends per wave (payload.objectinfoSends)
       and the bridge hides loading only on structure waves or watchdog stalls.
-- [ ] NEW (C1 review, needs-hardware) Wave-saturation smoke: with meter polling + updateBitmapOnChange on,
+- [ ] NEW (C1 review, needs-hardware, GH #107) Wave-saturation smoke: with meter polling + updateBitmapOnChange on,
       confirm `outstanding` still reaches 0 between ticks on the real 31250-baud link (link-busy periods
       like a ~1.2s 0x17 transfer could keep waves merged until the WATCHDOG_MAX_MS 10s ceiling, freezing
       settled renders for up to 10s; pre-C1 CONs rendered per message regardless). If saturation is real,
@@ -407,7 +407,7 @@ MAINTAINER DIRECTIVE (2026-06-10, governs the rest of Phase 3): "we should be re
 a tree... make sure we have good tree navigation since we are navigating a tree of states from the
 unit" — not one-off handler fixes. R1/R2/R6 were symptoms of view state assembled from click history
 and arrival races; the cure is view DERIVED from the device tree.
-- [~] T1  Tree audit + tree-derived navigation (the maintainer's audit ask: "render the html and audit
+- [~] T1  (GH #105 for the (b) half) Tree audit + tree-derived navigation (the maintainer's audit ask: "render the html and audit
       whether we have odd behavior that doesn't get us the full state of a tree and its leaves").
       (a) DONE — TREE AUDITOR SHIPPED: build_tools/tree-audit.mjs (npm run tree-audit) on the headless
       harness build_tools/live-app.mjs (both promoted from prototypes). Phase 1 fetches the ground-truth
@@ -447,9 +447,9 @@ and arrival races; the cure is view DERIVED from the device tree.
       fully-blank nodes (setup's 100100d0 — statement AND tag empty, children are DSP A/B i/p routing)
       stay unlabeled and audit-flagged; label policy (derive from children? device shows 'dsp B') is a
       T1b question. Position 'c' added to device-model §3.
-- [ ] NEW Eager loader: traverse active preset tree (OBJECTINFO each COL + VALUE_DUMP each param), bounded by depth + visited set, completion via dumpComplete; show loading UX. Subordinate to T1's tree model; R5's pacing data (bitmap-in-wave stalls; bank-list fan-out starvation) constrains the request scheduling.
-- [ ] NEW `eagerLoad` config flag (default on; persisted in midiConfig) toggles eager vs lazy
-- [ ] NEW Render guard enforcing the invariant: unconfirmed values render as a loading placeholder, never a stale cached number
+- [ ] NEW (GH #106) Eager loader: traverse active preset tree (OBJECTINFO each COL + VALUE_DUMP each param), bounded by depth + visited set, completion via dumpComplete; show loading UX. Subordinate to T1's tree model; R5's pacing data (bitmap-in-wave stalls; bank-list fan-out starvation) constrains the request scheduling.
+- [ ] NEW (GH #106) `eagerLoad` config flag (default on; persisted in midiConfig) toggles eager vs lazy
+- [ ] NEW (GH #106) Render guard enforcing the invariant: unconfirmed values render as a loading placeholder, never a stale cached number
 HUMAN-GATE: needs-hardware (eager-load throughput on the real unit; offline parse/render half covered by replay harness)
 
 ### Batch 3.3b — Live-loop findings (headless live session, 2026-06-09; maintainer-confirmed symptoms)
@@ -489,7 +489,7 @@ in logs/ (program-screen.png).
       Third trigger added: objectinfo:received for a key present in childSubs (the C8 guard guarantees
       it belongs to the on-screen menu) repaints. The embed now appears the moment its data arrives.
       Bridge test pins it (fails pre-fix).
-- [ ] R3  Stale-menu render: clicking a menu renders the OLD menu under the NEW key (wrong title and
+- [ ] R3  (owned by GH #106, the render guard) Stale-menu render: clicking a menu renders the OLD menu under the NEW key (wrong title and
       breadcrumb, e.g. "[program] program functions" while currentKey=10030000) until the new dump
       lands — on a backed-up link that is seconds. This is the "never render an unconfirmed value"
       invariant violation the 3.3 render guard owns; live evidence captured.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -161,6 +161,7 @@ Field order per line — `type position key parent statement tag …`:
 | `CON` | continuous / meter | `value`                                                    |
 | `TRG` | trigger / action   | —                                                          |
 | `INF` | info / read-only   | `value`                                                    |
+| `STR` | string-edit field  | `value` (live-discovered 2026-06-10; device-model.md §3)    |
 
 On the dump's first line (the queried object itself), `parent` echoes the
 object's **own key**, not its real parent; only the child lines carry a real
@@ -184,6 +185,12 @@ possibly clamped — value, even when the value is unchanged (live-probed; this
 corrects an earlier "no ack" note here — see `device-model.md` §6/§9 and
 tracker B10g.3). The app still issues a value request after a put to reconcile
 rather than trusting an optimistic local write.
+
+String puts (`STR` fields, live-probed 2026-06-10): the value bytes may contain
+spaces — the device accepts a multi-word value and **quotes it in dumps**
+(`put 'Two Words'` → echo `10020052 'Two Words'`), so `splitLine` readback keeps
+it one token. An **empty-string put is ignored** (the value is unchanged); there
+is no clear-to-empty semantic.
 
 `0x2e` response payload is ASCII `"<key> <value…>"`; `parser.js` caches it under
 the key and emits `value:received`, classified immediate iff the loaded subs


### PR DESCRIPTION
Ledger/docs-only closeout for the 2026-06-09/10 sessions. (1) Issue board synced: #11 closed as resolved by the program-flow arc; retest comments on #2/#3/#5; substrate note on #45; new mirrors #105 (T1b tree-derived navigation — the resume point), #106 (eager loader + render guard, owns R3), #107 (wave-saturation hardware smoke). (2) Spec/docs: STR type added to protocol.md's sub-object table and CLAUDE.md's quick reference; string-put wire semantics (multi-word values quoted in dumps; empty puts ignored) recorded in the 0x2d section; CLAUDE.md build-tools section now documents the headless harness and tree auditor. (3) Resumability: ledger items carry their GH numbers; the [~] T1 entry remains the single resume point. Reviewer not spawned: records session outcomes and cross-references verbatim; no code changes (suite re-verified green).