### PR TITLE
fix: render guard — never paint a stale dump under the new key (R3)

### DIFF
--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -477,7 +477,7 @@ and arrival races; the cure is view DERIVED from the device tree.
       T1b question. Position 'c' added to device-model §3.
 - [ ] NEW (GH #106) Eager loader: traverse active preset tree (OBJECTINFO each COL + VALUE_DUMP each param), bounded by depth + visited set, completion via dumpComplete; show loading UX. Subordinate to T1's tree model; R5's pacing data (bitmap-in-wave stalls; bank-list fan-out starvation) constrains the request scheduling.
 - [ ] NEW (GH #106) `eagerLoad` config flag (default on; persisted in midiConfig) toggles eager vs lazy
-- [ ] NEW (GH #106) Render guard enforcing the invariant: unconfirmed values render as a loading placeholder, never a stale cached number
+- [x] NEW (GH #106) Render guard enforcing the invariant: unconfirmed values render as a loading placeholder, never a stale cached number — shipped with R3 below (branch fix/r3-render-guard)
 HUMAN-GATE: needs-hardware (eager-load throughput on the real unit; offline parse/render half covered by replay harness)
 
 ### Batch 3.3b — Live-loop findings (headless live session, 2026-06-09; maintainer-confirmed symptoms)
@@ -519,10 +519,17 @@ in logs/ (program-screen.png).
       it belongs to the on-screen menu; condition since T1b/#105: tree parentage, parentOf(key) ===
       currentKey) repaints. The embed now appears the moment its data arrives.
       Bridge test pins it (fails pre-fix).
-- [ ] R3  (owned by GH #106, the render guard) Stale-menu render: clicking a menu renders the OLD menu under the NEW key (wrong title and
-      breadcrumb, e.g. "[program] program functions" while currentKey=10030000) until the new dump
-      lands — on a backed-up link that is seconds. This is the "never render an unconfirmed value"
-      invariant violation the 3.3 render guard owns; live evidence captured.
+- [x] R3  (branch fix/r3-render-guard; the GH #106 render-guard half) Stale-menu render FIXED: clicking a
+      menu rendered the OLD menu under the NEW key (wrong title and breadcrumb, e.g. "[program]
+      program functions" while currentKey=10030000) until the new dump landed — seconds on a backed-up
+      link. renderScreen now guards: when subs[0].key !== currentKey it never paints those subs;
+      instead it PRE-PAINTS the tree's cached structure for the navigated-to key (params as inert
+      placeholder lines — format specifiers -> '...', no clickables, no value refetches; COL children
+      stay live softkeys; embeds deferred to the real render), or an honest 'loading ...' title when
+      the tree has never seen the key. The pre-paint pass writes NO state (currentSubs/currentSoftkeys
+      pins stay device-confirmed — also keeps the tree-audit settle honest: it waits for the real
+      dump, never a cache paint). Renderer tests pin both guard paths (fail pre-fix); snapshots
+      unchanged. The eager loader + eagerLoad flag remain the open #106 half.
 - [x] R4  NEW PROTOCOL TYPE observed live: `STR` (string-edit field) — `STR 0 10020052 10020050
       name:%-22s name Favorites` under 'save bank'. SPEC HALF DONE: device-model §3 TYPE table documents
       STR (shipped with the T1a harness PR). The rendering half is R8 below.

--- a/docs/refactor/phase3-state-model.md
+++ b/docs/refactor/phase3-state-model.md
@@ -291,6 +291,24 @@ old fixed 15s cap flagged one spurious no-render while the program
 subtree's bank-list backlog was still draining, the R5 congestion class;
 app-side request scheduling stays with #106.)
 
+## R3 render guard — pre-paint from the tree (#106 first half; branch fix/r3-render-guard)
+
+The "never render unconfirmed state as confirmed" invariant, made concrete:
+`renderScreen` refuses to paint subs whose main key differs from
+`currentKey` (a stale dump while the navigated-to key's response is in
+flight). It pre-paints instead: the tree's cached node for `currentKey` —
+title + breadcrumb real, COL children as live softkeys, every param line
+inert with format specifiers replaced by `RENDER.VALUE_PLACEHOLDER` (no
+clickable spans/selects, no value refetches — the real render owns those) —
+or a synthetic `RENDER.LOADING_STATEMENT` node when the tree has never seen
+the key. Pre-paint passes write no state: the `currentSubs`/
+`currentSoftkeys` render-pins record device-confirmed renders only, which
+also keeps the tree-audit settle condition honest (it waits for the real
+dump, never a cache paint). Embeds are deferred to the real render (their
+child params would also be unconfirmed). The remaining #106 half — eager
+loader, `eagerLoad` flag, request scheduling from R5's data — is unchanged
+by this and builds on the same tree.
+
 ## Validation / open items
 
 - Eager-load throughput on real hardware (many `OBJECTINFO`/`VALUE` round

--- a/src/constants.js
+++ b/src/constants.js
@@ -30,6 +30,15 @@ export const LAYOUT = {
   SHORT_TAG_MAX: 10, // max tag length treated as a softkey-eligible COL
 };
 
+// R3 render guard (#106): pre-paint presentation for nodes whose live dump
+// has not landed yet. The placeholder substitutes for every value format
+// specifier ('...' matches the tree's blank-label placeholder); the loading
+// statement is the synthetic title when the tree has never seen the key.
+export const RENDER = {
+  VALUE_PLACEHOLDER: '...',
+  LOADING_STATEMENT: 'loading ...',
+};
+
 // Canvas presentation for the bitmap screen (CSS, cosmetic only).
 export const CANVAS = {
   CSS_WIDTH: '480px',

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -371,12 +371,14 @@ function formatValue(statement, value, isHtml = false, key = '') {
 let prePainting = false;
 
 // A param line with every value slot blanked to the placeholder: the
-// statement (else the tag) with format specifiers substituted; '%%' still
-// renders as a literal '%'.
+// statement (else the tag) with format specifiers substituted; '%%'
+// collapses to a literal '%' (each '%' matches the bare-% alternative
+// individually, so the pair needs the same explicit collapse the CON
+// render path applies).
 const placeholderLine = (s) =>
-  (s.statement || s.tag || '').replace(FORMAT_SPEC_RE, (m) =>
-    m === '%' ? '%' : RENDER.VALUE_PLACEHOLDER
-  );
+  (s.statement || s.tag || '')
+    .replace(FORMAT_SPEC_RE, (m) => (m === '%' ? '%' : RENDER.VALUE_PLACEHOLDER))
+    .replace('%%', '%');
 
 export function renderScreen(subs, ascii, logParam) {
   const lcdEl = document.getElementById('lcd');
@@ -391,6 +393,16 @@ export function renderScreen(subs, ascii, logParam) {
   // cached structure instead, or an honest loading title when the tree has
   // never seen the key.
   if (!prePainting && subs[0]?.key !== appState.currentKey) {
+    // Root with no cached dump: the ROOT render branch never displays a
+    // title and filters the main sub out of its softkey rows, so the
+    // synthetic loading node would paint a blank screen. Keeping the old
+    // DOM beats painting nothing — skip the paint entirely (the root dump
+    // is always the connect flow's first fetch, so this is a cold-start
+    // corner only).
+    if (appState.currentKey === KEY.ROOT && !getNode(KEY.ROOT)) {
+      log('Render guard (R3): root not cached yet; skipping paint', 'debug', 'renderScreen');
+      return;
+    }
     const cached = getNode(appState.currentKey) || [
       {
         type: 'COL',
@@ -493,15 +505,19 @@ export function renderScreen(subs, ascii, logParam) {
       titleHtml = `<span class="back-link" data-key="${parent.key}">[${parent.tag}]</span> ${titleText.replace(`[${parent.tag}] `, '')}`;
     }
     displayLines.push(titleText);
-    // Group graphic EQ NUMs with position 'a' (skipped in pre-paint: the
-    // R3 shortcut below renders every param as a placeholder line instead,
-    // and this block sends value fetches the real render owns).
-    const graphicEqSubs = prePainting
-      ? []
-      : subs.slice(1).filter((s) => s.type === 'NUM' && s.position === 'a');
+    // Group graphic EQ NUMs with position 'a'. The pre-paint pass keeps the
+    // grouped one-line layout (placeholder values, no fetches) so the real
+    // render doesn't collapse N lines into one when the dump lands (R3).
+    const graphicEqSubs = subs.slice(1).filter((s) => s.type === 'NUM' && s.position === 'a');
     let graphicEqLine;
     let graphicEqHtml;
-    if (graphicEqSubs.length > 0) {
+    if (graphicEqSubs.length > 0 && prePainting) {
+      const line = graphicEqSubs
+        .map((s) => `${s.tag.split(':')[0]}: ${RENDER.VALUE_PLACEHOLDER}`)
+        .join(' ');
+      paramLines.push(line);
+      paramHtmlLines.push(line);
+    } else if (graphicEqSubs.length > 0) {
       const formattedParts = graphicEqSubs.map((s) => {
         const value = appState.currentValues[s.key] || s.value;
         if (appState.currentValues[s.key] === undefined) sendValueDump(s.key); // empty string = confirmed-absent, do not refetch (C1 review)
@@ -526,8 +542,9 @@ export function renderScreen(subs, ascii, logParam) {
       if (prePainting) {
         // R3: one inert placeholder line per param — no clickable spans,
         // no selects, and no value refetches (the real render issues those
-        // when the live dump lands).
-        if (s.type === 'COL' || s.type === '8') return;
+        // when the live dump lands). 'a'-positioned NUMs already rendered
+        // as the grouped graphic-EQ placeholder line above.
+        if (s.type === 'COL' || s.type === '8' || s.position === 'a') return;
         const text = placeholderLine(s);
         if (text) {
           paramLines.push(text);
@@ -740,7 +757,10 @@ export function renderScreen(subs, ascii, logParam) {
       softSubs = localSoftSubs;
     }
     // Pre-paint passes write no state at all (R3): the softkey pin, like
-    // the currentSubs pin, records only device-confirmed renders.
+    // the currentSubs pin, records only device-confirmed renders. (Note:
+    // currentSoftkeys currently has no reader in src — clicks resolve via
+    // data-key attributes — so during a pre-paint window the DOM's softkeys
+    // intentionally lead this pin; revisit if a consumer is ever added.)
     if (softSubs.length > 0 && !prePainting) {
       setState({ currentSoftkeys: softSubs }, 'renderer:render-pin');
     }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,7 +1,7 @@
 // renderer.js
 import { appState } from './state.js';
 import { CMD, KEY, KEY_PREFIX, ROOT_SOFTKEYS } from './sysex-commands.js';
-import { TIMING, LAYOUT } from './constants.js';
+import { TIMING, LAYOUT, RENDER } from './constants.js';
 import { setState } from './store.js';
 import { sendObjectInfoDump, sendValueDump, sendValuePut, sendSysEx } from './midi.js';
 import { showLoading } from './main.js';
@@ -314,9 +314,14 @@ const handleParamClick = (e) => {
  * formatValue('%3.0f dB', 5.5); // '  6 dB'
  * formatValue('%-10s', 'test', true, 'key123'); // '<span class="param-value" data-key="key123">test      </span>'
  */
+// Every value format specifier the device's statement strings use (%f and %s
+// families plus the literal '%%'); shared by formatValue and the R3
+// pre-paint placeholder substitution.
+const FORMAT_SPEC_RE = /%(-)?(\d*)(\.\d*)?f|%(-)?(\d*)s|%/g;
+
 function formatValue(statement, value, isHtml = false, key = '') {
   return statement.replace(
-    /%(-)?(\d*)(\.\d*)?f|%(-)?(\d*)s|%/g,
+    FORMAT_SPEC_RE,
     (match, fLeftFlag, fWidthStr, precStr, sLeftFlag, sWidthStr) => {
       if (match === '%') return '%';
       if (fLeftFlag !== undefined || fWidthStr !== undefined || precStr !== undefined) {
@@ -356,13 +361,60 @@ function formatValue(statement, value, isHtml = false, key = '') {
  * @example
  * renderScreen(parsedSubs, asciiDump, log);
  */
+// R3 (#106): true while renderScreen is repainting from the tree cache
+// because the navigated-to key's live dump has not landed yet. The pre-paint
+// pass renders structure (title, breadcrumb, COL softkeys) but inert
+// placeholder lines for params — no clickable values, no value refetches
+// (the real render issues those), and NO currentSubs render-pin, so
+// currentSubs stays device-confirmed (and the tree audit settles on the
+// real dump, never on a cache paint).
+let prePainting = false;
+
+// A param line with every value slot blanked to the placeholder: the
+// statement (else the tag) with format specifiers substituted; '%%' still
+// renders as a literal '%'.
+const placeholderLine = (s) =>
+  (s.statement || s.tag || '').replace(FORMAT_SPEC_RE, (m) =>
+    m === '%' ? '%' : RENDER.VALUE_PLACEHOLDER
+  );
+
 export function renderScreen(subs, ascii, logParam) {
   const lcdEl = document.getElementById('lcd');
   if (!subs || subs.length === 0) {
     log('Skipping render: no subs available', 'debug', 'renderScreen');
     return;
   }
-  setState({ currentSubs: subs }, 'renderer:render-pin');
+  // R3 render guard (#106): these subs describe a DIFFERENT node than the
+  // one navigated to — the new key's dump is still in flight. Never paint
+  // the old menu under the new key (live bug: "[program] program functions"
+  // titled as levels for seconds on a backed-up link). Pre-paint the tree's
+  // cached structure instead, or an honest loading title when the tree has
+  // never seen the key.
+  if (!prePainting && subs[0]?.key !== appState.currentKey) {
+    const cached = getNode(appState.currentKey) || [
+      {
+        type: 'COL',
+        position: '0',
+        key: appState.currentKey,
+        parent: appState.currentKey,
+        statement: RENDER.LOADING_STATEMENT,
+        tag: '',
+      },
+    ];
+    log(
+      `Render guard (R3): dump for ${subs[0]?.key} != current ${appState.currentKey}; pre-painting ${getNode(appState.currentKey) ? 'cached structure' : 'loading view'}`,
+      'debug',
+      'renderScreen'
+    );
+    prePainting = true;
+    try {
+      renderScreen(cached, '', logParam);
+    } finally {
+      prePainting = false;
+    }
+    return;
+  }
+  if (!prePainting) setState({ currentSubs: subs }, 'renderer:render-pin');
   const main = subs[0];
   if (!main) {
     log('Skipping render: main sub undefined', 'debug', 'renderScreen');
@@ -441,8 +493,12 @@ export function renderScreen(subs, ascii, logParam) {
       titleHtml = `<span class="back-link" data-key="${parent.key}">[${parent.tag}]</span> ${titleText.replace(`[${parent.tag}] `, '')}`;
     }
     displayLines.push(titleText);
-    // Group graphic EQ NUMs with position 'a'
-    const graphicEqSubs = subs.slice(1).filter((s) => s.type === 'NUM' && s.position === 'a');
+    // Group graphic EQ NUMs with position 'a' (skipped in pre-paint: the
+    // R3 shortcut below renders every param as a placeholder line instead,
+    // and this block sends value fetches the real render owns).
+    const graphicEqSubs = prePainting
+      ? []
+      : subs.slice(1).filter((s) => s.type === 'NUM' && s.position === 'a');
     let graphicEqLine;
     let graphicEqHtml;
     if (graphicEqSubs.length > 0) {
@@ -467,6 +523,18 @@ export function renderScreen(subs, ascii, logParam) {
       paramHtmlLines.push(graphicEqHtml);
     }
     subs.slice(1).forEach((s) => {
+      if (prePainting) {
+        // R3: one inert placeholder line per param — no clickable spans,
+        // no selects, and no value refetches (the real render issues those
+        // when the live dump lands).
+        if (s.type === 'COL' || s.type === '8') return;
+        const text = placeholderLine(s);
+        if (text) {
+          paramLines.push(text);
+          paramHtmlLines.push(text);
+        }
+        return;
+      }
       if (s.position === 'a') return; // Skip individual 'a' after grouping
       let fullText = '';
       let fullHtml = '';
@@ -556,10 +624,15 @@ export function renderScreen(subs, ascii, logParam) {
     // and the embedded UI varied run to run. The physical PROGRAM page is
     // the ground truth: the first child ('load new preset') is the menu's
     // default view.
-    let potentialEmbedSubs = subs
-      .slice(1)
-      .filter((s) => s.type === 'COL' && s.position === '0' && s.parent === appState.currentKey)
-      .slice(0, 1);
+    // Embeds are a real-render concern: the pre-paint pass keeps every COL
+    // child a softkey (no embedded child params, whose values would also be
+    // unconfirmed) — R3.
+    let potentialEmbedSubs = prePainting
+      ? []
+      : subs
+          .slice(1)
+          .filter((s) => s.type === 'COL' && s.position === '0' && s.parent === appState.currentKey)
+          .slice(0, 1);
     let embeddedKey = null;
     // T1b: the parser fan-out fetches ALL COL children of the current menu,
     // so the embed candidate is always covered - the R6/R9 prefetch (which
@@ -666,7 +739,9 @@ export function renderScreen(subs, ascii, logParam) {
     } else {
       softSubs = localSoftSubs;
     }
-    if (softSubs.length > 0) {
+    // Pre-paint passes write no state at all (R3): the softkey pin, like
+    // the currentSubs pin, records only device-confirmed renders.
+    if (softSubs.length > 0 && !prePainting) {
       setState({ currentSoftkeys: softSubs }, 'renderer:render-pin');
     }
     // Build current/sibling soft text lines (lower level first)

--- a/tests/renderer.test.js
+++ b/tests/renderer.test.js
@@ -819,6 +819,33 @@ describe('renderer.js', () => {
         statement: 'meter setup',
         tag: 'meter',
       },
+      {
+        type: 'CON',
+        position: '3',
+        key: '10030002',
+        parent: '10030000',
+        statement: 'wet %3.0f%%',
+        tag: 'wet',
+        value: '56',
+      },
+      {
+        type: 'NUM',
+        position: 'a',
+        key: '10030003',
+        parent: '10030000',
+        statement: '',
+        tag: 'v1:%3.0f',
+        value: '2',
+      },
+      {
+        type: 'NUM',
+        position: 'a',
+        key: '10030004',
+        parent: '10030000',
+        statement: '',
+        tag: 'v2:%3.0f',
+        value: '5',
+      },
     ]);
     const staleSubs = [
       {
@@ -850,6 +877,11 @@ describe('renderer.js', () => {
     expect(lcd.textContent).toContain('level functions');
     expect(lcd.textContent).toContain('in gain ... dB');
     expect(lcd.textContent).not.toMatch(/in gain\s+6/);
+    // '%%' collapses to a literal '%' in placeholder lines (reviewer fix).
+    expect(lcd.textContent).toContain('wet ...%');
+    expect(lcd.textContent).not.toContain('%%');
+    // 'a'-positioned NUMs keep the grouped one-line graphic-EQ layout.
+    expect(lcd.textContent).toContain('v1: ... v2: ...');
     expect(document.querySelector('.softkey[data-key="10030045"]')).toBeTruthy();
     // Placeholder params are inert: no clickable value span for the NUM.
     expect(document.querySelector('.param-value[data-key="10030001"]')).toBeFalsy();

--- a/tests/renderer.test.js
+++ b/tests/renderer.test.js
@@ -787,6 +787,97 @@ describe('renderer.js', () => {
     expect(appState.currentKey).toBe('0');
   });
 
+  test('render guard: a stale dump never paints under the new key — cached pre-paint (R3/#106)', () => {
+    // Live bug: clicking levels while the link is backed up rendered the OLD
+    // program menu titled/breadcrumbed as levels for seconds. The guard
+    // pre-paints the tree's cached structure for the navigated-to key:
+    // params as inert placeholder lines, COL children as live softkeys.
+    appState.currentKey = '10030000';
+    recordDump([
+      {
+        type: 'COL',
+        position: '0',
+        key: '10030000',
+        parent: '10030000',
+        statement: 'level functions',
+        tag: 'level',
+      },
+      {
+        type: 'NUM',
+        position: '1',
+        key: '10030001',
+        parent: '10030000',
+        statement: 'in gain %3.0f dB',
+        tag: '',
+        value: '6',
+      },
+      {
+        type: 'COL',
+        position: '2',
+        key: '10030045',
+        parent: '10030000',
+        statement: 'meter setup',
+        tag: 'meter',
+      },
+    ]);
+    const staleSubs = [
+      {
+        type: 'COL',
+        position: '0',
+        key: '10020000',
+        parent: '10020000',
+        statement: 'program functions',
+        tag: 'program',
+      },
+      {
+        type: 'TRG',
+        position: '1',
+        key: '10020001',
+        parent: '10020000',
+        statement: '<- load program in A',
+        tag: 'load',
+      },
+    ];
+    appState.currentSubs = staleSubs;
+    renderScreen(staleSubs, '', mockLog);
+
+    const lcd = document.getElementById('lcd');
+    // The old menu's content is nowhere in the paint.
+    expect(lcd.textContent).not.toContain('program functions');
+    expect(lcd.textContent).not.toContain('load program');
+    // The cached structure is: title, placeholder param (stale cached value
+    // 6 must NOT render as if confirmed), navigable COL softkey.
+    expect(lcd.textContent).toContain('level functions');
+    expect(lcd.textContent).toContain('in gain ... dB');
+    expect(lcd.textContent).not.toMatch(/in gain\s+6/);
+    expect(document.querySelector('.softkey[data-key="10030045"]')).toBeTruthy();
+    // Placeholder params are inert: no clickable value span for the NUM.
+    expect(document.querySelector('.param-value[data-key="10030001"]')).toBeFalsy();
+    // The pre-paint pass writes no state and fetches nothing: currentSubs
+    // stays device-confirmed (the stale dump) and no value refetch fires.
+    expect(appState.currentSubs).toBe(staleSubs);
+    expect(sendValueDump).not.toHaveBeenCalled();
+  });
+
+  test('render guard: an unknown key pre-paints an honest loading view, never the old menu (R3/#106)', () => {
+    appState.currentKey = '10030000'; // tree has never seen this key
+    const staleSubs = [
+      {
+        type: 'COL',
+        position: '0',
+        key: '10020000',
+        parent: '10020000',
+        statement: 'program functions',
+        tag: 'program',
+      },
+    ];
+    renderScreen(staleSubs, '', mockLog);
+
+    const lcd = document.getElementById('lcd');
+    expect(lcd.textContent).not.toContain('program functions');
+    expect(lcd.textContent).toContain('loading ...');
+  });
+
   test('lcd click on dsp-clickable swaps active preset with a derived stack (T1b)', () => {
     appState.currentKey = '0';
     appState.dspAName = 'Reverb';


### PR DESCRIPTION
First half of #106 (the render guard; the eager loader + `eagerLoad` flag remain open).

## What

Fixes the live-reported R3 bug: on a backed-up link, clicking a menu rendered the OLD menu titled and breadcrumbed as the NEW key for seconds (e.g. "[program] program functions" while `currentKey=10030000`).

`renderScreen` now refuses to paint subs whose main key differs from `currentKey` and pre-paints instead:

- **Tree cache known**: the cached node's structure — real title/breadcrumb, COL children as live softkeys (navigation stays instant), every param as an inert placeholder line (format specifiers → `...`, `%%` collapses to `%`, graphic-EQ groups keep their one-line layout). No clickable value spans, no selects, no value refetches — the real render owns those, so a stale cached number can never render as if confirmed.
- **Tree cache cold**: a synthetic `loading ...` title (root special-cased: the ROOT branch can't display it, so the paint is skipped rather than blanked).

Pre-paint passes write **no state**: the `currentSubs`/`currentSoftkeys` render-pins record device-confirmed renders only — which also keeps the tree-audit settle condition honest (it waits for the real dump, never a cache paint).

## Review

Correctness + docs reviewer agents ran; all findings applied in `60cfd48` (`%%` collapse with test, root cold-start hole, EQ grouping layout jump, reader-less pin comment). Docs reviewer found no staleness.

## Verification

- 135/135 tests; the two new renderer tests pin both guard paths and fail pre-fix; **all 10 snapshots unchanged** (normal renders byte-identical).
- Lint + format clean.
- Device-on `npm run tree-audit` at stock defaults with the guard in place: 42 nodes fetched, 41 audited, **zero violations**.
