### PR TITLE
fix: CON display semantics — format-in-tag, display-unit values (R10)

### DIFF
--- a/build_tools/tree-audit.mjs
+++ b/build_tools/tree-audit.mjs
@@ -276,6 +276,10 @@ for (const [key, node] of colNodes) {
     const valFrag = (p.value || '').trim().slice(0, 20);
     if (!stmtFrag && !tagFrag && !valFrag) continue; // blank spacers: render-skip by design
     if (p.type === 'INF' && !stmtFrag && !valFrag) continue; // pure-format INF, value arrives later
+    // Format-only CON (statement blank, tag IS the format spec — the pedal
+    // monitors): renders as pure formatted value with no stable literal to
+    // match and no data-key (CON display-semantics fix).
+    if (p.type === 'CON' && !stmtFrag && /%.*[fs]/.test(tagFrag)) continue;
     const textHit =
       (stmtFrag && mainText.includes(stmtFrag)) ||
       (p.type === 'INF' && valFrag && mainText.includes(valFrag)) || // INF renders its value

--- a/build_tools/tree-audit.mjs
+++ b/build_tools/tree-audit.mjs
@@ -277,13 +277,24 @@ for (const [key, node] of colNodes) {
     if (!stmtFrag && !tagFrag && !valFrag) continue; // blank spacers: render-skip by design
     if (p.type === 'INF' && !stmtFrag && !valFrag) continue; // pure-format INF, value arrives later
     // Format-only CON (statement blank, tag IS the format spec — the pedal
-    // monitors): renders as pure formatted value with no stable literal to
-    // match and no data-key (CON display-semantics fix).
-    if (p.type === 'CON' && !stmtFrag && /%.*[fs]/.test(tagFrag)) continue;
+    // monitors): renders as pure formatted value with no stable literal and
+    // no data-key (R10). Rather than skipping blind, derive a pattern from
+    // the format (specs -> a number, '%%' -> '%') and require SOME line to
+    // match it, so total disappearance still flags.
+    if (p.type === 'CON' && !stmtFrag && /%-?\d*(\.\d*)?[fs]/.test(tagFrag)) {
+      const derived = tagFrag
+        .replace(/[.*+?^${}()|[\]\\]/g, '\\$&') // escape literals
+        .replace(/%-?\\?\d*(\\\.\d*)?[fs]/g, '-?\\d+(\\.\\d+)?\\s*') // specs -> a number
+        .replace(/%%/g, '%');
+      if (!new RegExp(derived).test(mainText)) {
+        flag(key, 'param-missing', `format-only CON ${p.key} '${p.tag}' not rendered`);
+      }
+      continue;
+    }
     const textHit =
       (stmtFrag && mainText.includes(stmtFrag)) ||
       (p.type === 'INF' && valFrag && mainText.includes(valFrag)) || // INF renders its value
-      (tagFrag && mainText.includes(tagFrag)); // blanket short-text fallback (bar CONs render tag-only, no data-key)
+      (tagFrag && mainText.includes(tagFrag)); // blanket short-text fallback (spec-less indicator CONs render tag + bar, no data-key — R10)
     if (keyCount === 0 && !textHit) {
       flag(key, 'param-missing', `${p.type} ${p.key} '${p.statement}' not rendered`);
     } else if (keyCount > 1) {

--- a/docs/device-model.md
+++ b/docs/device-model.md
@@ -160,11 +160,17 @@ After the six common fields, trailing fields depend on TYPE:
   options become the choice list; `currentIndex` is **hex** and **0-based** —
   the Programming Manual's `textknob`: "if the 1st selection is made the output
   = 0, if the 3rd, = 2". `[V/D]`
-- **CON** — `value` (continuous; rendered as a bar; meter keys observed to end
+- **CON** — `value` (continuous, read-only; meter keys observed to end
   `0002` — naming convention only, see §5).
   Maps to the documented `monitor`/`hmonitor`/`vmonitor`/`meter` modules, which
-  have their own min/max display specifiers `[D]`; the absolute value range is
-  still `[?]` (we treat ≈0..1).
+  have their own min/max display specifiers `[D]`. **Values arrive in DISPLAY
+  units, not normalized fractions** `[V]` (probed live 2026-06-10): assign/MIDI
+  monitors report `0.033`–`100.03` against a `%%` format (percent, 0–100), file
+  sizes report raw byte counts (`2714`), the sample-rate monitor reports Hz
+  (`48000.398`). **The format spec may live in the TAG slot when the statement
+  is blank** `[V]` — the pedal monitors are `statement ''`, `tag '%2.1f%%'`. A
+  CON with no format spec in either slot is an indicator (only live example:
+  Tempo `Beat`, value `0`), which the app renders as a bar.
 - **TRG** — no value field; fire by `VALUE_PUT <key> 1`. `[V]` (no direct
   documented module — a runtime momentary).
 - **INF** — `value` (read-only). Maps to `monitor`/`tmonitor`/`textblock`. `[V/D]`
@@ -425,9 +431,12 @@ Still open — needs a hardware session or more captures (all minor):
 
 - A *dedicated* read for the active DSP (we can drive/detect it via §8, but no
   single "which DSP" value key has been found).
-- **CON** absolute value range — live meters read ~0 at rest (need an audio
-  signal through the unit to see a non-zero meter), so the wire range is still
-  unconfirmed (we treat ≈0..1).
+- ~~**CON** absolute value range~~ — RESOLVED (2026-06-10 live probe): values
+  are display-unit floats, not normalized fractions — percent monitors span
+  0–100, file sizes raw bytes, sample rate Hz; see §3. (Note the AUDIO level
+  meters on the LEVELS screen are not tree CONs at all — the device draws
+  them straight into the LCD framebuffer; the bitmap path is the only way to
+  see them in the app, probed to depth 3.)
 - The **bank-change SysEx** message format (deferred to the Programming Manual,
   which doesn't spell it out) — capture by watching what the unit emits.
 

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -601,10 +601,21 @@ in logs/ (program-screen.png).
       actions (save/delete program/bank, card ops, link, STR name edits — TRG/STR puts under
       10020xxx); known gap: front-panel changes outside the app (mitigate via Sync button /
       reconnect refetch). Possibly also clear hideLoading earlier when content is cache-served.
+- [x] R10 (GH #116; branch fix/con-format-in-tag) CON DISPLAY SEMANTICS FIXED + §12 'CON range'
+      RESOLVED (live probe 2026-06-10): CON values arrive in DISPLAY units, not 0-1 fractions —
+      assign/MIDI monitors 0-100 against '%%' formats, file sizes raw bytes, sample rate Hz — and
+      the format spec may live in the TAG when the statement is blank (pedal monitors: '' +
+      '%2.1f%%'). Two renderer bugs fell out of the old assumptions: format-in-tag CONs went down
+      the bar path (literal '%2.1f%%' as label + pegged-full bar from 70.7 clamped into 0-1), and
+      the *100 'percent inflation' rendered 'monitor = 10003.00%'. Fix in both CON render sites
+      (top-level + embed): format detection falls back to the tag; *100 deleted; bar path remains
+      for spec-less indicator CONs only (Tempo 'Beat'). Audit detector: format-only-CON exception
+      (pure-value render, no stable literal). device-model §3 + §12 updated; CON snapshot input
+      corrected to display units. NOTE: audio LEVEL meters are NOT tree CONs (device draws them
+      into the LCD framebuffer; bitmap path only — probed to depth 3).
 NOTE: C2 landing validated LIVE end to end on this session: root dump -> landing -> descend ->
 'space parameters' with values matching the physical LCD capture (logs/hil-shot.png). Perf reported
-good by the maintainer. The B10g.3 §12 item "CON range" still open (no audio signal connected;
-meter rendering verifiable offline with synthetic values — renderer CON snapshot covers it).
+good by the maintainer. The B10g.3 §12 item "CON range" RESOLVED by R10 above.
 HUMAN-GATE: none (all reproducible offline or with the harness)
 
 ### Batch 3.4 — Cycle cleanup   [branch: refactor/logcategories-off-appstate]  (GH #42)

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -609,9 +609,13 @@ in logs/ (program-screen.png).
       the bar path (literal '%2.1f%%' as label + pegged-full bar from 70.7 clamped into 0-1), and
       the *100 'percent inflation' rendered 'monitor = 10003.00%'. Fix in both CON render sites
       (top-level + embed): format detection falls back to the tag; *100 deleted; bar path remains
-      for spec-less indicator CONs only (Tempo 'Beat'). Audit detector: format-only-CON exception
-      (pure-value render, no stable literal). device-model §3 + §12 updated; CON snapshot input
-      corrected to display units. NOTE: audio LEVEL meters are NOT tree CONs (device draws them
+      for spec-less indicator CONs only (Tempo 'Beat'). Review hardening: '%%' now collapses to '%'
+      via FORMAT_SPEC_RE's leading alternative on EVERY param path — the live LCD used to show
+      'mod rate :  60 %%' because only the CON branch collapsed post-hoc; CON format detection uses
+      the tight CON_FORMAT_RE (a literal '%' can't be misread as a format). Audit detector: format-
+      only CONs are checked against a PATTERN derived from their format (specs -> a number) instead
+      of skipped blind, so total disappearance still flags. device-model §3 + §12 updated; CON
+      snapshot input corrected to display units. NOTE: audio LEVEL meters are NOT tree CONs (device draws them
       into the LCD framebuffer; bitmap path only — probed to depth 3).
 NOTE: C2 landing validated LIVE end to end on this session: root dump -> landing -> descend ->
 'space parameters' with values matching the physical LCD capture (logs/hil-shot.png). Perf reported

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -597,13 +597,28 @@ export function renderScreen(subs, ascii, logParam) {
         if (isNaN(meterValue)) {
           meterValue = 0; // Default to 0 if invalid value
         }
-        if (/%.*[fs]/.test(s.statement)) {
-          let displayValue = meterValue;
-          if (s.statement.includes('%%')) displayValue *= 100;
-          fullText = formatValue(s.statement, displayValue);
+        // CON display semantics (probed live, device-model §3/§12): values
+        // arrive in DISPLAY units (assign monitors 0-100 with a '%%'
+        // format; file sizes in raw bytes), and the format spec can live
+        // in the TAG when the statement is blank (the pedal monitors:
+        // statement '', tag '%2.1f%%'). The old statement-only check sent
+        // pedal monitors down the bar path with the literal format string
+        // as their label, and the old *100 "percent inflation" assumed 0-1
+        // fractions — live values disprove it ('monitor = %2.2f%%' at
+        // 100.03 rendered as 10003.00%).
+        const conFormat = /%.*[fs]/.test(s.statement)
+          ? s.statement
+          : /%.*[fs]/.test(s.tag)
+            ? s.tag
+            : null;
+        if (conFormat) {
+          fullText = formatValue(conFormat, meterValue);
           if (fullText.includes('%%')) fullText = fullText.replace('%%', '%');
           fullHtml = fullText;
         } else {
+          // No format spec anywhere: an indicator CON (the Tempo 'Beat'
+          // flasher is the only live-observed case) — render the bar,
+          // treating the value as a 0-1 fraction, clamped.
           const tagLength = s.tag.length;
           const barSpace = LAYOUT.LCD_COLUMNS - tagLength - 1;
           let barLength = Math.round(meterValue * barSpace);
@@ -715,10 +730,16 @@ export function renderScreen(subs, ascii, logParam) {
             if (isNaN(meterValue)) {
               meterValue = 0; // Default to 0 if invalid value
             }
-            if (/%.*[fs]/.test(cs.statement)) {
-              let displayValue = meterValue;
-              if (cs.statement.includes('%%')) displayValue *= 100;
-              childFullText = formatValue(cs.statement, displayValue);
+            // Same CON display semantics as the top-level branch (probed
+            // live): format spec may live in the tag; values are display
+            // units, never *100-inflated.
+            const conFormat = /%.*[fs]/.test(cs.statement)
+              ? cs.statement
+              : /%.*[fs]/.test(cs.tag)
+                ? cs.tag
+                : null;
+            if (conFormat) {
+              childFullText = formatValue(conFormat, meterValue);
               if (childFullText.includes('%%')) childFullText = childFullText.replace('%%', '%');
               childFullHtml = childFullText;
             } else {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -315,15 +315,25 @@ const handleParamClick = (e) => {
  * formatValue('%-10s', 'test', true, 'key123'); // '<span class="param-value" data-key="key123">test      </span>'
  */
 // Every value format specifier the device's statement strings use (%f and %s
-// families plus the literal '%%'); shared by formatValue and the R3
-// pre-paint placeholder substitution.
-const FORMAT_SPEC_RE = /%(-)?(\d*)(\.\d*)?f|%(-)?(\d*)s|%/g;
+// families plus the literal '%%', which collapses to a single '%' — the
+// leading alternative, so the device's percent-suffix statements like
+// 'diff/time : %3.0f %%' render '60 %' and not '60 %%' on EVERY param
+// path (R10 review: only the CON branch used to collapse, post-hoc).
+// Shared by formatValue and the R3 pre-paint placeholder substitution.
+const FORMAT_SPEC_RE = /%%|%(-)?(\d*)(\.\d*)?f|%(-)?(\d*)s|%/g;
+
+// Does a string contain a REAL value format spec ('%[-][width][.prec]f' or
+// '%[-][width]s')? Used to decide whether a CON's statement/tag is a format
+// (R10) — deliberately tighter than FORMAT_SPEC_RE's bare-'%' alternative,
+// so a hypothetical literal like '% of files' is not misread as a format.
+// No /g flag: .test() on a global regex is lastIndex-stateful.
+const CON_FORMAT_RE = /%-?\d*(\.\d*)?f|%-?\d*s/;
 
 function formatValue(statement, value, isHtml = false, key = '') {
   return statement.replace(
     FORMAT_SPEC_RE,
     (match, fLeftFlag, fWidthStr, precStr, sLeftFlag, sWidthStr) => {
-      if (match === '%') return '%';
+      if (match === '%%' || match === '%') return '%';
       if (fLeftFlag !== undefined || fWidthStr !== undefined || precStr !== undefined) {
         // %[-]width[.prec]f
         const leftAlign = fLeftFlag === '-';
@@ -372,13 +382,11 @@ let prePainting = false;
 
 // A param line with every value slot blanked to the placeholder: the
 // statement (else the tag) with format specifiers substituted; '%%'
-// collapses to a literal '%' (each '%' matches the bare-% alternative
-// individually, so the pair needs the same explicit collapse the CON
-// render path applies).
+// collapses to a literal '%' via the shared regex's leading alternative.
 const placeholderLine = (s) =>
-  (s.statement || s.tag || '')
-    .replace(FORMAT_SPEC_RE, (m) => (m === '%' ? '%' : RENDER.VALUE_PLACEHOLDER))
-    .replace('%%', '%');
+  (s.statement || s.tag || '').replace(FORMAT_SPEC_RE, (m) =>
+    m === '%%' || m === '%' ? '%' : RENDER.VALUE_PLACEHOLDER
+  );
 
 export function renderScreen(subs, ascii, logParam) {
   const lcdEl = document.getElementById('lcd');
@@ -606,14 +614,13 @@ export function renderScreen(subs, ascii, logParam) {
         // as their label, and the old *100 "percent inflation" assumed 0-1
         // fractions — live values disprove it ('monitor = %2.2f%%' at
         // 100.03 rendered as 10003.00%).
-        const conFormat = /%.*[fs]/.test(s.statement)
+        const conFormat = CON_FORMAT_RE.test(s.statement)
           ? s.statement
-          : /%.*[fs]/.test(s.tag)
+          : CON_FORMAT_RE.test(s.tag)
             ? s.tag
             : null;
         if (conFormat) {
-          fullText = formatValue(conFormat, meterValue);
-          if (fullText.includes('%%')) fullText = fullText.replace('%%', '%');
+          fullText = formatValue(conFormat, meterValue); // '%%' collapses in formatValue
           fullHtml = fullText;
         } else {
           // No format spec anywhere: an indicator CON (the Tempo 'Beat'
@@ -733,14 +740,13 @@ export function renderScreen(subs, ascii, logParam) {
             // Same CON display semantics as the top-level branch (probed
             // live): format spec may live in the tag; values are display
             // units, never *100-inflated.
-            const conFormat = /%.*[fs]/.test(cs.statement)
+            const conFormat = CON_FORMAT_RE.test(cs.statement)
               ? cs.statement
-              : /%.*[fs]/.test(cs.tag)
+              : CON_FORMAT_RE.test(cs.tag)
                 ? cs.tag
                 : null;
             if (conFormat) {
-              childFullText = formatValue(conFormat, meterValue);
-              if (childFullText.includes('%%')) childFullText = childFullText.replace('%%', '%');
+              childFullText = formatValue(conFormat, meterValue); // '%%' collapses in formatValue
               childFullHtml = childFullText;
             } else {
               const tagLength = cs.tag.length;

--- a/tests/renderer.snapshot.test.js
+++ b/tests/renderer.snapshot.test.js
@@ -394,7 +394,10 @@ describe('renderScreen golden snapshots', () => {
         parent: '10010001',
         statement: 'Level %3.0f%%',
         tag: 'lvl',
-        value: '0.5',
+        // Display units, as the device sends them (probed live: assign
+        // monitors report 0-100 against a '%%' format) — the old synthetic
+        // 0.5 relied on the deleted *100 inflation.
+        value: '50',
         options: [],
       },
     ];

--- a/tests/renderer.test.js
+++ b/tests/renderer.test.js
@@ -800,6 +800,62 @@ describe('renderer.js', () => {
     expect(appState.currentKey).toBe('0');
   });
 
+  test('CON values render in display units; the format spec may live in the tag (live-probed)', () => {
+    // Live ground truth: pedal monitors are statement '' / tag '%2.1f%%' /
+    // value 70.705 (percent, NOT a 0-1 fraction), and assign monitors
+    // report 0-100 against a '%%' statement format. The old renderer sent
+    // pedal CONs down the bar path with the literal format string as their
+    // label, and *100-inflated percent values ('monitor = 10003.00%').
+    appState.currentKey = '10030301';
+    const subs = [
+      {
+        type: 'COL',
+        position: '0',
+        key: '10030301',
+        parent: '10030301',
+        statement: 'Pedal 1 setup',
+        tag: 'pedals',
+      },
+      {
+        type: 'CON',
+        position: '10',
+        key: '1003030a',
+        parent: '10030301',
+        statement: '',
+        tag: '%2.1f%%',
+        value: '70.705',
+      },
+      {
+        type: 'CON',
+        position: '1',
+        key: '1001007a',
+        parent: '10030301',
+        statement: 'monitor = %2.2f%%',
+        tag: '%2.1f%%',
+        value: '100.03',
+      },
+      {
+        type: 'CON',
+        position: '2',
+        key: '40090004',
+        parent: '10030301',
+        statement: '',
+        tag: 'Beat',
+        value: '0',
+      },
+    ];
+    renderScreen(subs, '', mockLog);
+
+    const text = document.getElementById('lcd').textContent;
+    expect(text).toContain('70.7%'); // tag format applied to the display-unit value
+    expect(text).not.toContain('%2.1f'); // the format string is never a label
+    expect(text).toContain('monitor = 100.03%'); // no *100 inflation
+    expect(text).not.toContain('10003');
+    // A spec-less indicator CON still gets the bar.
+    expect(document.querySelector('.meter-bar')).toBeTruthy();
+    expect(text).toContain('Beat');
+  });
+
   test('render guard: a stale dump never paints under the new key — cached pre-paint (R3/#106)', () => {
     // Live bug: clicking levels while the link is backed up rendered the OLD
     // program menu titled/breadcrumbed as levels for seconds. The guard

--- a/tests/renderer.test.js
+++ b/tests/renderer.test.js
@@ -843,6 +843,15 @@ describe('renderer.js', () => {
         tag: 'Beat',
         value: '0',
       },
+      {
+        type: 'NUM',
+        position: '3',
+        key: '40a0001',
+        parent: '10030301',
+        statement: 'mod rate  : %3.0f %%',
+        tag: '',
+        value: '60',
+      },
     ];
     renderScreen(subs, '', mockLog);
 
@@ -851,6 +860,10 @@ describe('renderer.js', () => {
     expect(text).not.toContain('%2.1f'); // the format string is never a label
     expect(text).toContain('monitor = 100.03%'); // no *100 inflation
     expect(text).not.toContain('10003');
+    // '%%' collapses on EVERY param path now (the live LCD used to show
+    // 'mod rate :  60 %%' — the collapse lived only in the CON branch).
+    expect(text).toContain('60 %');
+    expect(text).not.toContain('%%');
     // A spec-less indicator CON still gets the bar.
     expect(document.querySelector('.meter-bar')).toBeTruthy();
     expect(text).toContain('Beat');


### PR DESCRIPTION
Closes #116

Resolves the device-model §12 'CON range' unknown with live probe data, and fixes the renderer bugs the old assumptions caused.

## Ground truth (probed live)

- CON values arrive in **display units**, never 0-1 fractions: assign/MIDI monitors report 0-100 against '%%' formats, file sizes raw bytes, the sample-rate monitor Hz.
- The format spec **may live in the TAG slot** when the statement is blank (pedal monitors: statement '', tag '%2.1f%%').
- The audio LEVEL meters are NOT tree CONs at all — the device draws them into its LCD framebuffer (bitmap path only; probed to depth 3).

## Fixes

1. **Format detection falls back to the tag** (tight CON_FORMAT_RE) in both CON render sites — pedal monitors used to render the literal '%2.1f%%' as a bar label with a pegged-full bar.
2. **The *100 percent inflation is deleted** — 'monitor = %2.2f%%' at 100.03 rendered as 'monitor = 10003.00%'.
3. **'%%' collapses to '%' on every param path** via FORMAT_SPEC_RE's leading alternative — the live LCD showed 'mod rate :  60 %%' because only the CON branch collapsed post-hoc.
4. The bar path remains for spec-less indicator CONs (Tempo 'Beat'), 0-1 clamped.
5. Audit detector: format-only CONs are checked against a pattern derived from their format instead of skipped blind.

## Verification

- 155/155 tests (new renderer test pins format-in-tag, no-inflation, the %% collapse, and the surviving Beat bar; verified fail-on-old by the reviewer against a main worktree).
- Device-on tree audit with the hardened detector: 42 nodes, 41 audited, **zero violations** — the derived patterns matched the real rendered percent values on both pedal pages.
- Correctness + docs reviewers ran; all findings applied. device-model §3 documents the semantics; §12 marks 'CON range' resolved.