### PR TITLE
fix: parser hardening — quoting invariant + canary (D1), type-8 defined (D2)

### DIFF
--- a/build_tools/tree-audit.mjs
+++ b/build_tools/tree-audit.mjs
@@ -65,7 +65,7 @@ const { appState } = await import('../src/state.js');
 const { setState } = await import('../src/store.js');
 const { updateScreen } = await import('../src/renderer.js');
 const { deriveKeyStack, getNode, recordDump } = await import('../src/tree.js');
-const { KEY, CMD, SYSEX } = await import('../src/sysex-commands.js');
+const { KEY, CMD, SYSEX, TYPE_EMPTY } = await import('../src/sysex-commands.js');
 const { log } = await import('../src/logger.js');
 
 // ---------- real MIDI ------------------------------------------------------
@@ -269,7 +269,7 @@ for (const [key, node] of colNodes) {
   }
 
   // 2. Params rendered exactly once.
-  for (const p of children.filter((s) => s.type !== 'COL' && s.type !== '8')) {
+  for (const p of children.filter((s) => s.type !== 'COL' && s.type !== TYPE_EMPTY)) {
     const keyCount = mainKeys.filter((k) => k === p.key).length;
     const stmtFrag = p.statement ? p.statement.replace(/%.*$/, '').trim() : '';
     const tagFrag = (p.tag || '').trim();

--- a/docs/device-model.md
+++ b/docs/device-model.md
@@ -97,7 +97,10 @@ TYPE  POSITION  KEY  PARENT  STATEMENT  TAG  [type-specific…]
 
 Tokenized like a shell line: whitespace-separated, single/double quotes group a
 multi-word field (so `'space parameters'` is one token). This is `splitLine` in
-`src/sysex-split.js`.
+`src/sysex-split.js`. **Quoting invariant** `[V]` (D1/#118): the device quotes
+a value iff it contains a space — verified across all 52 captured fixture
+lines and hardware STR-put echoes (#104) — so positional parsing is safe;
+`parseSubObject`'s hex-child-count canary logs if this ever breaks (§8).
 
 On the object's **own** line, the `PARENT` field echoes the object's **own key**
 (self-referential), not its real parent — verified across every captured dump,
@@ -344,10 +347,19 @@ distinct ids; id 0 = broadcast (§1).
 - **Active DSP not on the wire** `[V]` — app-side view state.
 - **Favorites re-order** `[V]` — loading from the favorites bank can shift the
   program index; correct the selection then re-dump (`parser.js`).
-- **Root `type=8` entry** `[V]` — `10040000`, filtered from menus.
-- **Preset-name quoting inconsistent** `[V]` — DSP A quoted (`'Black Hole'`),
-  DSP B unquoted (`MetallicChamber`); a multi-word *unquoted* name would
-  mis-tokenize (latent).
+- **Root `type=8` entry** `[V]` — `10040000`, filtered from menus (named
+  `TYPE_EMPTY` in `sysex-commands.js` — D2/#119). Probed directly
+  (2026-06-10): its `OBJECTINFO` returns only its own line (`8 0 10040000
+  10040000 '' ''` — no children, no trailing count field) and its `VALUE`
+  returns an empty value. An empty/reserved leaf; render-skip is correct.
+- **Quoting is need-based, and that IS the invariant** `[V]` (D1/#118,
+  resolves the old "inconsistent" reading) — the device quotes a value iff
+  it contains a space: `'Black Hole'` quoted, `MetallicChamber` bare,
+  verified across all 52 captured fixture lines and on hardware for
+  multi-word STR puts (#104, quoted echoes). Positional `splitLine` parsing
+  is therefore safe; `parseSubObject` carries a canary (a COL line's
+  trailing field must be hex — a non-hex token there is the earliest
+  symptom of a field shift) that logs loudly if the invariant ever breaks.
 - **Framing** `[V]` — OBJECTINFO uses CRLF lines + trailing NUL; VALUE_DUMP does
   not (see §1).
 - **Screen dump carries a checksum** `[V]` — the trailing byte is a sum-to-zero

--- a/docs/device-model.md
+++ b/docs/device-model.md
@@ -98,9 +98,11 @@ TYPE  POSITION  KEY  PARENT  STATEMENT  TAG  [type-specific…]
 Tokenized like a shell line: whitespace-separated, single/double quotes group a
 multi-word field (so `'space parameters'` is one token). This is `splitLine` in
 `src/sysex-split.js`. **Quoting invariant** `[V]` (D1/#118): the device quotes
-a value iff it contains a space — verified across all 52 captured fixture
-lines and hardware STR-put echoes (#104) — so positional parsing is safe;
-`parseSubObject`'s hex-child-count canary logs if this ever breaks (§8).
+any value containing a space (and quotes empty values) — verified across all
+52 captured fixture lines and hardware STR-put echoes (#104) — so positional
+parsing is safe. `parseSubObject`'s canary (a COL line's trailing field must
+be a non-empty hex child count) logs the earliest symptom of a COL-line
+break; a break confined to a param line is not detected (§8).
 
 On the object's **own** line, the `PARENT` field echoes the object's **own key**
 (self-referential), not its real parent — verified across every captured dump,
@@ -353,13 +355,16 @@ distinct ids; id 0 = broadcast (§1).
   10040000 '' ''` — no children, no trailing count field) and its `VALUE`
   returns an empty value. An empty/reserved leaf; render-skip is correct.
 - **Quoting is need-based, and that IS the invariant** `[V]` (D1/#118,
-  resolves the old "inconsistent" reading) — the device quotes a value iff
-  it contains a space: `'Black Hole'` quoted, `MetallicChamber` bare,
-  verified across all 52 captured fixture lines and on hardware for
-  multi-word STR puts (#104, quoted echoes). Positional `splitLine` parsing
-  is therefore safe; `parseSubObject` carries a canary (a COL line's
-  trailing field must be hex — a non-hex token there is the earliest
-  symptom of a field shift) that logs loudly if the invariant ever breaks.
+  resolves the old "inconsistent" reading) — the device quotes any value
+  containing a space, and quotes empty values: `'Black Hole'` quoted,
+  `MetallicChamber` bare, `''` for blank tags; verified across all 52
+  captured fixture lines and on hardware for multi-word STR puts (#104,
+  quoted echoes). Positional `splitLine` parsing is therefore safe;
+  `parseSubObject` carries a canary (a COL line's trailing field must be a
+  NON-EMPTY hex child count — non-hex or missing means a field shift) that
+  logs the earliest symptom of a COL-line break. Honest scope: a break
+  confined to a param line (e.g. an unquoted multi-word SET option) is not
+  detected.
 - **Framing** `[V]` — OBJECTINFO uses CRLF lines + trailing NUL; VALUE_DUMP does
   not (see §1).
 - **Screen dump carries a checksum** `[V]` — the trailing byte is a sum-to-zero

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -662,12 +662,22 @@ HUMAN-GATE: none
 
 ## Phase 4 — Parser quirks & edge hardening
 
-### Batch 4.1
-- [ ] D1  (GH #118) Make splitLine robust to multi-word unquoted preset names (sysex-split.js), or
-      prove the device always quotes (hardware evidence: #104 multi-word STR puts echo QUOTED) and
-      document + assert the invariant. Offline.
-- [ ] D2  (GH #119) Handle/define root OBJECTINFO type=8 entry (key=10040000) in parseSubObject
-      dispatch; remove the scattered ad-hoc `'8'` exclusions (renderer, eager-loader, audit). Offline.
+### Batch 4.1   [branch: fix/parser-hardening-d1-d2]
+- [x] D1  (GH #118) RESOLVED as document + assert — the invariant is PROVEN, not patched around:
+      the device quotes a value iff it contains a space ('Black Hole' quoted, MetallicChamber bare;
+      verified across all 52 captured fixture lines and hardware multi-word STR-put echoes #104),
+      so positional splitLine parsing is safe. ASSERT: parseSubObject gains a field-shift canary —
+      a COL line's trailing field is its HEX child count (e.g. setup's 'f' = 15, a discovery of
+      this batch), so a non-hex token there logs loudly as the earliest symptom of an unquoted
+      multi-word shift. device-model line-grammar + §8 updated; tests pin quoted/bare parsing, the
+      real 'f' count passing, and the canary firing on a synthetic shifted line.
+- [x] D2  (GH #119) RESOLVED with live evidence: probed 10040000 directly — its OBJECTINFO returns
+      only its own line (8 0 10040000 10040000 '' '': no children, no count field) and its VALUE
+      returns empty. Type 8 = an empty/reserved leaf; render-skip is correct and now DEFINED:
+      sysex-commands.js TYPE_EMPTY names it with the probe evidence, and every ad-hoc '8' literal
+      (renderer pre-paint, parser warm-path value filter, audit detector, fixture helper) now
+      references the constant. The '8' lines stay in subs (subsCount semantics unchanged).
+      device-model §8 type-8 entry updated with the probe.
 HUMAN-GATE: none
 
 ---

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -664,13 +664,16 @@ HUMAN-GATE: none
 
 ### Batch 4.1   [branch: fix/parser-hardening-d1-d2]
 - [x] D1  (GH #118) RESOLVED as document + assert — the invariant is PROVEN, not patched around:
-      the device quotes a value iff it contains a space ('Black Hole' quoted, MetallicChamber bare;
-      verified across all 52 captured fixture lines and hardware multi-word STR-put echoes #104),
-      so positional splitLine parsing is safe. ASSERT: parseSubObject gains a field-shift canary —
-      a COL line's trailing field is its HEX child count (e.g. setup's 'f' = 15, a discovery of
-      this batch), so a non-hex token there logs loudly as the earliest symptom of an unquoted
-      multi-word shift. device-model line-grammar + §8 updated; tests pin quoted/bare parsing, the
-      real 'f' count passing, and the canary firing on a synthetic shifted line.
+      the device quotes any value containing a space, and quotes empty values ('Black Hole'
+      quoted, MetallicChamber bare, '' for blank tags; verified across all 52 captured fixture
+      lines and hardware multi-word STR-put echoes #104), so positional splitLine parsing is safe.
+      ASSERT: parseSubObject gains a field-shift canary — a COL line's trailing field is its HEX
+      child count on every observed line (e.g. setup's 'f' = 15, a discovery of this batch), so a
+      non-hex OR MISSING token there logs loudly (review hardening: the empty case catches the
+      two-word-name + quoted-empty-tag shift, the exact 'Black Hole' shape D1 is about). HONEST
+      SCOPE (review): the canary detects COL-line breaks only — a break confined to a param line
+      is not detected. device-model line-grammar + §8 updated; tests pin quoted/bare parsing, the
+      real 'f' count passing, and the canary firing on both shifted shapes.
 - [x] D2  (GH #119) RESOLVED with live evidence: probed 10040000 directly — its OBJECTINFO returns
       only its own line (8 0 10040000 10040000 '' '': no children, no count field) and its VALUE
       returns empty. Type 8 = an empty/reserved leaf; render-skip is correct and now DEFINED:

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,6 +1,6 @@
 // parser.js
 import { appState } from './state.js';
-import { CMD, KEY, KEY_PREFIX, KEY_SUFFIX, SYSEX } from './sysex-commands.js';
+import { CMD, KEY, KEY_PREFIX, KEY_SUFFIX, SYSEX, TYPE_EMPTY } from './sysex-commands.js';
 import { TIMING } from './constants.js';
 import { setState } from './store.js';
 import { sendValuePut, sendValueDump, sendObjectInfoDump, notifyResponse } from './midi.js';
@@ -91,7 +91,7 @@ export function parseResponse(data) {
           if (isFresh(s.key)) {
             log(`Skipping refetch of fresh stable child ${s.key} (#113)`, 'debug', 'parsedDump');
             for (const line of (getNode(s.key) || []).slice(1)) {
-              if (line.key && !['COL', 'TRG', '8'].includes(line.type)) {
+              if (line.key && !['COL', 'TRG', TYPE_EMPTY].includes(line.type)) {
                 sendValueDump(line.key);
               }
             }
@@ -278,6 +278,22 @@ export function parseSubObject(line) {
     }
   } else {
     value = parts[6] || '';
+  }
+  // D1 (#118) field-shift canary. Positional parsing is safe because the
+  // device QUOTES any value containing a space — verified across all 52
+  // captured fixture lines (multi-word statements like 'Black Hole' always
+  // quoted, single words like MetallicChamber bare) and on hardware for
+  // multi-word STR puts (#104, quoted echoes). If that invariant ever
+  // breaks, fields shift: a COL line's trailing field is its HEX child
+  // count (e.g. setup's 'f' = 15), so a non-hex token there is the
+  // earliest detectable symptom — log loudly instead of corrupting every
+  // downstream consumer silently.
+  if (type === 'COL' && value && !/^[0-9a-f]+$/i.test(value)) {
+    log(
+      `Suspect COL line (non-hex child count — unquoted multi-word field shift? D1/#118): ${line}`,
+      'error',
+      'error'
+    );
   }
   return { type, position, key, parent, statement, tag, value, min, max, step, options };
 }

--- a/src/parser.js
+++ b/src/parser.js
@@ -280,15 +280,18 @@ export function parseSubObject(line) {
     value = parts[6] || '';
   }
   // D1 (#118) field-shift canary. Positional parsing is safe because the
-  // device QUOTES any value containing a space — verified across all 52
-  // captured fixture lines (multi-word statements like 'Black Hole' always
-  // quoted, single words like MetallicChamber bare) and on hardware for
-  // multi-word STR puts (#104, quoted echoes). If that invariant ever
-  // breaks, fields shift: a COL line's trailing field is its HEX child
-  // count (e.g. setup's 'f' = 15), so a non-hex token there is the
-  // earliest detectable symptom — log loudly instead of corrupting every
-  // downstream consumer silently.
-  if (type === 'COL' && value && !/^[0-9a-f]+$/i.test(value)) {
+  // device QUOTES any value containing a space (and quotes empty values) —
+  // verified across all 52 captured fixture lines (multi-word statements
+  // like 'Black Hole' always quoted, single words like MetallicChamber
+  // bare) and on hardware for multi-word STR puts (#104, quoted echoes).
+  // If that invariant breaks on a COL line, fields shift: the trailing
+  // field is its HEX child count (e.g. setup's 'f' = 15) on every observed
+  // COL line, so a non-hex OR MISSING token there is the earliest
+  // detectable symptom (a two-word unquoted name shifts a quoted-empty tag
+  // into this slot — review finding) — log loudly instead of corrupting
+  // downstream consumers silently. Scope honesty: this detects COL-line
+  // breaks only; a break confined to a param line is not detected.
+  if (type === 'COL' && !/^[0-9a-f]+$/i.test(value)) {
     log(
       `Suspect COL line (non-hex child count — unquoted multi-word field shift? D1/#118): ${line}`,
       'error',

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,6 +1,6 @@
 // renderer.js
 import { appState } from './state.js';
-import { CMD, KEY, KEY_PREFIX, ROOT_SOFTKEYS } from './sysex-commands.js';
+import { CMD, KEY, KEY_PREFIX, ROOT_SOFTKEYS, TYPE_EMPTY } from './sysex-commands.js';
 import { TIMING, LAYOUT, RENDER } from './constants.js';
 import { setState } from './store.js';
 import { sendObjectInfoDump, sendValueDump, sendValuePut, sendSysEx } from './midi.js';
@@ -558,7 +558,7 @@ export function renderScreen(subs, ascii, logParam) {
         // no selects, and no value refetches (the real render issues those
         // when the live dump lands). 'a'-positioned NUMs already rendered
         // as the grouped graphic-EQ placeholder line above.
-        if (s.type === 'COL' || s.type === '8' || s.position === 'a') return;
+        if (s.type === 'COL' || s.type === TYPE_EMPTY || s.position === 'a') return;
         const text = placeholderLine(s);
         if (text) {
           paramLines.push(text);

--- a/src/sysex-commands.js
+++ b/src/sysex-commands.js
@@ -77,6 +77,14 @@ export const KEY_SUFFIX = {
 // STR = string-edit field, observed live under save program/bank (R8).
 export const PARAM_TYPES = ['NUM', 'SET', 'CON', 'TRG', 'INF', 'STR'];
 
+// The EMPTY object type (D2/#119, probed live 2026-06-10): the root dump
+// carries an `8 0 10040000 0 '' ''` line. Its own OBJECTINFO returns only
+// that line (no children, no trailing count field) and its VALUE returns an
+// empty value — an empty/reserved leaf the device exposes but gives no
+// content for. Correct handling everywhere is render-skip; consumers
+// reference this constant instead of a bare '8' literal.
+export const TYPE_EMPTY = '8';
+
 // Root-level menus, in softkey order, used both as a "is this a top-level menu"
 // set and as the static bottom softkey row.
 export const ROOT_SOFTKEYS = [

--- a/tests/helpers/sysex-fixture.js
+++ b/tests/helpers/sysex-fixture.js
@@ -6,6 +6,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { splitLine } from '../../src/sysex-split.js';
+import { TYPE_EMPTY } from '../../src/sysex-commands.js';
 
 const FIXTURES_DIR = path.join(process.cwd(), 'tests', 'fixtures');
 
@@ -81,7 +82,7 @@ export function extractParamKeysFromDump(bytes) {
   const subs = decodeSubs(bytes);
   return subs
     .slice(1)
-    .filter((s) => !['COL', '8'].includes(s.type))
+    .filter((s) => !['COL', TYPE_EMPTY].includes(s.type))
     .map((s) => s.key);
 }
 

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -412,6 +412,41 @@ describe('parseResponse', () => {
     expect(sendObjectInfoDump).toHaveBeenCalledWith('10010010'); // freshness = per-visit
   });
 
+  test('quoting invariant: quoted multi-word fields parse intact, bare single words positionally (D1/#118)', () => {
+    // The device quotes a value iff it contains a space (verified across
+    // all captured fixtures + hardware STR echoes, #104).
+    const quoted = parseSubObject("COL 0 401000b 0 'Black Hole' '' 3");
+    expect(quoted.statement).toBe('Black Hole');
+    expect(quoted.value).toBe('3'); // the hex child count lands in value
+
+    const bare = parseSubObject("COL 0 801000b 0 MetallicChamber '' 4");
+    expect(bare.statement).toBe('MetallicChamber');
+    expect(bare.value).toBe('4');
+
+    // Real capture: setup's count is hex 'f' (15 children) — no canary.
+    mockLog.mockClear();
+    const setup = parseSubObject("COL 0 10010000 10010000 'setup functions' setup f");
+    expect(setup.value).toBe('f');
+    expect(mockLog).not.toHaveBeenCalledWith(
+      expect.stringContaining('Suspect COL line'),
+      'error',
+      'error'
+    );
+  });
+
+  test('the COL hex-count canary logs loudly on a field shift (D1/#118)', () => {
+    // A hypothetical UNQUOTED multi-word statement shifts every field: the
+    // trailing slot stops being a hex count — the earliest detectable
+    // symptom, logged instead of silently corrupting downstream consumers.
+    mockLog.mockClear();
+    parseSubObject('COL 0 9990000 0 Two Words tag 3'); // 'tag' lands in the count slot
+    expect(mockLog).toHaveBeenCalledWith(
+      expect.stringContaining('Suspect COL line'),
+      'error',
+      'error'
+    );
+  });
+
   test('handles screen dump (bitmap) and calls renderBitmap', () => {
     // Mock SysEx: device 0, cmd 0x17 (screen dump), some nibbles
     const nibbles = [0x00, 0x01, 0x02, 0x03]; // Simplified even nibbles

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -445,6 +445,17 @@ describe('parseResponse', () => {
       'error',
       'error'
     );
+
+    // The motivating shape (review finding): a TWO-word unquoted name with
+    // a quoted-empty tag shifts '' into the count slot — empty must fire
+    // too (every observed COL line carries a count).
+    mockLog.mockClear();
+    parseSubObject("COL 0 401000b 0 Black Hole '' 0");
+    expect(mockLog).toHaveBeenCalledWith(
+      expect.stringContaining('Suspect COL line'),
+      'error',
+      'error'
+    );
   });
 
   test('handles screen dump (bitmap) and calls renderBitmap', () => {


### PR DESCRIPTION
Closes #118
Closes #119

## D1 — the multi-word-unquoted risk, resolved by proof + assert

The device quotes any value containing a space (and quotes empty values): verified across **all 52 captured fixture lines** and on hardware for multi-word STR puts (#104, quoted echoes). Positional splitLine parsing is therefore safe — no parser rewrite needed.

The assert: parseSubObject gains a **field-shift canary**. Every observed COL line ends in its hex child count (a discovery of this batch — setup reports 'f' = 15), so a non-hex **or missing** token in that slot logs loudly as the earliest symptom of an unquoted multi-word shift. The missing-token case matters: review found that a two-word unquoted name with a quoted-empty tag — the exact 'Black Hole' shape D1 worries about — shifts an empty token into the count slot, which a truthiness-guarded check would have missed. Both shifted shapes are test-pinned, and the honest scope is documented (COL-line breaks only; a break confined to a param line is not detected).

## D2 — type 8 defined with live evidence

Probed 10040000 directly: its OBJECTINFO returns only its own line (no children, no count field), its VALUE returns an empty value — an empty/reserved leaf; render-skip is correct. Now named **TYPE_EMPTY** in sysex-commands.js with the probe evidence, and every ad-hoc bare-'8' type literal (renderer pre-paint, parser warm-path filter, audit detector, fixture helper) references the constant. Type-8 lines stay in subs, so subsCount semantics are unchanged.

## Review

Combined correctness+docs reviewer ran; all three findings applied in 4ed49f1 (canary blind spot closed + pinned, coverage scope de-overclaimed, 'iff' wording corrected). Reviewer independently re-verified the 52-line/42-COL fixture evidence.

## Verification

164/164 tests; lint + format clean; device-model line-grammar and §8 updated; ledger Batch 4.1 closed.