### PR TITLE
test: offline golden screenshot regression (G2a)

### DIFF
--- a/build_tools/png-codec.js
+++ b/build_tools/png-codec.js
@@ -70,8 +70,12 @@ export function encodePNG(width, height, rgba) {
 
 /**
  * Decodes a PNG produced by encodePNG back to pixels. Throws on any shape
- * outside our encoder's subset (bit depth 8, RGBA, no interlace, filter 0
- * rows) — a golden that fails to decode is itself a regression signal.
+ * outside our encoder's subset (bit depth 8, RGBA, compression/filter
+ * method 0, no interlace, filter-0 rows) — a golden that fails to decode
+ * is itself a regression signal. Chunk CRCs are NOT validated: corruption
+ * confined to a CRC field decodes silently (pixels are the golden
+ * contract); corruption of the pixel data itself is still caught by
+ * zlib's adler-32 trailer or by the pixel comparison.
  *
  * @param {Buffer} buf
  * @returns {{width: number, height: number, rgba: Uint8ClampedArray}}
@@ -91,8 +95,10 @@ export function decodePNG(buf) {
     if (type === 'IHDR') {
       width = data.readUInt32BE(0);
       height = data.readUInt32BE(4);
-      if (data[8] !== 8 || data[9] !== 6 || data[12] !== 0) {
-        throw new Error('unsupported PNG shape (want 8-bit RGBA, no interlace)');
+      if (data[8] !== 8 || data[9] !== 6 || data[10] !== 0 || data[11] !== 0 || data[12] !== 0) {
+        throw new Error(
+          'unsupported PNG shape (want 8-bit RGBA, compression/filter method 0, no interlace)'
+        );
       }
     } else if (type === 'IDAT') {
       idatParts.push(data);

--- a/build_tools/png-codec.js
+++ b/build_tools/png-codec.js
@@ -1,0 +1,141 @@
+// build_tools/png-codec.js
+// Minimal PNG encode/decode for the screen-golden pipeline (G2/#45) —
+// extracted from render-screen.js so the CLI and the jest golden test share
+// one implementation. Scope: exactly the subset our encoder emits (8-bit
+// RGBA, no interlace, filter type 0 on every row); decodePNG throws on
+// anything else rather than guessing. Pixel-level comparison is the golden
+// contract — deflate output is NOT stable across Node/zlib versions, so
+// byte-comparing whole PNG files would be a false regression signal.
+
+import zlib from 'node:zlib';
+
+const CRC_TABLE = (() => {
+  const t = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    t[n] = c >>> 0;
+  }
+  return t;
+})();
+
+function crc32(buf) {
+  let c = 0xffffffff;
+  for (let i = 0; i < buf.length; i++) c = CRC_TABLE[(c ^ buf[i]) & 0xff] ^ (c >>> 8);
+  return (c ^ 0xffffffff) >>> 0;
+}
+
+function chunk(type, data) {
+  const len = Buffer.alloc(4);
+  len.writeUInt32BE(data.length, 0);
+  const typeBuf = Buffer.from(type, 'ascii');
+  const body = Buffer.concat([typeBuf, data]);
+  const crc = Buffer.alloc(4);
+  crc.writeUInt32BE(crc32(body), 0);
+  return Buffer.concat([len, body, crc]);
+}
+
+const PNG_SIG = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+/**
+ * Encodes 8-bit RGBA pixels as a PNG (filter 0, no interlace).
+ *
+ * @param {number} width
+ * @param {number} height
+ * @param {Uint8ClampedArray} rgba - width*height*4 bytes.
+ * @returns {Buffer}
+ */
+export function encodePNG(width, height, rgba) {
+  const sig = Buffer.from(PNG_SIG);
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(width, 0);
+  ihdr.writeUInt32BE(height, 4);
+  ihdr[8] = 8; // bit depth
+  ihdr[9] = 6; // color type RGBA
+  // 10,11,12 = compression, filter, interlace = 0
+  const stride = width * 4;
+  const raw = Buffer.alloc((stride + 1) * height);
+  for (let y = 0; y < height; y++) {
+    raw[y * (stride + 1)] = 0; // filter type 0 (none)
+    Buffer.from(rgba.buffer, rgba.byteOffset + y * stride, stride).copy(raw, y * (stride + 1) + 1);
+  }
+  const idat = zlib.deflateSync(raw);
+  return Buffer.concat([
+    sig,
+    chunk('IHDR', ihdr),
+    chunk('IDAT', idat),
+    chunk('IEND', Buffer.alloc(0)),
+  ]);
+}
+
+/**
+ * Decodes a PNG produced by encodePNG back to pixels. Throws on any shape
+ * outside our encoder's subset (bit depth 8, RGBA, no interlace, filter 0
+ * rows) — a golden that fails to decode is itself a regression signal.
+ *
+ * @param {Buffer} buf
+ * @returns {{width: number, height: number, rgba: Uint8ClampedArray}}
+ */
+export function decodePNG(buf) {
+  for (let i = 0; i < PNG_SIG.length; i++) {
+    if (buf[i] !== PNG_SIG[i]) throw new Error('not a PNG (bad signature)');
+  }
+  let off = PNG_SIG.length;
+  let width = 0;
+  let height = 0;
+  const idatParts = [];
+  while (off < buf.length) {
+    const len = buf.readUInt32BE(off);
+    const type = buf.toString('ascii', off + 4, off + 8);
+    const data = buf.subarray(off + 8, off + 8 + len);
+    if (type === 'IHDR') {
+      width = data.readUInt32BE(0);
+      height = data.readUInt32BE(4);
+      if (data[8] !== 8 || data[9] !== 6 || data[12] !== 0) {
+        throw new Error('unsupported PNG shape (want 8-bit RGBA, no interlace)');
+      }
+    } else if (type === 'IDAT') {
+      idatParts.push(data);
+    } else if (type === 'IEND') {
+      break;
+    }
+    off += 12 + len; // len + type + data + crc
+  }
+  const raw = zlib.inflateSync(Buffer.concat(idatParts));
+  const stride = width * 4;
+  const rgba = new Uint8ClampedArray(width * height * 4);
+  for (let y = 0; y < height; y++) {
+    const filter = raw[y * (stride + 1)];
+    if (filter !== 0) throw new Error(`unsupported PNG row filter ${filter} (want 0)`);
+    rgba.set(raw.subarray(y * (stride + 1) + 1, (y + 1) * (stride + 1)), y * stride);
+  }
+  return { width, height, rgba };
+}
+
+/**
+ * Nearest-neighbor integer upscale.
+ *
+ * @param {Uint8ClampedArray} rgba
+ * @param {number} w
+ * @param {number} h
+ * @param {number} factor
+ * @returns {{rgba: Uint8ClampedArray, width: number, height: number}}
+ */
+export function scale(rgba, w, h, factor) {
+  const sw = w * factor;
+  const sh = h * factor;
+  const out = new Uint8ClampedArray(sw * sh * 4);
+  for (let y = 0; y < sh; y++) {
+    const sy = Math.floor(y / factor);
+    for (let x = 0; x < sw; x++) {
+      const sx = Math.floor(x / factor);
+      const src = (sy * w + sx) * 4;
+      const dst = (y * sw + x) * 4;
+      out[dst] = rgba[src];
+      out[dst + 1] = rgba[src + 1];
+      out[dst + 2] = rgba[src + 2];
+      out[dst + 3] = rgba[src + 3];
+    }
+  }
+  return { rgba: out, width: sw, height: sh };
+}

--- a/build_tools/render-screen.js
+++ b/build_tools/render-screen.js
@@ -12,6 +12,7 @@
 
 import fs from 'node:fs';
 import { denibble, computePixels } from '../src/framebuffer.js';
+import { SYSEX } from '../src/sysex-commands.js';
 // Encoder/scaler shared with the screen-golden jest suite (G2/#45).
 import { encodePNG, scale } from './png-codec.js';
 
@@ -34,7 +35,7 @@ const frame = fs
   .trim()
   .split(/\s+/)
   .map((h) => parseInt(h, 16));
-const rawBytes = denibble(frame.slice(5, -1)); // strip F0 1C 70 dev 17 ... F7
+const rawBytes = denibble(frame.slice(SYSEX.FRAME_PREFIX_LEN, -1)); // strip F0 1C 70 dev 17 ... F7
 const pixels = computePixels(rawBytes, { width: SCREEN_W, height: SCREEN_H, header });
 const scaled = scale(pixels, SCREEN_W, SCREEN_H, factor);
 fs.writeFileSync(outFile, encodePNG(scaled.width, scaled.height, scaled.rgba));

--- a/build_tools/render-screen.js
+++ b/build_tools/render-screen.js
@@ -11,80 +11,12 @@
 // diagnosing future captures).
 
 import fs from 'node:fs';
-import zlib from 'node:zlib';
 import { denibble, computePixels } from '../src/framebuffer.js';
+// Encoder/scaler shared with the screen-golden jest suite (G2/#45).
+import { encodePNG, scale } from './png-codec.js';
 
 const SCREEN_W = 240;
 const SCREEN_H = 64;
-
-// ----- minimal PNG encoder (RGBA, 8-bit) -----------------------------------
-const CRC_TABLE = (() => {
-  const t = new Uint32Array(256);
-  for (let n = 0; n < 256; n++) {
-    let c = n;
-    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
-    t[n] = c >>> 0;
-  }
-  return t;
-})();
-
-function crc32(buf) {
-  let c = 0xffffffff;
-  for (let i = 0; i < buf.length; i++) c = CRC_TABLE[(c ^ buf[i]) & 0xff] ^ (c >>> 8);
-  return (c ^ 0xffffffff) >>> 0;
-}
-
-function chunk(type, data) {
-  const len = Buffer.alloc(4);
-  len.writeUInt32BE(data.length, 0);
-  const typeBuf = Buffer.from(type, 'ascii');
-  const body = Buffer.concat([typeBuf, data]);
-  const crc = Buffer.alloc(4);
-  crc.writeUInt32BE(crc32(body), 0);
-  return Buffer.concat([len, body, crc]);
-}
-
-function encodePNG(width, height, rgba) {
-  const sig = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
-  const ihdr = Buffer.alloc(13);
-  ihdr.writeUInt32BE(width, 0);
-  ihdr.writeUInt32BE(height, 4);
-  ihdr[8] = 8; // bit depth
-  ihdr[9] = 6; // color type RGBA
-  // 10,11,12 = compression, filter, interlace = 0
-  const stride = width * 4;
-  const raw = Buffer.alloc((stride + 1) * height);
-  for (let y = 0; y < height; y++) {
-    raw[y * (stride + 1)] = 0; // filter type 0 (none)
-    Buffer.from(rgba.buffer, rgba.byteOffset + y * stride, stride).copy(raw, y * (stride + 1) + 1);
-  }
-  const idat = zlib.deflateSync(raw);
-  return Buffer.concat([
-    sig,
-    chunk('IHDR', ihdr),
-    chunk('IDAT', idat),
-    chunk('IEND', Buffer.alloc(0)),
-  ]);
-}
-
-function scale(rgba, w, h, factor) {
-  const sw = w * factor;
-  const sh = h * factor;
-  const out = new Uint8ClampedArray(sw * sh * 4);
-  for (let y = 0; y < sh; y++) {
-    const sy = Math.floor(y / factor);
-    for (let x = 0; x < sw; x++) {
-      const sx = Math.floor(x / factor);
-      const src = (sy * w + sx) * 4;
-      const dst = (y * sw + x) * 4;
-      out[dst] = rgba[src];
-      out[dst + 1] = rgba[src + 1];
-      out[dst + 2] = rgba[src + 2];
-      out[dst + 3] = rgba[src + 3];
-    }
-  }
-  return { rgba: out, width: sw, height: sh };
-}
 
 // ----- main ----------------------------------------------------------------
 const [inFile, outFile, scaleArg, headerArg] = process.argv.slice(2);

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -695,12 +695,20 @@ HUMAN-GATE: none
 HUMAN-GATE: none
 
 ### Batch 5.2 — HIL screenshot regression + live self-loop   (GH #45)
-- [ ] G2  Offline golden-PNG screenshot regression on the 0.4 replay harness
-- [ ] G2  Live loop: drive Orville via MIDI masks -> 0x18 screengrab -> diff against golden.
+- [x] G2a (branch feat/golden-screen-regression) Offline golden screenshot regression SHIPPED:
+      tests/screen-golden.test.js decodes each captured 0x17 fixture (denibble -> parseScreenHeader
+      integrity -> computePixels) and compares PIXEL-EXACT against the 5 hardware-captured golden
+      PNGs (tests/fixtures/golden/, physical Orville 2026-06-08). Comparison is pixel-level, not
+      PNG-byte-level — deflate output is not stable across Node/zlib versions. The PNG codec is
+      extracted to build_tools/png-codec.js (encode + a strict subset decoder that throws on
+      foreign shapes), shared by render-screen.js (verified: refactored CLI output byte-identical
+      to the committed goldens) and the test. Fail-on-mutation verified (a flipped golden byte
+      fails exactly that screen, with a pixel-coordinate error message + regeneration pointer).
+- [ ] G2b Live loop: drive Orville via MIDI masks -> 0x18 screengrab -> diff against golden.
       Substrate already shipped: build_tools/live-app.mjs (real app headless against the device,
-      walk/load/eager/smoke modes) + tree-audit (per-node DOM diffing). What remains is the
-      golden-capture format + diff harness.
-HUMAN-GATE: needs-decision — live drive-the-physical-machine loop held until maintainer go signal
+      walk/load/eager/smoke/prog modes) + tree-audit (per-node DOM diffing) + hil-screenshot.cjs
+      (capture). What remains is the drive-grab-diff loop itself.
+HUMAN-GATE: needs-decision — live drive-the-physical-machine loop (G2b) held until maintainer go signal
 
 ---
 

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -702,8 +702,9 @@ HUMAN-GATE: none
       PNG-byte-level — deflate output is not stable across Node/zlib versions. The PNG codec is
       extracted to build_tools/png-codec.js (encode + a strict subset decoder that throws on
       foreign shapes), shared by render-screen.js (verified: refactored CLI output byte-identical
-      to the committed goldens) and the test. Fail-on-mutation verified (a flipped golden byte
-      fails exactly that screen, with a pixel-coordinate error message + regeneration pointer).
+      to the committed goldens) and the test. Fail-on-mutation verified (a flipped pixel-data byte
+      fails exactly that screen, with a pixel-coordinate error message + regeneration pointer;
+      chunk CRCs are deliberately not validated — pixels are the contract).
 - [ ] G2b Live loop: drive Orville via MIDI masks -> 0x18 screengrab -> diff against golden.
       Substrate already shipped: build_tools/live-app.mjs (real app headless against the device,
       walk/load/eager/smoke/prog modes) + tree-audit (per-node DOM diffing) + hil-screenshot.cjs

--- a/tests/fixtures/golden/README.md
+++ b/tests/fixtures/golden/README.md
@@ -12,8 +12,11 @@ tracker FB5).
 Each `screen-<name>.png` here is the expected render of the raw `0x17` capture in
 `tests/fixtures/screen-<name>.txt`, decoded by `build_tools/render-screen.js`
 (which shares `computePixels` from `src/framebuffer.js`). They are the reference
-set for the offline screenshot-regression net (issue G2): render the `.txt`
-fixture and byte-compare the PNG against the golden here.
+set for the offline screenshot-regression net (issue G2a, shipped):
+`tests/screen-golden.test.js` decodes both the fixture and the golden and
+compares **pixel-exact** — not whole-file PNG bytes, because deflate output is
+not stable across Node/zlib versions. The shared codec is
+`build_tools/png-codec.js`.
 
 Device state at capture: DSP A running **Black Hole**, DSP B **MetallicChamber**,
 device id 1, internal clock 48 kHz.

--- a/tests/screen-golden.test.js
+++ b/tests/screen-golden.test.js
@@ -1,0 +1,80 @@
+// tests/screen-golden.test.js — G2's offline half (#45).
+//
+// Screenshot regression: every captured 0x17 screen fixture must decode to
+// EXACTLY the pixels of its golden PNG (tests/fixtures/golden/ — canonical
+// 240x64 renders captured from the physical Orville, 2026-06-08). A diff
+// here means the framebuffer decode pipeline (denibble -> parseScreenHeader
+// -> computePixels) changed behavior; either it is a regression, or the
+// goldens must be intentionally regenerated via
+//   node build_tools/render-screen.js tests/fixtures/screen-<name>.txt tests/fixtures/golden/screen-<name>.png 1
+// in the same commit (see the golden README).
+//
+// Comparison is PIXEL-level, not PNG-byte-level: deflate output is not
+// stable across Node/zlib versions, so whole-file comparison would be a
+// false regression signal. decodePNG throws on anything outside our
+// encoder's subset — a golden that fails to decode is itself a failure.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { denibble, computePixels, parseScreenHeader } from '../src/framebuffer.js';
+import { decodePNG } from '../build_tools/png-codec.js';
+import { SCREEN, SYSEX } from '../src/sysex-commands.js';
+
+const FIXTURES = path.join(process.cwd(), 'tests', 'fixtures');
+const GOLDEN = path.join(FIXTURES, 'golden');
+
+// The golden set (see golden/README.md). screen-dump-black-hole.txt predates
+// the golden capture session and has no golden — it is covered by the replay
+// suite's framebuffer-to-ASCII decode instead.
+const GOLDEN_SCREENS = ['parameter', 'setup', 'program', 'levels', 'bypass'];
+
+const loadFrame = (file) =>
+  fs
+    .readFileSync(file, 'utf8')
+    .trim()
+    .split(/\s+/)
+    .map((h) => parseInt(h, 16));
+
+describe('screen-golden regression (G2 offline half, #45)', () => {
+  test.each(GOLDEN_SCREENS)('screen-%s decodes to its golden pixels', (name) => {
+    const frame = loadFrame(path.join(FIXTURES, `screen-${name}.txt`));
+    const rawBytes = denibble(frame.slice(SYSEX.FRAME_PREFIX_LEN, -1));
+
+    // The capture must still be internally sound — a corrupted fixture
+    // should fail loudly here, not as a confusing pixel diff.
+    const hdr = parseScreenHeader(rawBytes);
+    expect(hdr.dimsValid).toBe(true);
+    expect(hdr.complete).toBe(true);
+    expect(hdr.checksumOk).toBe(true);
+
+    const pixels = computePixels(rawBytes, {
+      width: SCREEN.WIDTH,
+      height: SCREEN.HEIGHT,
+      header: SCREEN.HEADER_BYTES,
+    });
+
+    const golden = decodePNG(fs.readFileSync(path.join(GOLDEN, `screen-${name}.png`)));
+    expect(golden.width).toBe(SCREEN.WIDTH);
+    expect(golden.height).toBe(SCREEN.HEIGHT);
+
+    // Pixel-exact or fail. On mismatch, report WHERE for debuggability
+    // instead of dumping two 61KB arrays.
+    const a = Buffer.from(pixels.buffer, pixels.byteOffset, pixels.byteLength);
+    const b = Buffer.from(golden.rgba.buffer, golden.rgba.byteOffset, golden.rgba.byteLength);
+    if (!a.equals(b)) {
+      let firstDiff = -1;
+      for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i]) {
+          firstDiff = i;
+          break;
+        }
+      }
+      const px = Math.floor(firstDiff / 4);
+      throw new Error(
+        `screen-${name}: render differs from golden starting at pixel (${px % SCREEN.WIDTH}, ${Math.floor(px / SCREEN.WIDTH)}) ` +
+          `(byte ${firstDiff}). If the decoder change is intentional, regenerate the golden ` +
+          `(see tests/fixtures/golden/README.md) in the same commit.`
+      );
+    }
+  });
+});


### PR DESCRIPTION
Ships the offline half of #45 (the live drive-grab-diff loop, G2b, stays open behind its needs-decision gate — so this PR does NOT close #45).

## What

**tests/screen-golden.test.js**: every captured 0x17 screen fixture must decode — denibble, parseScreenHeader integrity (dims/complete/checksum), computePixels — to **exactly** the pixels of its hardware-captured golden PNG (the 5 canonical 240x64 renders in tests/fixtures/golden/, captured from the physical Orville on 2026-06-08). A diff fails with the first differing pixel coordinate and a pointer to the regeneration command, so an intentional decoder change updates its goldens in the same commit.

Comparison is **pixel-level, not PNG-byte-level**: deflate output is not stable across Node/zlib versions. The hand-rolled PNG codec moved from render-screen.js into **build_tools/png-codec.js** (encoder + a strict subset decoder that throws on foreign shapes; chunk CRCs deliberately not validated — pixels are the contract, and zlib's adler-32 still catches pixel-data corruption), shared by the CLI and the test.

## Verification

- 169/169 tests (5 new golden comparisons).
- Refactor fidelity: all 5 CLI re-renders byte-identical to the committed goldens (reviewer independently reproduced with cmp).
- Fail-on-mutation: a flipped pixel-data byte fails exactly that screen.
- Reviewer findings all applied (stale README byte-compare wording, CRC-honesty docs, IHDR compression/filter strictness, FRAME_PREFIX_LEN constant).