### PR TITLE
feat: inbound SysEx boundary validation (#47)

### DIFF
--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -721,6 +721,16 @@ HUMAN-GATE: needs-decision — live drive-the-physical-machine loop (G2b) held u
       appState LIVE via change listeners — previously boot-init-only, so a mid-session toggle was
       a silent no-op until Save Config + reload (the defect characterized in the #48 status
       comment). Persistence still requires Save Config, as before.
+- [x] GH #47 (branch fix/inbound-length-validation-2, stacked on the #3/#48 branch) Inbound frame
+      validation at the boundary: midi.js inboundFrameError rejects — with a logged reason —
+      before parseResponse sees the bytes: non-Eventide manufacturer/product bytes (previously
+      NEVER checked; a foreign device sharing the port could half-parse — rejected at debug
+      severity, not error: sharing a port is not a malfunction), empty 0x32/0x2e payloads, and
+      0x17 dumps with odd nibble counts or shorter than the 12-byte header (so parseScreenHeader
+      cannot read garbage). Device-id matching stays in the parser (it ADOPTS the id when
+      configured 0); unknown commands pass through (rejecting would outlaw discovery captures).
+      A rejected frame never reaches notifyResponse — the wave watchdog self-heals. The FB6/FB7
+      reassembly was the other half of the original #47 scope, long shipped.
 HUMAN-GATE: none
 
 ---

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -48,9 +48,19 @@ tracker FB7); the CLI capture tool does the same (tracker FB5; see
 hardware-specific chunk sizes/timing). This applies to *all* inbound types
 (`0x17`, `0x2e`, `0x32`), not just screens.
 
+**Boundary validation (#47).** Every reassembled frame is validated before
+`parseResponse` sees it (`midi.js inboundFrameError`): Eventide
+manufacturer/product bytes (`1C 70`), non-empty `0x32`/`0x2e` payloads, and
+`0x17` nibble counts that are even and at least header-sized (24 nibbles).
+Foreign-manufacturer frames drop at debug severity (a shared port is not a
+malfunction); malformed Eventide frames log at error. Unknown commands pass
+through for discovery. A rejected frame never reaches `notifyResponse`; the
+wave watchdog self-heals.
+
 **Device ID.** The hardware uses 1–63. OrvilleCommander treats `0` as an
 auto-detect sentinel: on the first inbound message it adopts `data[3]` as the
-device ID, then matches on it thereafter.
+device ID, then matches on it thereafter. (Device-id matching deliberately
+stays in the parser, after boundary validation, because of this adoption.)
 
 ## Commands
 

--- a/src/midi.js
+++ b/src/midi.js
@@ -4,7 +4,7 @@ import { appState } from './state.js';
 import { setState } from './store.js';
 import { log } from './logger.js';
 import { emit } from './events.js';
-import { CMD, SYSEX } from './sysex-commands.js';
+import { CMD, SYSEX, SCREEN } from './sysex-commands.js';
 import { TIMING } from './constants.js';
 import { markDirtyIfStable, markAllStableDirty } from './tree.js';
 
@@ -190,6 +190,62 @@ export function isOutputConnected() {
 }
 
 /**
+ * Inbound frame validation (#47): the reason a complete F0..F7 frame must
+ * be REJECTED before parseResponse sees it, or null when it may pass.
+ * Checks the boundary invariants the parser assumes instead of validating:
+ * Eventide manufacturer/product bytes (previously never checked — a frame
+ * from another device on the same port could half-parse if its bytes
+ * happened to line up), a non-empty payload for the ASCII commands
+ * (0x32/0x2e), and a screen dump (0x17) with an even nibble count that at
+ * least covers the 12-byte header (so parseScreenHeader cannot read
+ * garbage). Device-id matching deliberately stays in the parser — it
+ * ADOPTS the id from the first frame when configured as 0. Unknown
+ * commands pass through: the parser ignores them, and rejecting them here
+ * would outlaw future discovery captures.
+ *
+ * Exported for tests; production callers go through addSysexListener.
+ *
+ * @param {number[]} frame - Complete frame, F0 ... F7.
+ * @returns {{reason: string, severity: 'error'|'debug'}|null} Rejection
+ *   with a log severity ('debug' for foreign-manufacturer frames — another
+ *   device sharing the port is not a malfunction), or null when valid.
+ */
+export function inboundFrameError(frame) {
+  // Smallest meaningful frame: prefix + F7 (an empty-payload command).
+  if (frame.length < SYSEX.FRAME_PREFIX_LEN + 1) {
+    return { reason: `frame too short (${frame.length} bytes)`, severity: 'error' };
+  }
+  if (frame[1] !== SYSEX.MANUFACTURER[0] || frame[2] !== SYSEX.MANUFACTURER[1]) {
+    return {
+      reason: `not an Eventide frame (manufacturer ${frame[1]?.toString(16)} ${frame[2]?.toString(16)})`,
+      severity: 'debug',
+    };
+  }
+  const cmd = frame[4];
+  const payloadLen = frame.length - SYSEX.FRAME_PREFIX_LEN - 1; // minus F7
+  if ((cmd === CMD.OBJECTINFO || cmd === CMD.VALUE_DUMP) && payloadLen < 1) {
+    return {
+      reason: `empty ${cmd === CMD.OBJECTINFO ? 'OBJECTINFO' : 'VALUE_DUMP'} payload`,
+      severity: 'error',
+    };
+  }
+  if (cmd === CMD.SCREEN_BITMAP) {
+    if (payloadLen % 2 !== 0) {
+      return { reason: `odd screen-dump nibble count (${payloadLen})`, severity: 'error' };
+    }
+    // Two nibbles per byte: the payload must at least cover the header so
+    // the dimension/size fields exist.
+    if (payloadLen < SCREEN.HEADER_BYTES * 2) {
+      return {
+        reason: `screen dump shorter than its header (${payloadLen} nibbles)`,
+        severity: 'error',
+      };
+    }
+  }
+  return null;
+}
+
+/**
  * Whether a request wave is currently open (responses outstanding). The
  * meter-poll gate (#107): the live saturation smoke measured poll ticks
  * joining waves faster than the 31250-baud link drains them — outstanding
@@ -267,7 +323,16 @@ export function addSysexListener() {
     // Flush only a properly framed message (starts F0, ends F7). The F0 guard
     // discards a stray continuation packet that arrives with no header.
     if (sysexBuffer[0] === SYSEX.START && sysexBuffer[sysexBuffer.length - 1] === SYSEX.END) {
-      parseResponse(sysexBuffer);
+      // #47: reject malformed frames at the boundary with a logged reason
+      // instead of letting them half-parse into state. A rejected frame
+      // never reaches notifyResponse; if it was the answer to a counted
+      // request, the wave watchdog self-heals.
+      const rejection = inboundFrameError(sysexBuffer);
+      if (rejection) {
+        log(`Rejected inbound SysEx (#47): ${rejection.reason}`, rejection.severity, 'error');
+      } else {
+        parseResponse(sysexBuffer);
+      }
       sysexBuffer = [];
     }
   };

--- a/tests/midi.test.js
+++ b/tests/midi.test.js
@@ -44,6 +44,7 @@ import {
   sendValuePut,
   sendKeypress,
   addSysexListener,
+  inboundFrameError,
 } from '../src/midi.js';
 import { parseResponse } from '../src/parser.js';
 import { on } from '../src/events.js';
@@ -388,12 +389,15 @@ describe('addSysexListener multi-packet reassembly', () => {
   });
 
   test('reassembles a SysEx split across packets and parses once on F7', () => {
-    handler({ data: [0xf0, 0x1c, 0x70, 1, 0x17, 0x01, 0x02] }); // header packet, no F7
+    // 0x32 fixture: reassembly mechanics are command-agnostic, and a tiny
+    // 0x17 payload would now (correctly) be rejected by the #47 boundary
+    // validation as shorter than the screen header.
+    handler({ data: [0xf0, 0x1c, 0x70, 1, 0x32, 0x41, 0x42] }); // header packet, no F7
     expect(parseResponse).not.toHaveBeenCalled();
-    handler({ data: [0x03, 0x04, 0xf7] }); // continuation + terminator
+    handler({ data: [0x43, 0x44, 0xf7] }); // continuation + terminator
     expect(parseResponse).toHaveBeenCalledTimes(1);
     expect(parseResponse).toHaveBeenCalledWith([
-      0xf0, 0x1c, 0x70, 1, 0x17, 0x01, 0x02, 0x03, 0x04, 0xf7,
+      0xf0, 0x1c, 0x70, 1, 0x32, 0x41, 0x42, 0x43, 0x44, 0xf7,
     ]);
   });
 
@@ -410,12 +414,13 @@ describe('addSysexListener multi-packet reassembly', () => {
   });
 
   test('reassembles a SysEx split across three packets', () => {
-    handler({ data: [0xf0, 0x1c, 0x70, 1, 0x17] }); // header
-    handler({ data: [0x01, 0x02] }); // middle continuation
+    // 0x32 fixture for the same reason as above (#47 boundary validation).
+    handler({ data: [0xf0, 0x1c, 0x70, 1, 0x32] }); // header
+    handler({ data: [0x41, 0x42] }); // middle continuation
     expect(parseResponse).not.toHaveBeenCalled();
-    handler({ data: [0x03, 0xf7] }); // final continuation + terminator
+    handler({ data: [0x43, 0xf7] }); // final continuation + terminator
     expect(parseResponse).toHaveBeenCalledTimes(1);
-    expect(parseResponse).toHaveBeenCalledWith([0xf0, 0x1c, 0x70, 1, 0x17, 0x01, 0x02, 0x03, 0xf7]);
+    expect(parseResponse).toHaveBeenCalledWith([0xf0, 0x1c, 0x70, 1, 0x32, 0x41, 0x42, 0x43, 0xf7]);
   });
 
   test('ignores a stray continuation packet (no F0 header) ending in F7', () => {
@@ -448,6 +453,66 @@ describe('addSysexListener multi-packet reassembly', () => {
 
     const msg = [0xf0, 0x1c, 0x70, 1, 0x2e, 0x41, 0xf7];
     newInput.listeners.forEach((cb) => cb({ data: msg }));
+    expect(parseResponse).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('inbound frame validation (#47)', () => {
+  const F = (bytes) => [0xf0, ...bytes, 0xf7];
+
+  test('accepts every known-good frame shape', () => {
+    expect(inboundFrameError(F([0x1c, 0x70, 1, 0x32, 0x43, 0x4f, 0x4c]))).toBeNull(); // OBJECTINFO 'COL'
+    expect(inboundFrameError(F([0x1c, 0x70, 1, 0x2e, 0x41]))).toBeNull(); // VALUE_DUMP
+    // Screen dump: header-sized even nibble payload.
+    expect(inboundFrameError(F([0x1c, 0x70, 1, 0x17, ...new Array(24).fill(0)]))).toBeNull();
+    // Unknown command: passes through (the parser ignores it; rejecting
+    // would outlaw discovery captures).
+    expect(inboundFrameError(F([0x1c, 0x70, 1, 0x99, 0x01]))).toBeNull();
+  });
+
+  test('rejects malformed Eventide frames at error severity', () => {
+    expect(inboundFrameError([0xf0, 0x1c, 0x70, 0xf7])).toMatchObject({ severity: 'error' }); // too short
+    expect(inboundFrameError(F([0x1c, 0x70, 1, 0x32]))).toMatchObject({
+      reason: expect.stringContaining('empty OBJECTINFO'),
+      severity: 'error',
+    });
+    expect(inboundFrameError(F([0x1c, 0x70, 1, 0x2e]))).toMatchObject({
+      reason: expect.stringContaining('empty VALUE_DUMP'),
+      severity: 'error',
+    });
+    expect(inboundFrameError(F([0x1c, 0x70, 1, 0x17, ...new Array(25).fill(0)]))).toMatchObject({
+      reason: expect.stringContaining('odd screen-dump nibble count'),
+      severity: 'error',
+    });
+    expect(inboundFrameError(F([0x1c, 0x70, 1, 0x17, ...new Array(22).fill(0)]))).toMatchObject({
+      reason: expect.stringContaining('shorter than its header'),
+      severity: 'error',
+    });
+  });
+
+  test('foreign-manufacturer frames reject at debug severity (shared port is not a malfunction)', () => {
+    expect(inboundFrameError(F([0x43, 0x10, 1, 0x32, 0x41]))).toMatchObject({
+      reason: expect.stringContaining('not an Eventide frame'),
+      severity: 'debug',
+    });
+  });
+
+  test('the listener drops rejected frames before parseResponse and keeps accepting after', () => {
+    let handler;
+    const input = {
+      addListener: (type, fn) => {
+        handler = fn;
+      },
+      removeListener: jest.fn(),
+    };
+    setMidiPorts({ sendSysex: jest.fn() }, input, 0);
+    addSysexListener();
+    parseResponse.mockClear();
+
+    handler({ data: [0xf0, 0x43, 0x10, 1, 0x32, 0x41, 0xf7] }); // foreign: dropped
+    expect(parseResponse).not.toHaveBeenCalled();
+
+    handler({ data: [0xf0, 0x1c, 0x70, 1, 0x32, 0x41, 0xf7] }); // valid: parsed
     expect(parseResponse).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Closes #47

Every reassembled F0..F7 frame is validated before parseResponse sees the bytes (midi.js inboundFrameError; rejected frames log their reason and drop at the boundary instead of half-parsing into state):

- **Eventide manufacturer/product bytes (1C 70)** — previously NEVER checked: a frame from another device sharing the port could half-parse if its bytes lined up. Foreign frames drop at **debug** severity (a shared port is not a malfunction; checked before the length test so even short foreign frames stay quiet); malformed Eventide frames log at **error**. Side benefit: a foreign frame arriving first can no longer poison deviceId-0 auto-adoption.
- **Non-empty payloads** for the ASCII commands (0x32 / 0x2e — the device never sends keyless ones; verified against docs and fixtures).
- **0x17 screen dumps**: even nibble count AND at least header-sized (24 nibbles), so parseScreenHeader can never read garbage dimensions.

Device-id matching stays in the parser (it ADOPTS the id when configured 0). Unknown commands pass through — rejecting would outlaw discovery captures. A rejected frame never reaches notifyResponse; the wave watchdog self-heals.

## Verification

- 179/179 tests (validator accept/reject matrix incl. the severity split and listener drop-and-continue; two reassembly tests switched fixtures from 0x17 to 0x32 since their tiny synthetic screen payloads are now correctly rejected).
- **Live walk** with validation active (logs/live-walk-47.log): landed on the preset, visited all four top menus, **zero rejected frames** — no false rejections of real traffic.
- Reviewer findings applied (manufacturer-before-length severity ordering). protocol.md documents the boundary.