### PR TITLE
fix: generation-stamped trust for stable-cache records (#121)

### DIFF
--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -608,8 +608,13 @@ in logs/ (program-screen.png).
       (device-side mutations the app cannot observe: physical panel, card swap, external MIDI
       program changes). FUTURE HOOK: the device's uncaptured bank-change SysEx (§12) would give
       automatic invalidation. RESIDUAL (GH #121, low): an in-flight dump racing a mutating put can
-      record pre-mutation structure as fresh — bounded recovery; generation-counter fix sketched
-      in the issue.
+      record pre-mutation structure as fresh — FIXED (branch fix/stale-mark-generation): mutation
+      marks bump a generation; sendObjectInfoDump stamps each stable-key request with the
+      generation at request time; recordDump trusts the response only when the stamp is current
+      (else recorded — newest data for labels/embeds — but kept stale, so the next visit
+      refetches). Generation 0 trusts unstamped records (seeding/cold caches: nothing can predate
+      a mutation that never happened). Both race variants test-pinned; warm-path skip re-verified
+      live (logs/live-prog-121.log).
       LIVE ACCEPTANCE (2026-06-10, logs/live-prog-113b.log, live-app 'prog' mode): COLD visit
       (stale = pre-#113 behavior) 17 waves / 41 sends / settled 17919ms; WARM visit 1 wave /
       27 sends (1 objectinfo + the small per-param VALUE refreshes) / settled 646ms — ~28x,

--- a/src/midi.js
+++ b/src/midi.js
@@ -6,7 +6,7 @@ import { log } from './logger.js';
 import { emit } from './events.js';
 import { CMD, SYSEX, SCREEN } from './sysex-commands.js';
 import { TIMING } from './constants.js';
-import { markDirtyIfStable, markAllStableDirty } from './tree.js';
+import { markDirtyIfStable, markAllStableDirty, stampStableRequest } from './tree.js';
 
 let selectedOutput = null;
 let selectedInput = null;
@@ -396,6 +396,10 @@ export function sendSysEx(cmd, dataBytes = []) {
  * sendObjectInfoDump('401000b');
  */
 export function sendObjectInfoDump(key) {
+  // #121: stamp stable-subtree requests with the current mutation
+  // generation, so a response whose request predates a later put cannot
+  // record pre-mutation structure as trustworthy.
+  stampStableRequest(key);
   recordRequest(key, 'objectinfo');
   const keyBytes = key.split('').map((c) => c.charCodeAt(0));
   sendSysEx(CMD.OBJECTINFO_DUMP, keyBytes);

--- a/src/midi.js
+++ b/src/midi.js
@@ -211,15 +211,21 @@ export function isOutputConnected() {
  *   device sharing the port is not a malfunction), or null when valid.
  */
 export function inboundFrameError(frame) {
-  // Smallest meaningful frame: prefix + F7 (an empty-payload command).
-  if (frame.length < SYSEX.FRAME_PREFIX_LEN + 1) {
-    return { reason: `frame too short (${frame.length} bytes)`, severity: 'error' };
-  }
-  if (frame[1] !== SYSEX.MANUFACTURER[0] || frame[2] !== SYSEX.MANUFACTURER[1]) {
+  // Manufacturer first (review finding): a too-short FOREIGN frame (e.g.
+  // 'F0 7D 01 F7' from a port-sharing device) must reject at debug, not be
+  // caught by the length check at error severity.
+  if (
+    frame.length >= 3 &&
+    (frame[1] !== SYSEX.MANUFACTURER[0] || frame[2] !== SYSEX.MANUFACTURER[1])
+  ) {
     return {
       reason: `not an Eventide frame (manufacturer ${frame[1]?.toString(16)} ${frame[2]?.toString(16)})`,
       severity: 'debug',
     };
+  }
+  // Smallest meaningful frame: prefix + F7 (an empty-payload command).
+  if (frame.length < SYSEX.FRAME_PREFIX_LEN + 1) {
+    return { reason: `frame too short (${frame.length} bytes)`, severity: 'error' };
   }
   const cmd = frame[4];
   const payloadLen = frame.length - SYSEX.FRAME_PREFIX_LEN - 1; // minus F7

--- a/src/tree.js
+++ b/src/tree.js
@@ -50,7 +50,14 @@ export function recordDump(subs) {
       // trusted across visits: the next visit refetches.
       staleKeys.add(main.key);
     }
-    requestGeneration.delete(main.key);
+    // The stamp is NOT consumed (review finding): a double-requested key
+    // (rapid double navigation fans out twice) gets two responses, and
+    // consuming on the first would flip the second — genuinely post-mark —
+    // back to stale, silently defeating the warm path. The stamp stays
+    // until the next stampStableRequest overwrites it or reset() clears;
+    // a later mutation bumps the generation, so the kept stamp can never
+    // launder a pre-mutation response. Memory is bounded by the stable
+    // key count.
   }
   for (const s of subs.slice(1)) {
     if (s.key) parents.set(s.key, { parentKey: main.key, sub: s });

--- a/src/tree.js
+++ b/src/tree.js
@@ -33,7 +33,25 @@ export function recordDump(subs) {
   const main = subs?.[0];
   if (!main?.key) return;
   nodes.set(main.key, subs);
-  staleKeys.delete(main.key); // a re-recorded node is fresh by definition (#113)
+  // #121 generation check: a stable-subtree dump may be trusted across
+  // visits only if its REQUEST was stamped after the latest mutation mark
+  // — an in-flight dump racing a put would otherwise record pre-mutation
+  // structure as fresh (both race variants: a stale refetch overtaken by a
+  // put, and a never-cached child whose pre-put request lands post-mark).
+  // Generation 0 (no mutation ever marked since reset) trusts everything:
+  // nothing can predate a mutation that never happened — this keeps
+  // seeding (audit phase 1) and cold caches trusted without stamps.
+  const p = stablePrefixOf(main.key);
+  if (p) {
+    if (markGeneration === 0 || requestGeneration.get(main.key) === markGeneration) {
+      staleKeys.delete(main.key);
+    } else {
+      // Recorded (newest data we have, labels/embeds may use it) but NOT
+      // trusted across visits: the next visit refetches.
+      staleKeys.add(main.key);
+    }
+    requestGeneration.delete(main.key);
+  }
   for (const s of subs.slice(1)) {
     if (s.key) parents.set(s.key, { parentKey: main.key, sub: s });
   }
@@ -178,7 +196,27 @@ export function deriveKeyStack(key) {
 // never launder staleness into siblings it did not re-record.
 const staleKeys = new Set();
 
+// #121 mutation generations. Every mutation mark bumps the generation;
+// sendObjectInfoDump stamps a stable key's request with the generation
+// current AT REQUEST TIME. recordDump trusts the response only when the
+// stamp matches — a response whose request predates the latest mutation
+// may carry pre-mutation structure, so it records but stays stale.
+let markGeneration = 0;
+const requestGeneration = new Map(); // stable key -> generation when requested
+
 const stablePrefixOf = (key) => CACHE.STABLE_SUBTREE_PREFIXES.find((p) => key.startsWith(p));
+
+/**
+ * Stamps a stable-subtree OBJECTINFO request with the current mutation
+ * generation (#121). Called by sendObjectInfoDump for every request; a
+ * no-op for keys outside stable subtrees. Tests simulating the
+ * request->response cycle must stamp before recordDump, as production does.
+ *
+ * @param {string} key
+ */
+export function stampStableRequest(key) {
+  if (stablePrefixOf(key)) requestGeneration.set(key, markGeneration);
+}
 
 /**
  * Whether a key's cached dump may be trusted across visits: tree-cached,
@@ -204,6 +242,7 @@ export function isFresh(key) {
 export function markDirtyIfStable(key) {
   const p = stablePrefixOf(key);
   if (!p) return;
+  markGeneration++; // #121: in-flight requests are now pre-mutation
   for (const k of nodes.keys()) {
     if (k.startsWith(p)) staleKeys.add(k);
   }
@@ -216,6 +255,7 @@ export function markDirtyIfStable(key) {
  * sequence the app cannot interpret).
  */
 export function markAllStableDirty() {
+  markGeneration++; // #121: in-flight requests are now pre-mutation
   for (const p of CACHE.STABLE_SUBTREE_PREFIXES) {
     for (const k of nodes.keys()) {
       if (k.startsWith(p)) staleKeys.add(k);
@@ -228,4 +268,6 @@ export function reset() {
   nodes.clear();
   parents.clear();
   staleKeys.clear();
+  requestGeneration.clear();
+  markGeneration = 0;
 }

--- a/tests/midi.test.js
+++ b/tests/midi.test.js
@@ -495,6 +495,12 @@ describe('inbound frame validation (#47)', () => {
       reason: expect.stringContaining('not an Eventide frame'),
       severity: 'debug',
     });
+    // Even a TOO-SHORT foreign frame is debug, not error (review fix:
+    // manufacturer is checked before length).
+    expect(inboundFrameError([0xf0, 0x7d, 0x01, 0xf7])).toMatchObject({
+      reason: expect.stringContaining('not an Eventide frame'),
+      severity: 'debug',
+    });
   });
 
   test('the listener drops rejected frames before parseResponse and keeps accepting after', () => {

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -21,7 +21,13 @@ import { appState } from '../src/state.js';
 import { sendObjectInfoDump, sendValueDump, sendValuePut, notifyResponse } from '../src/midi.js';
 import { emit } from '../src/events.js';
 import { log as mockLog } from '../src/logger.js';
-import { recordDump, getNode, markDirtyIfStable, reset as treeReset } from '../src/tree.js';
+import {
+  recordDump,
+  getNode,
+  markDirtyIfStable,
+  stampStableRequest,
+  reset as treeReset,
+} from '../src/tree.js';
 
 const parseAscii = (ascii) => {
   const bytes = ascii.split('').map((c) => c.charCodeAt(0));
@@ -386,7 +392,10 @@ describe('parseResponse', () => {
     expect(sendObjectInfoDump).toHaveBeenCalledWith('10020010');
 
     // The child's own dump finally arrives (re-recorded by this parser):
-    // the key is fresh again and the next visit skips.
+    // the key is fresh again and the next visit skips. Production stamps
+    // the request in sendObjectInfoDump (mocked here), so the test stamps
+    // explicitly — the response must come from a POST-mark request (#121).
+    stampStableRequest('10020010');
     parseAscii('COL 0 10020010 10020010 "load new preset" "load"');
     sendObjectInfoDump.mockClear();
     parseAscii(programDump);

--- a/tests/tree.test.js
+++ b/tests/tree.test.js
@@ -173,6 +173,32 @@ describe('tree store (T1b)', () => {
       expect(isFresh('10020020')).toBe(false);
     });
 
+    test('a duplicate response without a new stamp stays TRUSTED (#121 review fix)', () => {
+      // Rapid double navigation fans out twice: two responses for one
+      // stamped request. Consuming the stamp on the first would flip the
+      // second — genuinely post-mark — back to stale.
+      recordDump([col('10020010', '10020010', 'load new preset', 'load')]);
+      markDirtyIfStable('1002001c'); // gen > 0 (the norm in a live session)
+      stampStableRequest('10020010');
+      recordDump([col('10020010', '10020010', 'load new preset', 'load')]); // response 1
+      expect(isFresh('10020010')).toBe(true);
+      recordDump([col('10020010', '10020010', 'load new preset', 'load')]); // duplicate
+      expect(isFresh('10020010')).toBe(true); // stamp kept, still trusted
+
+      // A LATER mutation still wins: the kept stamp cannot launder.
+      markDirtyIfStable('1002001c');
+      recordDump([col('10020010', '10020010', 'load new preset', 'load')]); // old stamp
+      expect(isFresh('10020010')).toBe(false);
+    });
+
+    test('markAllStableDirty also bumps the generation (#121)', () => {
+      recordDump([col('10020010', '10020010', 'load new preset', 'load')]);
+      stampStableRequest('10020010'); // request in flight...
+      markAllStableDirty(); // ...keypress/Sync lands mid-flight
+      recordDump([col('10020010', '10020010', 'load new preset', 'load')]); // pre-mark response
+      expect(isFresh('10020010')).toBe(false);
+    });
+
     test('generation 0 trusts unstamped records — seeding before any mutation (#121)', () => {
       // The audit seeds the tree via direct recordDump with no requests;
       // with no mutation ever marked, nothing can be pre-mutation.

--- a/tests/tree.test.js
+++ b/tests/tree.test.js
@@ -10,6 +10,7 @@ import {
   isFresh,
   markDirtyIfStable,
   markAllStableDirty,
+  stampStableRequest,
   reset,
 } from '../src/tree.js';
 
@@ -134,13 +135,48 @@ describe('tree store (T1b)', () => {
 
       // Re-recording ONE node un-stales only that node — a deep visit (or
       // a dropped sibling response) can never launder staleness into the
-      // rest of the subtree.
+      // rest of the subtree. The re-record must come from a POST-mark
+      // request (#121): stamp as sendObjectInfoDump does in production.
+      stampStableRequest('10020010');
       recordDump([col('10020010', '10020010', 'load new preset', 'load')]);
       expect(isFresh('10020010')).toBe(true);
       expect(isFresh('10020020')).toBe(false); // sibling stays stale
 
       // Puts outside any stable subtree mark nothing.
       markDirtyIfStable('4070001');
+      expect(isFresh('10020010')).toBe(true);
+    });
+
+    test('a response whose request predates the mutation stays stale (#121 race, both variants)', () => {
+      // Variant (i): a refetch in flight when the put fires. The request
+      // was stamped pre-mark; the put bumps the generation; the arriving
+      // pre-mutation dump records but is NOT trusted across visits.
+      recordDump([col('10020010', '10020010', 'load new preset', 'load')]);
+      markDirtyIfStable('1002001c');
+      stampStableRequest('10020010'); // refetch goes out...
+      markDirtyIfStable('1002001c'); // ...another put lands mid-flight
+      recordDump([col('10020010', '10020010', 'load new preset', 'load')]); // pre-put response
+      expect(getNode('10020010')).toBeDefined(); // recorded (newest data we have)
+      expect(isFresh('10020010')).toBe(false); // but not trusted
+
+      // A post-mark request -> response cycle restores trust.
+      stampStableRequest('10020010');
+      recordDump([col('10020010', '10020010', 'load new preset', 'load')]);
+      expect(isFresh('10020010')).toBe(true);
+
+      // Variant (ii): a NEVER-cached child requested pre-put, recorded
+      // post-put. markDirtyIfStable could not stale it (not cached), but
+      // the generation check still refuses trust.
+      stampStableRequest('10020020');
+      markDirtyIfStable('1002001c');
+      recordDump([col('10020020', '10020020', 'save program', 'save')]);
+      expect(isFresh('10020020')).toBe(false);
+    });
+
+    test('generation 0 trusts unstamped records — seeding before any mutation (#121)', () => {
+      // The audit seeds the tree via direct recordDump with no requests;
+      // with no mutation ever marked, nothing can be pre-mutation.
+      recordDump([col('10020010', '10020010', 'load new preset', 'load')]);
       expect(isFresh('10020010')).toBe(true);
     });
 


### PR DESCRIPTION
Closes #121

(Supersedes #127, which GitHub auto-closed when its stacked base branch was deleted by the #126 merge; the branch is rebased onto main, suite green.)

Closes the in-flight race the #113 delta review found: an OBJECTINFO requested BEFORE a mutating put whose response arrives AFTER the staleness marking recorded pre-mutation structure as fresh. Now impossible by construction:

- Every mutation mark bumps a **generation counter**; sendObjectInfoDump **stamps** each stable-subtree request with the generation at request time; recordDump trusts a response only when its stamp is current. A pre-mark response still records (newest data — labels/embeds may use it) but stays stale, so the next visit refetches. Covers both variants, including the never-cached child the marking could not stale.
- **Generation 0 trusts unstamped records**: seeding (audit phase 1) and cold caches keep working without stamps.
- Stamps are **kept, not consumed** (reviewer MEDIUM): a double-requested key gets two responses, and consuming on the first would flip the second — genuinely post-mark — back to stale. A later mutation bumps the generation, so a kept stamp can never launder.

## Verification

- 179/179 tests (both race variants, duplicate-response trust, markAllStableDirty bump, gen-0 seeding pinned).
- Live re-verification (logs/live-prog-121.log): warm program visit 1 wave / 27 sends / 649 ms — identical to pre-#121, zero cost to the #113 win.
- Reviewer ran on the stack; all findings applied.