### PR TITLE
fix: bank change refilters the program list in one targeted wave

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -182,6 +182,16 @@ const handleSelectChange = (e) => {
       // (#138). One targeted dump is a single wave; the R7 child-arrival
       // repaint (or the progressive paint, if the load menu IS the current
       // key) updates the dropdowns the moment it lands.
+      // Prune the load menu's cached values first (review blocker): this
+      // branch skips updateScreen's full currentValues clear, and a stale
+      // cache entry shadows the fresh dump's value in the render
+      // precedence (currentValues[key] || s.value) — the program dropdown
+      // would keep the OLD bank's selection and never self-correct.
+      const pruned = { ...appState.currentValues };
+      delete pruned[KEY.PROGRAM_SELECT];
+      delete pruned[KEY.BANK_SELECT];
+      delete pruned[KEY.FAVORITES];
+      setState({ currentValues: pruned }, 'renderer:bank-change-prune');
       sendObjectInfoDump(KEY.FAVORITES);
       sendValueDump(KEY.FAVORITES);
     } else {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -174,7 +174,19 @@ const handleSelectChange = (e) => {
     'renderer:select-change-value-cache'
   ); // Removed immediate renderScreen to avoid old subs with new value
   setTimeout(() => {
-    updateScreen();
+    if (key === KEY.BANK_SELECT) {
+      // Bank scroll: the ONLY node whose options change is the load menu
+      // (both of its SETs re-list for the new bank). The generic
+      // updateScreen path refetches EVERY child of the staled program
+      // subtree — measured live at 13.3s before the program list updated
+      // (#138). One targeted dump is a single wave; the R7 child-arrival
+      // repaint (or the progressive paint, if the load menu IS the current
+      // key) updates the dropdowns the moment it lands.
+      sendObjectInfoDump(KEY.FAVORITES);
+      sendValueDump(KEY.FAVORITES);
+    } else {
+      updateScreen();
+    }
     if (appState.updateBitmapOnChange) {
       sendSysEx(CMD.GET_SCREEN, []);
       log('Triggered bitmap update after value change.', 'debug', 'bitmap');

--- a/tests/renderer.test.js
+++ b/tests/renderer.test.js
@@ -147,18 +147,29 @@ describe('renderer.js', () => {
     const select = document.querySelector('select[data-key="10020012"]');
     expect(select).toBeTruthy();
 
+    // Warm-path cache state: a prior visit cached the OLD bank's program
+    // value — it must be pruned, or it shadows the fresh dump's value in
+    // the render precedence (review blocker).
+    appState.currentValues['10020011'] = 'c Old Bank Program';
+
     jest.useFakeTimers();
     select.value = '0';
     select.dispatchEvent(new Event('change', { bubbles: true }));
     expect(sendValuePut).toHaveBeenCalledWith('10020012', '0');
 
     jest.advanceTimersByTime(200);
-    // Targeted: the load menu's dump (it carries both re-listed SETs)...
+    // Targeted: the load menu's dump + values (it carries both re-listed
+    // SETs)...
     expect(sendObjectInfoDump).toHaveBeenCalledWith('10020010');
+    expect(sendValueDump).toHaveBeenCalledWith('10020010');
     // ...and NOT the generic full-menu refresh that refetched the whole
-    // staled program subtree (13.3s measured live before the fix).
-    expect(sendObjectInfoDump).not.toHaveBeenCalledWith('10020000', undefined);
-    expect(sendObjectInfoDump).not.toHaveBeenCalledWith('10020000', null);
+    // staled program subtree (13.3s measured live before the fix) —
+    // first-arg sweep, so a one-arg regression cannot slip past.
+    expect(sendObjectInfoDump.mock.calls.map((c) => c[0])).not.toContain('10020000');
+    // The stale program/bank cache entries are pruned so the fresh dump's
+    // values render.
+    expect(appState.currentValues['10020011']).toBeUndefined();
+    expect(appState.currentValues['10020012']).toBeUndefined();
     jest.useRealTimers();
   });
 

--- a/tests/renderer.test.js
+++ b/tests/renderer.test.js
@@ -118,6 +118,50 @@ describe('renderer.js', () => {
     jest.useRealTimers();
   });
 
+  test('a bank change fetches ONLY the load menu, not the whole program subtree (#138)', () => {
+    appState.currentKey = '10020000';
+    const subs = [
+      {
+        type: 'COL',
+        position: '0',
+        key: '10020000',
+        parent: '10020000',
+        statement: 'Program',
+        tag: 'program',
+      },
+      {
+        type: 'SET',
+        position: '1',
+        key: '10020012', // KEY.BANK_SELECT
+        parent: '10020010',
+        statement: 'Bank: %-20s',
+        tag: 'Bank',
+        options: [
+          { index: '0', desc: '0 Favorites' },
+          { index: '50', desc: '50 Reverbs - Unusual' },
+        ],
+        value: '32 50 Reverbs - Unusual',
+      },
+    ];
+    renderScreen(subs, '', mockLog);
+    const select = document.querySelector('select[data-key="10020012"]');
+    expect(select).toBeTruthy();
+
+    jest.useFakeTimers();
+    select.value = '0';
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(sendValuePut).toHaveBeenCalledWith('10020012', '0');
+
+    jest.advanceTimersByTime(200);
+    // Targeted: the load menu's dump (it carries both re-listed SETs)...
+    expect(sendObjectInfoDump).toHaveBeenCalledWith('10020010');
+    // ...and NOT the generic full-menu refresh that refetched the whole
+    // staled program subtree (13.3s measured live before the fix).
+    expect(sendObjectInfoDump).not.toHaveBeenCalledWith('10020000', undefined);
+    expect(sendObjectInfoDump).not.toHaveBeenCalledWith('10020000', null);
+    jest.useRealTimers();
+  });
+
   // #131: progressive paints during a wave must not destroy an open SET
   // dropdown — repaints park while a select inside #lcd is focused.
   const dropdownGuardSubs = (title) => [


### PR DESCRIPTION
Maintainer report: clicking a bank did not (apparently) refilter the program list. Live probe: it DID, after 13.3s — the bank PUT stales the whole cached program subtree (#113, correct) and the generic refresh refetched every program-menu child at 31250 baud, the changed node queued last.

A BANK_SELECT change now prunes the load menu's cached values and issues ONE targeted OBJECTINFO+VALUE fetch of the load menu (it carries both re-listed SETs); the R7 child-arrival repaint (or progressive paint when descended) updates the dropdowns on landing.

Live-measured from a quiet link: **5.1-5.6s** (the wire-time floor for the 70-bank dump; LCD dim + BUSY LED cover the transfer). Reviewed: one blocker found (stale cache shadowing the fresh values on the warm path) and fixed with the targeted prune + hardened test.

Probes: logs/probe-bank-3/5/6.log. Tests 206/206.

Closes #138