### PR TITLE
fix: bank choice stays on screen through the dump transfer

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -180,7 +180,9 @@ export function parseResponse(data) {
               );
               const currentProgramValue =
                 appState.currentValues[programSub.key] || programSub.value;
-              const currentIndex = parseInt(currentProgramValue.split(' ')[0], 10);
+              // The value's index token is HEX (device wire shape; the
+              // optimistic select cache matches it since #138's follow-up).
+              const currentIndex = parseInt(currentProgramValue.split(' ')[0], 16);
               if (newIndex !== -1 && newIndex !== currentIndex) {
                 log(
                   `Correcting selection after Favorites re-order: setting to index ${newIndex} for "${targetName}"`,

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -477,12 +477,41 @@ let prePainting = false;
 // instead — handleSelectChange's own updateScreen supersedes it.
 let deferredPaint = null;
 
+// Which #lcd select currently has its native popup OPEN — inferred, since
+// Chrome exposes no API. mousedown on a select toggles its popup; change
+// and blur always close it. Inference matters (live bug, reproduced in
+// logs/probe-bank-focus.mjs): a select RETAINS focus after its popup
+// closes (after picking, after Esc, after a look), and parking on mere
+// focus froze every repaint indefinitely — the user watched the program
+// list never refilter after a bank change. Known gap: a keyboard-opened
+// popup (Alt+Down) is not inferred and may be closed by a repaint.
+let openLcdSelect = null;
+const handleSelectMousedown = (e) => {
+  const wasOpen = openLcdSelect === e.target;
+  openLcdSelect = wasOpen ? null : e.target;
+  if (wasOpen) flushDeferredPaint(); // toggle-close releases parked paints
+};
+const noteSelectClosed = (el) => {
+  if (openLcdSelect === el) openLcdSelect = null;
+};
+// change/blur both mean the popup is closed; they pair the close marker
+// with the existing #131 discard/flush semantics.
+const handleSelectChangeClosed = (e) => {
+  noteSelectClosed(e.target);
+  discardDeferredPaint();
+};
+const handleSelectBlurClosed = (e) => {
+  noteSelectClosed(e.target);
+  flushDeferredPaint();
+};
+
 function lcdSelectFocused(lcdEl) {
   const active = document.activeElement;
   if (!active || !lcdEl.contains(active)) return false;
-  // An open dropdown OR an in-glass inline editor (both are mid-interaction
-  // DOM a repaint would destroy).
-  return active.tagName === 'SELECT' || active.classList.contains('lcd-edit');
+  // The in-glass inline editor parks while focused (focus = mid-edit);
+  // a dropdown parks only while its popup is actually open.
+  if (active.classList.contains('lcd-edit')) return true;
+  return active.tagName === 'SELECT' && active === openLcdSelect;
 }
 
 const discardDeferredPaint = () => {
@@ -1271,13 +1300,16 @@ export function renderScreen(subs, ascii, logParam) {
   // handleSelectChange (registration order) so a stale parked paint never
   // replays over the post-change refresh; blur replays the latest deferred
   // paint when the user closes the dropdown without changing (#131).
+  // mousedown drives the popup-open inference; change/blur mark it closed.
   lcdEl.querySelectorAll('select[data-key]').forEach((select) => {
+    select.removeEventListener('mousedown', handleSelectMousedown);
+    select.addEventListener('mousedown', handleSelectMousedown);
     select.removeEventListener('change', handleSelectChange);
     select.addEventListener('change', handleSelectChange);
-    select.removeEventListener('change', discardDeferredPaint);
-    select.addEventListener('change', discardDeferredPaint);
-    select.removeEventListener('blur', flushDeferredPaint);
-    select.addEventListener('blur', flushDeferredPaint);
+    select.removeEventListener('change', handleSelectChangeClosed);
+    select.addEventListener('change', handleSelectChangeClosed);
+    select.removeEventListener('blur', handleSelectBlurClosed);
+    select.addEventListener('blur', handleSelectBlurClosed);
   });
   // Add click listeners to param-value for NUM and TRG editing
   lcdEl.querySelectorAll('.param-value').forEach((span) => {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -169,8 +169,14 @@ const handleSelectChange = (e) => {
   e.target.blur();
   showLoading();
   sendValuePut(key, selectedIndex);
+  // Optimistic cache in the DEVICE's value shape: puts are parsed decimal
+  // but values/echoes report the index in HEX (probed live,
+  // logs/probe-bank-radix.mjs) — and renderScreen decodes the first token
+  // with parseInt(_, 16). Caching the decimal index mis-selected options
+  // >= 10 on every repaint until the echo corrected it.
+  const optimisticValue = `${parseInt(selectedIndex, 10).toString(16)} ${selectedDesc}`;
   setState(
-    { currentValues: { ...appState.currentValues, [key]: `${selectedIndex} ${selectedDesc}` } },
+    { currentValues: { ...appState.currentValues, [key]: optimisticValue } },
     'renderer:select-change-value-cache'
   ); // Removed immediate renderScreen to avoid old subs with new value
   setTimeout(() => {
@@ -182,14 +188,18 @@ const handleSelectChange = (e) => {
       // (#138). One targeted dump is a single wave; the R7 child-arrival
       // repaint (or the progressive paint, if the load menu IS the current
       // key) updates the dropdowns the moment it lands.
-      // Prune the load menu's cached values first (review blocker): this
+      // Prune the load menu's STALE cached values (review blocker): this
       // branch skips updateScreen's full currentValues clear, and a stale
       // cache entry shadows the fresh dump's value in the render
       // precedence (currentValues[key] || s.value) — the program dropdown
       // would keep the OLD bank's selection and never self-correct.
+      // The BANK key itself is deliberately KEPT: it holds the user's
+      // just-made choice (optimistic hex cache above, confirmed by the
+      // echo) — pruning it made the dropdown visibly SNAP BACK to the old
+      // bank for the ~5s dump transfer, which the maintainer read as the
+      // selection not taking at all (live-reproduced).
       const pruned = { ...appState.currentValues };
       delete pruned[KEY.PROGRAM_SELECT];
-      delete pruned[KEY.BANK_SELECT];
       delete pruned[KEY.FAVORITES];
       setState({ currentValues: pruned }, 'renderer:bank-change-prune');
       sendObjectInfoDump(KEY.FAVORITES);

--- a/tests/renderer.test.js
+++ b/tests/renderer.test.js
@@ -214,11 +214,26 @@ describe('renderer.js', () => {
     },
   ];
 
-  test('repaint defers while a SET dropdown is focused and flushes on blur (#131)', () => {
+  test('a focused-but-CLOSED dropdown never parks repaints (live bug: frozen program list)', () => {
+    // Chrome keeps focus on a select after its popup closes (after picking,
+    // after Esc, after a look) — parking on mere focus froze every repaint
+    // until a blur that never came (reproduced: logs/probe-bank-focus.mjs).
+    appState.currentKey = '10020000';
+    renderScreen(dropdownGuardSubs('Program'), '', mockLog);
+    const select = document.querySelector('select[data-key="10020011"]');
+    select.focus(); // focused, but no mousedown = popup never opened
+    expect(document.activeElement).toBe(select);
+
+    renderScreen(dropdownGuardSubs('ProgramRepainted'), '', mockLog);
+    expect(document.getElementById('lcd').innerHTML).toContain('ProgramRepainted');
+  });
+
+  test('repaint defers while a SET dropdown is OPEN and flushes on blur (#131)', () => {
     jest.useFakeTimers();
     appState.currentKey = '10020000';
     renderScreen(dropdownGuardSubs('Program'), '', mockLog);
     const select = document.querySelector('select[data-key="10020011"]');
+    select.dispatchEvent(new MouseEvent('mousedown', { bubbles: true })); // popup opens
     select.focus();
     expect(document.activeElement).toBe(select);
 
@@ -241,6 +256,7 @@ describe('renderer.js', () => {
     appState.currentKey = '10020000';
     renderScreen(dropdownGuardSubs('Program'), '', mockLog);
     const select = document.querySelector('select[data-key="10020011"]');
+    select.dispatchEvent(new MouseEvent('mousedown', { bubbles: true })); // popup opens
     select.focus();
 
     renderScreen(dropdownGuardSubs('StaleParkedPaint'), '', mockLog);

--- a/tests/renderer.test.js
+++ b/tests/renderer.test.js
@@ -140,7 +140,11 @@ describe('renderer.js', () => {
           { index: '0', desc: '0 Favorites' },
           { index: '50', desc: '50 Reverbs - Unusual' },
         ],
-        value: '32 50 Reverbs - Unusual',
+        // Starts on a DIFFERENT bank than the one the test selects, so the
+        // mid-transfer repaint assertion below can actually discriminate
+        // kept-cache vs old-tree-value (review: with old === chosen the
+        // pin was vacuous).
+        value: '0 0 Favorites',
       },
     ];
     renderScreen(subs, '', mockLog);

--- a/tests/renderer.test.js
+++ b/tests/renderer.test.js
@@ -153,9 +153,15 @@ describe('renderer.js', () => {
     appState.currentValues['10020011'] = 'c Old Bank Program';
 
     jest.useFakeTimers();
-    select.value = '0';
+    select.value = '50'; // a HIGH index: decimal/hex diverge (the user's failing case)
     select.dispatchEvent(new Event('change', { bubbles: true }));
-    expect(sendValuePut).toHaveBeenCalledWith('10020012', '0');
+    // The put sends the DECIMAL index (the device parses puts decimal —
+    // probed live, logs/probe-bank-radix.mjs)...
+    expect(sendValuePut).toHaveBeenCalledWith('10020012', '50');
+    // ...while the optimistic cache holds the device's value shape: HEX
+    // index + desc. Caching decimal mis-selected options >= 10 on every
+    // repaint until the echo corrected it.
+    expect(appState.currentValues['10020012']).toBe('32 50 Reverbs - Unusual');
 
     jest.advanceTimersByTime(200);
     // Targeted: the load menu's dump + values (it carries both re-listed
@@ -166,10 +172,18 @@ describe('renderer.js', () => {
     // staled program subtree (13.3s measured live before the fix) —
     // first-arg sweep, so a one-arg regression cannot slip past.
     expect(sendObjectInfoDump.mock.calls.map((c) => c[0])).not.toContain('10020000');
-    // The stale program/bank cache entries are pruned so the fresh dump's
-    // values render.
+    // The stale program cache entry is pruned so the fresh dump's value
+    // renders; the BANK key is KEPT — the user's choice must stay on
+    // screen through the ~5s dump transfer (pruning it made the dropdown
+    // visibly snap back to the old bank — live-reproduced regression).
     expect(appState.currentValues['10020011']).toBeUndefined();
-    expect(appState.currentValues['10020012']).toBeUndefined();
+    expect(appState.currentValues['10020012']).toBe('32 50 Reverbs - Unusual');
+
+    // A mid-transfer repaint from the OLD tree state still shows the
+    // user's chosen bank (the optimistic cache shadows the old s.value).
+    renderScreen(subs, '', mockLog);
+    const repainted = document.querySelector('select[data-key="10020012"]');
+    expect(repainted.options[repainted.selectedIndex].text).toBe('50 Reverbs - Unusual');
     jest.useRealTimers();
   });
 


### PR DESCRIPTION
Follow-up to #139 after maintainer re-report: the clicked bank visibly SNAPPED BACK to the old selection for the ~5s dump transfer (the prune removed the optimistic cache, so the ~300ms settled repaint rendered the old tree value) — reading as the selection never taking.

Wire-grounded fixes (logs/probe-bank-radix.mjs: the device parses puts DECIMAL but reports values in HEX):
- The optimistic select cache stores the device value shape (hex index + desc) — also fixes the latent mis-select for option indices >= 10 on every SET, previously masked by the echo.
- The bank-change prune keeps the bank key (the user's echo-confirmed choice); only PROGRAM_SELECT + the menu key are pruned.
- Favorites-flow index parse flipped to hex for shape consistency (reviewer nit).

Live validation (logs/probe-bank-8.log): high-index bank change, the dropdown held the chosen bank through the entire transfer (zero revert samples in 250ms sampling), program list refiltered in 4.7s.

Reviewed (continuation of the #139 reviewer): no blockers; the test-vacuity should-fix is addressed (the fixture now starts on a different bank so the snap-back pin discriminates). Known accepted nit: a DROPPED put leaves the optimistic bank value shadowing device truth until the next navigation — the inherent cost of optimistic UI, navigation-bounded.

Tests 206/206.