### PR TITLE
feat: per-bank program-list memo + honest loading state

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -43,6 +43,8 @@ export const LAYOUT = {
 export const RENDER = {
   VALUE_PLACEHOLDER: '...',
   LOADING_STATEMENT: 'loading ...',
+  LOADING_PROGRAMS: 'loading programs ...', // the program field while an unseen
+  //                   bank's list is on the wire (#141) — never the old bank's list
   INDICATOR_BAR_CELLS: 8, // max bar width for spec-less indicator CONs: the only live-observed
   //                         case (the Tempo 'Beat' flasher) is binary 0/1, and a full-LCD-width
   //                         flashing slab overwhelmed the page (maintainer report, external-clock

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -11,6 +11,7 @@ import {
   findParamUnder,
   labelForSub,
   isGangCol,
+  bankProgramsFor,
   GANG_MAX_DEPTH,
 } from './tree.js';
 import { log } from './logger.js';
@@ -204,6 +205,11 @@ const handleSelectChange = (e) => {
       setState({ currentValues: pruned }, 'renderer:bank-change-prune');
       sendObjectInfoDump(KEY.FAVORITES);
       sendValueDump(KEY.FAVORITES);
+      // Paint NOW (#141, live finding): puts do not join waves, so without
+      // an explicit repaint nothing paints until the targeted dump drains
+      // (~4-5s) — the program field's memo (revisited bank, instant) or
+      // loading line (unseen bank) must show immediately.
+      renderScreen(appState.currentSubs, appState.lastAscii);
     } else {
       updateScreen();
     }
@@ -654,6 +660,28 @@ function renderGangInline(colSub, depth, paramLines, paramHtmlLines, logParam) {
   }
 }
 
+// Program-select view resolution (#141): the device's load-menu dump
+// carries ONLY the currently-selected bank's program list, so when the
+// user's chosen bank (optimistic/echo cache) differs from the bank the
+// dump was taken in, the dump's options are the OLD bank's — never show
+// them. Serve the session memo (tree.js) when this bank has been seen,
+// else an honest loading line until the targeted dump lands ("its the
+// fact we keep the old stuff around thats the issue" — maintainer).
+// Returns: {stale:false} = render the dump as usual; {loading:true} =
+// render RENDER.LOADING_PROGRAMS; {options,value} = render the memo.
+function programSelectView(s, siblings) {
+  if (s.key !== KEY.PROGRAM_SELECT) return { stale: false };
+  const chosenRaw = appState.currentValues[KEY.BANK_SELECT];
+  const bankSub = siblings.find((x) => x.key === KEY.BANK_SELECT);
+  if (!chosenRaw || !bankSub?.value) return { stale: false };
+  const chosen = parseInt(String(chosenRaw).split(' ')[0], 16);
+  const inDump = parseInt(String(bankSub.value).split(' ')[0], 16);
+  if (isNaN(chosen) || isNaN(inDump) || chosen === inDump) return { stale: false };
+  const memo = bankProgramsFor(chosen);
+  if (memo) return { stale: true, options: memo.options, value: memo.value };
+  return { stale: true, loading: true };
+}
+
 export function renderScreen(subs, ascii, logParam) {
   const lcdEl = document.getElementById('lcd');
   if (!subs || subs.length === 0) {
@@ -854,23 +882,35 @@ export function renderScreen(subs, ascii, logParam) {
         fullText = formatValue(s.statement, value); // Use updated formatValue with s support
         fullHtml = fullText;
       } else if (s.type === 'SET') {
-        let value = appState.currentValues[s.key] || s.value || '';
-        if (appState.currentValues[s.key] === undefined && !s.value) sendValueDump(s.key, logParam);
-        let displayValue = value;
-        let indexHex = '0';
-        if (value) {
-          indexHex = value.split(' ')[0];
-          displayValue = value.substring(indexHex.length + 1);
+        const progView = programSelectView(s, subs.slice(1));
+        if (progView.loading) {
+          // #141: the chosen bank's list is on the wire and unseen — an
+          // honest loading line, never the old bank's options.
+          fullText = RENDER.LOADING_PROGRAMS;
+          fullHtml = fullText;
+        } else {
+          const options = progView.options ?? s.options;
+          let value = progView.stale
+            ? progView.value
+            : appState.currentValues[s.key] || s.value || '';
+          if (!progView.stale && appState.currentValues[s.key] === undefined && !s.value)
+            sendValueDump(s.key, logParam);
+          let displayValue = value;
+          let indexHex = '0';
+          if (value) {
+            indexHex = value.split(' ')[0];
+            displayValue = value.substring(indexHex.length + 1);
+          }
+          const indexDec = parseInt(indexHex, 16).toString(10);
+          fullText = formatValue(s.statement || '', displayValue); // Use formatValue for %-width s
+          let selectHtml = `<select data-key="${s.key}" class="param-select">`;
+          options.forEach((option) => {
+            const isSelected = option.index === indexDec;
+            selectHtml += `<option value="${option.index}" ${isSelected ? 'selected' : ''}>${option.desc}</option>`;
+          });
+          selectHtml += `</select>`;
+          fullHtml = (s.statement || '').replace(/%(-)?(\d*)s/g, selectHtml);
         }
-        const indexDec = parseInt(indexHex, 16).toString(10);
-        fullText = formatValue(s.statement || '', displayValue); // Use formatValue for %-width s
-        let selectHtml = `<select data-key="${s.key}" class="param-select">`;
-        s.options.forEach((option) => {
-          const isSelected = option.index === indexDec;
-          selectHtml += `<option value="${option.index}" ${isSelected ? 'selected' : ''}>${option.desc}</option>`;
-        });
-        selectHtml += `</select>`;
-        fullHtml = (s.statement || '').replace(/%(-)?(\d*)s/g, selectHtml);
       } else if (s.type === 'CON') {
         let meterValue = parseFloat(appState.currentValues[s.key] || s.value) || 0;
         if (isNaN(meterValue)) {
@@ -996,24 +1036,34 @@ export function renderScreen(subs, ascii, logParam) {
             childFullText = formatValue(cs.statement, value);
             childFullHtml = childFullText;
           } else if (cs.type === 'SET') {
-            let value = appState.currentValues[cs.key] || cs.value || '';
-            if (appState.currentValues[cs.key] === undefined && !cs.value)
-              sendValueDump(cs.key, logParam);
-            let displayValue = value;
-            let indexHex = '0';
-            if (value) {
-              indexHex = value.split(' ')[0];
-              displayValue = value.substring(indexHex.length + 1);
+            const progView = programSelectView(cs, childSubs.slice(1));
+            if (progView.loading) {
+              // #141: honest loading line — never the old bank's options.
+              childFullText = RENDER.LOADING_PROGRAMS;
+              childFullHtml = childFullText;
+            } else {
+              const options = progView.options ?? cs.options;
+              let value = progView.stale
+                ? progView.value
+                : appState.currentValues[cs.key] || cs.value || '';
+              if (!progView.stale && appState.currentValues[cs.key] === undefined && !cs.value)
+                sendValueDump(cs.key, logParam);
+              let displayValue = value;
+              let indexHex = '0';
+              if (value) {
+                indexHex = value.split(' ')[0];
+                displayValue = value.substring(indexHex.length + 1);
+              }
+              const indexDec = parseInt(indexHex, 16).toString(10);
+              childFullText = formatValue(cs.statement || '', displayValue);
+              let selectHtml = `<select data-key="${cs.key}" class="param-select">`;
+              options.forEach((option) => {
+                const isSelected = option.index === indexDec;
+                selectHtml += `<option value="${option.index}" ${isSelected ? 'selected' : ''}>${option.desc}</option>`;
+              });
+              selectHtml += `</select>`;
+              childFullHtml = (cs.statement || '').replace(/%(-)?(\d*)s/g, selectHtml);
             }
-            const indexDec = parseInt(indexHex, 16).toString(10);
-            childFullText = formatValue(cs.statement || '', displayValue);
-            let selectHtml = `<select data-key="${cs.key}" class="param-select">`;
-            cs.options.forEach((option) => {
-              const isSelected = option.index === indexDec;
-              selectHtml += `<option value="${option.index}" ${isSelected ? 'selected' : ''}>${option.desc}</option>`;
-            });
-            selectHtml += `</select>`;
-            childFullHtml = (cs.statement || '').replace(/%(-)?(\d*)s/g, selectHtml);
           } else if (cs.type === 'CON') {
             let meterValue = parseFloat(appState.currentValues[cs.key] || cs.value) || 0;
             if (isNaN(meterValue)) {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -203,6 +203,10 @@ const handleSelectChange = (e) => {
       delete pruned[KEY.PROGRAM_SELECT];
       delete pruned[KEY.FAVORITES];
       setState({ currentValues: pruned }, 'renderer:bank-change-prune');
+      // Wipe-proof copy of the choice (#141 review): currentValues can be
+      // cleared mid-transfer by any updateScreen; programSelectView falls
+      // back to this until the load-menu dump converges.
+      chosenBankIdx = parseInt(selectedIndex, 10);
       sendObjectInfoDump(KEY.FAVORITES);
       sendValueDump(KEY.FAVORITES);
       // Paint NOW (#141, live finding): puts do not join waves, so without
@@ -662,21 +666,39 @@ function renderGangInline(colSub, depth, paramLines, paramHtmlLines, logParam) {
 
 // Program-select view resolution (#141): the device's load-menu dump
 // carries ONLY the currently-selected bank's program list, so when the
-// user's chosen bank (optimistic/echo cache) differs from the bank the
-// dump was taken in, the dump's options are the OLD bank's — never show
-// them. Serve the session memo (tree.js) when this bank has been seen,
-// else an honest loading line until the targeted dump lands ("its the
-// fact we keep the old stuff around thats the issue" — maintainer).
+// user's chosen bank differs from the bank the dump was taken in, the
+// dump's options are the OLD bank's — never show them. Serve the session
+// memo (tree.js) when this bank has been seen, else an honest loading
+// line until the targeted dump lands ("its the fact we keep the old
+// stuff around thats the issue" — maintainer).
 // Returns: {stale:false} = render the dump as usual; {loading:true} =
 // render RENDER.LOADING_PROGRAMS; {options,value} = render the memo.
+//
+// The chosen bank lives in MODULE state, not only the optimistic cache
+// (review): a program pick from the memoized list runs the generic
+// updateScreen refresh, which wipes currentValues wholesale mid-transfer
+// — the cache-only check then fell back to the dump and repainted the
+// old bank's list. Set by the bank-change handler; self-clears when the
+// load-menu dump converges on the chosen bank.
+let chosenBankIdx = null;
+
+/** Clears the chosen-bank module state (tests). */
+export function resetProgramSelectView() {
+  chosenBankIdx = null;
+}
+
 function programSelectView(s, siblings) {
   if (s.key !== KEY.PROGRAM_SELECT) return { stale: false };
-  const chosenRaw = appState.currentValues[KEY.BANK_SELECT];
   const bankSub = siblings.find((x) => x.key === KEY.BANK_SELECT);
-  if (!chosenRaw || !bankSub?.value) return { stale: false };
-  const chosen = parseInt(String(chosenRaw).split(' ')[0], 16);
+  if (!bankSub?.value) return { stale: false };
+  const cachedRaw = appState.currentValues[KEY.BANK_SELECT];
+  const cached = cachedRaw ? parseInt(String(cachedRaw).split(' ')[0], 16) : NaN;
+  const chosen = !isNaN(cached) ? cached : chosenBankIdx;
   const inDump = parseInt(String(bankSub.value).split(' ')[0], 16);
-  if (isNaN(chosen) || isNaN(inDump) || chosen === inDump) return { stale: false };
+  if (chosen === null || isNaN(inDump) || chosen === inDump) {
+    if (chosen !== null && chosen === inDump) chosenBankIdx = null; // converged
+    return { stale: false };
+  }
   const memo = bankProgramsFor(chosen);
   if (memo) return { stale: true, options: memo.options, value: memo.value };
   return { stale: true, loading: true };
@@ -890,8 +912,10 @@ export function renderScreen(subs, ascii, logParam) {
           fullHtml = fullText;
         } else {
           const options = progView.options ?? s.options;
+          // Stale branch: a program the user just picked from the memoized
+          // list (optimistic cache) beats the memo's remembered selection.
           let value = progView.stale
-            ? progView.value
+            ? appState.currentValues[s.key] || progView.value
             : appState.currentValues[s.key] || s.value || '';
           if (!progView.stale && appState.currentValues[s.key] === undefined && !s.value)
             sendValueDump(s.key, logParam);
@@ -1043,8 +1067,10 @@ export function renderScreen(subs, ascii, logParam) {
               childFullHtml = childFullText;
             } else {
               const options = progView.options ?? cs.options;
+              // A just-picked program (optimistic cache) beats the memo's
+              // remembered selection — same rule as the top-level branch.
               let value = progView.stale
-                ? progView.value
+                ? appState.currentValues[cs.key] || progView.value
                 : appState.currentValues[cs.key] || cs.value || '';
               if (!progView.stale && appState.currentValues[cs.key] === undefined && !cs.value)
                 sendValueDump(cs.key, logParam);

--- a/src/tree.js
+++ b/src/tree.js
@@ -69,13 +69,22 @@ export function recordDump(subs) {
   for (const s of subs.slice(1)) {
     if (s.key) parents.set(s.key, { parentKey: main.key, sub: s });
   }
-  // #141: memoize the program list under the bank it was listed FOR.
-  if (main.key === KEY.FAVORITES) {
+  // #141: memoize the program list under the bank it was listed FOR —
+  // gated by the SAME #121 generation trust as the structure check above
+  // (review): an in-flight pre-mutation dump (e.g. racing a program-load
+  // trigger that reorders Favorites) must not launder a pre-load list
+  // into the memo.
+  if (
+    main.key === KEY.FAVORITES &&
+    (markGeneration === 0 || requestGeneration.get(main.key) === markGeneration)
+  ) {
     const bankSub = subs.find((s) => s.key === KEY.BANK_SELECT);
     const progSub = subs.find((s) => s.key === KEY.PROGRAM_SELECT);
     const bankIdx = parseInt(String(bankSub?.value || '').split(' ')[0], 16);
     if (!isNaN(bankIdx) && progSub?.options?.length) {
-      bankProgramLists.set(bankIdx, { options: progSub.options, value: progSub.value });
+      // Shallow copy: the memo must hold its own snapshot, independent of
+      // the treat-as-read-only tree node it came from.
+      bankProgramLists.set(bankIdx, { options: [...progSub.options], value: progSub.value });
     }
   }
 }

--- a/src/tree.js
+++ b/src/tree.js
@@ -15,9 +15,16 @@
 // (currentKey, the derived keyStack) stays on appState.
 
 import { LAYOUT, CACHE } from './constants.js';
+import { KEY } from './sysex-commands.js';
 
 // key -> subs array (the node's own dump: main line + direct children).
 const nodes = new Map();
+// Per-bank program lists (#141): bankIdx (int) -> { options, value } from
+// the load-menu dump taken while that bank was selected. The device only
+// exposes ONE bank's program list at a time, so this session memo is the
+// only way a revisited bank can render instantly. Cleared by every
+// mutation chokepoint (program saves/deletes change the lists).
+const bankProgramLists = new Map();
 // childKey -> { parentKey, sub } where sub is the child's line in the
 // parent's dump (carries the authoritative tag/statement for labeling even
 // before the child's own dump has loaded).
@@ -62,6 +69,26 @@ export function recordDump(subs) {
   for (const s of subs.slice(1)) {
     if (s.key) parents.set(s.key, { parentKey: main.key, sub: s });
   }
+  // #141: memoize the program list under the bank it was listed FOR.
+  if (main.key === KEY.FAVORITES) {
+    const bankSub = subs.find((s) => s.key === KEY.BANK_SELECT);
+    const progSub = subs.find((s) => s.key === KEY.PROGRAM_SELECT);
+    const bankIdx = parseInt(String(bankSub?.value || '').split(' ')[0], 16);
+    if (!isNaN(bankIdx) && progSub?.options?.length) {
+      bankProgramLists.set(bankIdx, { options: progSub.options, value: progSub.value });
+    }
+  }
+}
+
+/**
+ * The memoized program list for a bank index, if this session has seen it
+ * (#141). { options, value } as captured from the load-menu dump.
+ *
+ * @param {number} bankIdx
+ * @returns {{options: Object[], value: string}|undefined}
+ */
+export function bankProgramsFor(bankIdx) {
+  return bankProgramLists.get(bankIdx);
 }
 
 /**
@@ -311,6 +338,15 @@ export function markDirtyIfStable(key) {
   for (const k of nodes.keys()) {
     if (k.startsWith(p)) staleKeys.add(k);
   }
+  // #141: selection puts (the bank/program choosers) are pure VIEW
+  // changes — they cannot alter any bank's program list, and the bank put
+  // is the very action the memo exists to accelerate (live finding: the
+  // unconditional clear wiped the memo on every bank change, defeating
+  // it). Everything else under the prefix (saves, deletes, renames, load
+  // triggers) may rewrite lists: clear.
+  if (key !== KEY.BANK_SELECT && key !== KEY.PROGRAM_SELECT) {
+    bankProgramLists.clear();
+  }
 }
 
 /**
@@ -326,6 +362,7 @@ export function markAllStableDirty() {
       if (k.startsWith(p)) staleKeys.add(k);
     }
   }
+  bankProgramLists.clear(); // #141: explicit re-read distrusts the memo too
 }
 
 /** Clears the tree (tests). */
@@ -334,5 +371,6 @@ export function reset() {
   parents.clear();
   staleKeys.clear();
   requestGeneration.clear();
+  bankProgramLists.clear();
   markGeneration = 0;
 }

--- a/tests/renderer.test.js
+++ b/tests/renderer.test.js
@@ -3,7 +3,12 @@ import { appState } from '../src/state.js';
 import { sendObjectInfoDump, sendValueDump, sendValuePut, sendSysEx } from '../src/midi.js';
 import { showLoading } from '../src/main.js';
 import { log as mockLog } from '../src/logger.js';
-import { recordDump, reset as treeReset } from '../src/tree.js';
+import {
+  recordDump,
+  markAllStableDirty,
+  markDirtyIfStable,
+  reset as treeReset,
+} from '../src/tree.js';
 
 jest.mock('../src/midi.js', () => ({
   sendObjectInfoDump: jest.fn(),
@@ -189,6 +194,121 @@ describe('renderer.js', () => {
     const repainted = document.querySelector('select[data-key="10020012"]');
     expect(repainted.options[repainted.selectedIndex].text).toBe('50 Reverbs - Unusual');
     jest.useRealTimers();
+  });
+
+  // #141: per-bank program-list memo + honest loading. The device's dump
+  // carries only the CURRENT bank's program list; a chosen bank that
+  // differs from the dump's bank renders its memoized list (seen this
+  // session) or a loading line — never the old bank's options.
+  const loadMenuDump = (bankValue, programs) => [
+    {
+      type: 'COL',
+      position: '0',
+      key: '10020010',
+      parent: '10020010',
+      statement: 'load new preset',
+      tag: 'load',
+    },
+    {
+      type: 'SET',
+      position: '1',
+      key: '10020012',
+      parent: '10020010',
+      statement: 'Bank: %-20s',
+      tag: 'Bank',
+      options: [
+        { index: '0', desc: '0 Favorites' },
+        { index: '5', desc: '5 Delays' },
+        { index: '50', desc: '50 Reverbs - Unusual' },
+      ],
+      value: bankValue,
+    },
+    {
+      type: 'SET',
+      position: '2',
+      key: '10020011',
+      parent: '10020010',
+      statement: '%-20s',
+      tag: 'Program',
+      options: programs.map((desc, i) => ({ index: `${i}`, desc })),
+      value: `0 ${programs[0]}`,
+    },
+  ];
+  const programMenu = [
+    {
+      type: 'COL',
+      position: '0',
+      key: '10020000',
+      parent: '10020000',
+      statement: 'program functions',
+      tag: 'program',
+    },
+    {
+      type: 'COL',
+      position: '0',
+      key: '10020010',
+      parent: '10020000',
+      statement: 'load new preset',
+      tag: 'load',
+    },
+  ];
+
+  test('program field renders the memoized list for a revisited bank (#141)', () => {
+    appState.currentKey = '10020000';
+    recordDump(programMenu);
+    recordDump(loadMenuDump('0 0 Favorites', ['0 Techno Rumble', '1 St DistortionTwo']));
+    // The device switched to bank 50; its dump is now the tree's latest.
+    recordDump(loadMenuDump('32 50 Reverbs - Unusual', ['10 Adaptive Reverb', '11 AlienShift']));
+
+    // The user re-chooses bank 0 (optimistic hex cache) — its list was
+    // seen this session, so it renders INSTANTLY from the memo.
+    appState.currentValues['10020012'] = '0 0 Favorites';
+    renderScreen(programMenu, '', mockLog);
+    const progSel = document.querySelector('select[data-key="10020011"]');
+    expect([...progSel.options].map((o) => o.text)).toEqual([
+      '0 Techno Rumble',
+      '1 St DistortionTwo',
+    ]);
+  });
+
+  test('program field shows LOADING for an unseen bank — never the old list (#141)', () => {
+    appState.currentKey = '10020000';
+    recordDump(programMenu);
+    recordDump(loadMenuDump('32 50 Reverbs - Unusual', ['10 Adaptive Reverb', '11 AlienShift']));
+
+    // The user chooses bank 5, never seen this session.
+    appState.currentValues['10020012'] = '5 5 Delays';
+    renderScreen(programMenu, '', mockLog);
+    expect(document.querySelector('select[data-key="10020011"]')).toBeNull();
+    expect(document.getElementById('lcd').textContent).toContain('loading programs ...');
+    expect(document.getElementById('lcd').textContent).not.toContain('Adaptive Reverb');
+  });
+
+  test('a bank-selection put does NOT clear the memo — it is the action the memo accelerates (#141)', () => {
+    appState.currentKey = '10020000';
+    recordDump(programMenu);
+    recordDump(loadMenuDump('0 0 Favorites', ['0 Techno Rumble']));
+    recordDump(loadMenuDump('32 50 Reverbs - Unusual', ['10 Adaptive Reverb']));
+    markDirtyIfStable('10020012'); // the bank put's own chokepoint call
+
+    appState.currentValues['10020012'] = '0 0 Favorites';
+    renderScreen(programMenu, '', mockLog);
+    const progSel = document.querySelector('select[data-key="10020011"]');
+    expect(progSel).toBeTruthy();
+    expect([...progSel.options].map((o) => o.text)).toEqual(['0 Techno Rumble']);
+  });
+
+  test('mutation chokepoints clear the bank memo (#141)', () => {
+    appState.currentKey = '10020000';
+    recordDump(programMenu);
+    recordDump(loadMenuDump('0 0 Favorites', ['0 Techno Rumble']));
+    recordDump(loadMenuDump('32 50 Reverbs - Unusual', ['10 Adaptive Reverb']));
+    markAllStableDirty(); // e.g. a keypress or reconnect — lists may have changed
+
+    appState.currentValues['10020012'] = '0 0 Favorites';
+    renderScreen(programMenu, '', mockLog);
+    // Memo gone: honest loading, not the (possibly stale) remembered list.
+    expect(document.getElementById('lcd').textContent).toContain('loading programs ...');
   });
 
   // #131: progressive paints during a wave must not destroy an open SET

--- a/tests/renderer.test.js
+++ b/tests/renderer.test.js
@@ -1,4 +1,4 @@
-import { renderScreen } from '../src/renderer.js';
+import { renderScreen, resetProgramSelectView } from '../src/renderer.js';
 import { appState } from '../src/state.js';
 import { sendObjectInfoDump, sendValueDump, sendValuePut, sendSysEx } from '../src/midi.js';
 import { showLoading } from '../src/main.js';
@@ -57,6 +57,7 @@ describe('renderer.js', () => {
     consoleLogSpy.mockClear();
 
     document.body.innerHTML = '<div id="lcd"></div>';
+    resetProgramSelectView();
   });
 
   afterEach(() => {
@@ -282,6 +283,59 @@ describe('renderer.js', () => {
     expect(document.querySelector('select[data-key="10020011"]')).toBeNull();
     expect(document.getElementById('lcd').textContent).toContain('loading programs ...');
     expect(document.getElementById('lcd').textContent).not.toContain('Adaptive Reverb');
+  });
+
+  test('the memo is keyed by the HEX bank index — a high bank revisits correctly (#141 review)', () => {
+    appState.currentKey = '10020000';
+    recordDump(programMenu);
+    // Bank 50's dump carries value token '32' (hex) — the memo key and
+    // the chosen-bank parse must agree on radix or bank >= 10 never hits.
+    recordDump(loadMenuDump('32 50 Reverbs - Unusual', ['10 Adaptive Reverb', '11 AlienShift']));
+    recordDump(loadMenuDump('0 0 Favorites', ['0 Techno Rumble']));
+
+    appState.currentValues['10020012'] = '32 50 Reverbs - Unusual';
+    renderScreen(programMenu, '', mockLog);
+    const progSel = document.querySelector('select[data-key="10020011"]');
+    expect([...progSel.options].map((o) => o.text)).toEqual([
+      '10 Adaptive Reverb',
+      '11 AlienShift',
+    ]);
+  });
+
+  test('the top-level SET branch (descended into the load menu) resolves the memo too (#141 review)', () => {
+    recordDump(loadMenuDump('0 0 Favorites', ['0 Techno Rumble']));
+    const bank50Dump = loadMenuDump('32 50 Reverbs - Unusual', ['10 Adaptive Reverb']);
+    recordDump(bank50Dump);
+
+    appState.currentKey = '10020010'; // user descended into the load menu
+    appState.currentValues['10020012'] = '0 0 Favorites'; // chose Favorites; dump is bank 50
+    renderScreen(bank50Dump, '', mockLog);
+    const progSel = document.querySelector('select[data-key="10020011"]');
+    expect([...progSel.options].map((o) => o.text)).toEqual(['0 Techno Rumble']);
+  });
+
+  test('the chosen bank survives a currentValues wipe mid-transfer (#141 review)', () => {
+    appState.currentKey = '10020000';
+    recordDump(programMenu);
+    recordDump(loadMenuDump('32 50 Reverbs - Unusual', ['10 Adaptive Reverb']));
+    recordDump(loadMenuDump('0 0 Favorites', ['0 Techno Rumble']));
+    // The dump in the tree is now bank 0; the user picks bank 50 through
+    // the REAL select path (sets the wipe-proof module state).
+    renderScreen(programMenu, '', mockLog);
+    const bankSel = document.querySelector('select[data-key="10020012"]');
+    jest.useFakeTimers();
+    bankSel.value = '50';
+    bankSel.dispatchEvent(new Event('change', { bubbles: true }));
+    jest.advanceTimersByTime(200);
+
+    // A program pick (or any refresh) wipes currentValues wholesale —
+    // the old-bank list must STILL not repaint (review: the cache-only
+    // check fell back to the dump here).
+    appState.currentValues = {};
+    renderScreen(programMenu, '', mockLog);
+    const progSel = document.querySelector('select[data-key="10020011"]');
+    expect([...progSel.options].map((o) => o.text)).toEqual(['10 Adaptive Reverb']);
+    jest.useRealTimers();
   });
 
   test('a bank-selection put does NOT clear the memo — it is the action the memo accelerates (#141)', () => {


### PR DESCRIPTION
Maintainer direction after the bank fixes: cache program lists per bank (the device only exposes one bank's list at a time), and when the chosen bank's list is unknown, SHOW that it is loading — never the old bank's stale list.

- tree.js bankProgramLists memo, populated from every load-menu dump (#121 generation-gated; own snapshot), cleared by mutation chokepoints EXCEPT the bank/program selection puts (pure view changes — the unconditional clear was wiping the memo on every bank change, found live).
- renderer.js programSelectView: chosen bank (optimistic cache, backed by wipe-proof module state) vs the dump's bank — memo hit renders instantly, miss renders 'loading programs ...'. Wired into both SET branches; the bank-change branch paints immediately (puts don't join waves — nothing else repaints for ~5s, found live).
- Reviewed; all should-fixes addressed (generation gate, wipe-proof choice, hex-radix + top-level-branch + wipe-survival tests).

Live acceptance (logs/probe-bank-memo3/4.log): unseen bank -> loading line, old list gone, ~4s wire floor; revisited bank -> **217-220ms**.

Tests 214/214.

Closes #141