### PR TITLE
feat: preset library sync + name search

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -110,6 +110,20 @@ export function saveThemeConfig(theme) {
   log(`Theme saved: ${theme.preset}`, 'debug', 'general');
 }
 
+/**
+ * Persists the synced preset library (#142) into midiConfig without
+ * touching the rest — banks/programs change rarely, so the library lives
+ * until the user re-syncs.
+ *
+ * @param {{banks: Object[], syncedAt: string}} library
+ */
+export function saveLibraryConfig(library) {
+  const existing = readStoredConfig();
+  existing.presetLibrary = library;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(existing));
+  log(`Preset library saved (${library.banks.length} banks)`, 'info', 'general');
+}
+
 // Stored config, tolerating corruption (review): the read-modify-write
 // savers must remain the self-healing path — a corrupt midiConfig string
 // becomes an empty object and the next save overwrites it, instead of

--- a/src/constants.js
+++ b/src/constants.js
@@ -91,6 +91,23 @@ export const KNOB = {
   //                              from bursting keypresses onto the 31250-baud link (review)
 };
 
+// Library sync + preset search (#142, src/library.js).
+export const LIBRARY = {
+  BANK_SETTLE_MS: 600, // wait after a bank PUT before requesting the load-menu
+  //                      dump: the device needs to re-list its program SET
+  //                      first (the #138 probes showed echoes inside ~100ms;
+  //                      600ms is a comfortable multiple, still negligible
+  //                      next to the ~4s dump transfer per bank)
+  BANK_DUMP_TIMEOUT_MS: 15000, // give up on one bank's dump and move on: well
+  //                              past the ~4-5s live-measured transfer, so it
+  //                              only fires on a genuinely dropped response
+  SEARCH_MAX_RESULTS: 24, // results dropdown cap — about a screenful; typing
+  //                         more letters narrows better than scrolling
+  LOAD_SETTLE_MS: 600, // wait between the search-load sequence's puts (bank ->
+  //                      program -> load trigger): same settle rationale as
+  //                      BANK_SETTLE_MS, applied to each step
+};
+
 // Demo mode (src/demo.js): the canned device built from a live capture.
 export const DEMO = {
   REPLY_LATENCY_MS: 25, // per-reply delay so the dump-wave lifecycle (BUSY

--- a/src/index.html
+++ b/src/index.html
@@ -32,6 +32,26 @@
           Demo Mode
         </button>
         <span class="conn-spacer"></span>
+        <!-- Preset library (#142): search across every synced bank; Sync
+             Library scans all banks (several minutes) and persists. -->
+        <span class="search-wrap">
+          <input
+            id="preset-search"
+            class="util-input util-search"
+            placeholder="Search presets (sync first)"
+            autocomplete="off"
+            spellcheck="false"
+          />
+          <div id="search-results" class="search-results" hidden></div>
+        </span>
+        <button
+          id="sync-library"
+          class="util-btn"
+          title="Scan every bank's program list so search covers the whole unit (several minutes)"
+        >
+          Sync Library
+        </button>
+        <span class="conn-spacer"></span>
         <button id="save-config" class="util-btn">Save Config</button>
         <button id="clear-config" class="util-btn">Clear Config</button>
       </header>

--- a/src/library.js
+++ b/src/library.js
@@ -12,7 +12,7 @@
 // wire shape), name is the option desc as listed.
 
 import { appState } from './state.js';
-import { sendValuePut, sendObjectInfoDump, sendValueDump } from './midi.js';
+import { sendValuePut, sendObjectInfoDump, sendValueDump, isOutputConnected } from './midi.js';
 import { KEY, KEY_PREFIX } from './sysex-commands.js';
 import { LIBRARY } from './constants.js';
 import { getNode, bankProgramsFor } from './tree.js';
@@ -30,8 +30,12 @@ export function getLibrary() {
   return library;
 }
 
-/** Hydrates the library from persisted config (boot). */
+/** Hydrates the library from persisted config (boot); null clears (tests). */
 export function setLibrary(persisted) {
+  if (persisted === null) {
+    library = null;
+    return;
+  }
   if (persisted?.banks?.length) library = persisted;
 }
 
@@ -88,6 +92,10 @@ export function isSyncing() {
  */
 export async function syncLibrary(onProgress) {
   if (syncing) return null;
+  if (!isOutputConnected()) {
+    log('Library sync: no MIDI output connected', 'error', 'error');
+    return null;
+  }
   const loadMenu = getNode(KEY.FAVORITES);
   const bankSub = loadMenu?.find((s) => s.key === KEY.BANK_SELECT);
   if (!bankSub?.options?.length) {
@@ -136,7 +144,15 @@ export async function syncLibrary(onProgress) {
     syncing = false;
   }
   if (banks.length === 0) return null;
-  library = { syncedAt: new Date().toISOString(), banks };
+  // MERGE over the existing library (review): a cancel at bank 5/70 or a
+  // dropped bank must never replace a previous full library with a
+  // partial one — fresh entries overlay, everything else is kept.
+  const merged = new Map((library?.banks || []).map((b) => [b.idx, b]));
+  for (const bank of banks) merged.set(bank.idx, bank);
+  library = {
+    syncedAt: new Date().toISOString(),
+    banks: [...merged.values()].sort((a, b) => parseInt(a.idx, 10) - parseInt(b.idx, 10)),
+  };
   return library;
 }
 
@@ -149,10 +165,22 @@ export async function syncLibrary(onProgress) {
  *   caller refreshes the screen / root names).
  */
 export async function loadSearchHit(hit, onDone) {
+  if (syncing) {
+    // The scan owns the bank selection: a load interleaved with it would
+    // land in whatever bank the scan happens to be visiting (review).
+    log('Search load ignored: library sync in progress', 'error', 'error');
+    return;
+  }
   log(`Search load: '${hit.programName}' (bank ${hit.bankIdx})`, 'info', 'general');
   sendValuePut(KEY.BANK_SELECT, hit.bankIdx);
   await sleep(LIBRARY.LOAD_SETTLE_MS);
   sendValuePut(KEY.PROGRAM_SELECT, hit.programIdx);
+  // Readback before the trigger: the device clamps out-of-range puts, so
+  // a stale library hit would otherwise load a DIFFERENT program silently
+  // — the echo lands in currentValues/the log for the eye to catch
+  // (review; full verify-or-abort is more wire round-trips than the
+  // explicit-resync freshness model warrants).
+  sendValueDump(KEY.PROGRAM_SELECT);
   await sleep(LIBRARY.LOAD_SETTLE_MS);
   const trigger = appState.presetKey.startsWith(KEY_PREFIX.DSP_A)
     ? KEY.LOAD_TRIGGER_A

--- a/src/library.js
+++ b/src/library.js
@@ -1,0 +1,180 @@
+// library.js
+// The preset library (#142): a user-triggered full sync over every bank,
+// and name search across the result. The device only exposes ONE bank's
+// program list at a time, so global search needs this scan — serialized
+// like the eager loader (one bank in flight), restoring the originally
+// selected bank when done. The library persists in midiConfig (the
+// maintainer's freshness model: banks/programs change rarely; re-sync is
+// explicit), so search works across sessions without re-scanning.
+//
+// Library shape: { syncedAt, banks: [{ idx, name, programs: [{ idx,
+// name }] }] } — idx is the SET option index (decimal string, the PUT
+// wire shape), name is the option desc as listed.
+
+import { appState } from './state.js';
+import { sendValuePut, sendObjectInfoDump, sendValueDump } from './midi.js';
+import { KEY, KEY_PREFIX } from './sysex-commands.js';
+import { LIBRARY } from './constants.js';
+import { getNode, bankProgramsFor } from './tree.js';
+import { on } from './events.js';
+import { log } from './logger.js';
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// The current library: hydrated from persisted config at boot
+// (setLibrary), replaced by a completed sync.
+let library = null;
+
+/** @returns {{syncedAt: string, banks: Object[]}|null} */
+export function getLibrary() {
+  return library;
+}
+
+/** Hydrates the library from persisted config (boot). */
+export function setLibrary(persisted) {
+  if (persisted?.banks?.length) library = persisted;
+}
+
+/**
+ * Case-insensitive substring search over every synced program name.
+ *
+ * @param {string} query
+ * @returns {Array<{bankIdx: string, bankName: string, programIdx: string, programName: string}>}
+ */
+export function searchLibrary(query) {
+  const q = query.trim().toLowerCase();
+  if (!q || !library) return [];
+  const hits = [];
+  for (const bank of library.banks) {
+    for (const program of bank.programs) {
+      if (program.name.toLowerCase().includes(q)) {
+        hits.push({
+          bankIdx: bank.idx,
+          bankName: bank.name,
+          programIdx: program.idx,
+          programName: program.name,
+        });
+        if (hits.length >= LIBRARY.SEARCH_MAX_RESULTS) return hits;
+      }
+    }
+  }
+  return hits;
+}
+
+let syncing = false;
+let cancelRequested = false;
+
+/** Requests cancellation of a running sync (finishes the current bank). */
+export function cancelSync() {
+  cancelRequested = true;
+}
+
+/** @returns {boolean} */
+export function isSyncing() {
+  return syncing;
+}
+
+/**
+ * Full library sync: for every bank listed in the load menu's bank SET,
+ * select it (PUT), fetch the load-menu dump (which memoizes that bank's
+ * program list via tree.js recordDump), and collect the result. Restores
+ * the originally selected bank afterward. Serialized — exactly one bank
+ * in flight; ~70 banks at the ~4-5s wire floor each is a several-minute
+ * scan, hence onProgress for UI.
+ *
+ * @param {(done: number, total: number, bankName: string) => void} onProgress
+ * @returns {Promise<{syncedAt: string, banks: Object[]}|null>} The new
+ *   library, or null when no load-menu dump is available / already syncing.
+ */
+export async function syncLibrary(onProgress) {
+  if (syncing) return null;
+  const loadMenu = getNode(KEY.FAVORITES);
+  const bankSub = loadMenu?.find((s) => s.key === KEY.BANK_SELECT);
+  if (!bankSub?.options?.length) {
+    log('Library sync: no load-menu dump yet — visit the program page first', 'error', 'error');
+    return null;
+  }
+  syncing = true;
+  cancelRequested = false;
+  const originalBankIdx = parseInt(String(bankSub.value || '0').split(' ')[0], 16);
+  const banks = [];
+  // The dump's arrival is observed through the tree memo (#141): the scan
+  // waits until bankProgramsFor(idx) materializes for the bank it selected.
+  try {
+    for (let i = 0; i < bankSub.options.length; i++) {
+      if (cancelRequested) break;
+      const option = bankSub.options[i];
+      const bankIdx = parseInt(option.index, 10);
+      onProgress?.(i, bankSub.options.length, option.desc);
+      if (!bankProgramsFor(bankIdx)) {
+        sendValuePut(KEY.BANK_SELECT, option.index);
+        await sleep(LIBRARY.BANK_SETTLE_MS);
+        sendObjectInfoDump(KEY.FAVORITES);
+        sendValueDump(KEY.FAVORITES);
+        const deadline = Date.now() + LIBRARY.BANK_DUMP_TIMEOUT_MS;
+        while (!bankProgramsFor(bankIdx) && Date.now() < deadline && !cancelRequested) {
+          await sleep(200);
+        }
+      }
+      const memo = bankProgramsFor(bankIdx);
+      if (memo) {
+        banks.push({
+          idx: option.index,
+          name: option.desc.trim(),
+          programs: memo.options.map((o) => ({ idx: o.index, name: o.desc.trim() })),
+        });
+      } else if (!cancelRequested) {
+        log(`Library sync: no dump for bank ${option.desc} — skipped`, 'error', 'error');
+      }
+    }
+  } finally {
+    // Restore the user's bank and refresh the on-screen list.
+    sendValuePut(KEY.BANK_SELECT, String(originalBankIdx));
+    await sleep(LIBRARY.BANK_SETTLE_MS);
+    sendObjectInfoDump(KEY.FAVORITES);
+    sendValueDump(KEY.FAVORITES);
+    syncing = false;
+  }
+  if (banks.length === 0) return null;
+  library = { syncedAt: new Date().toISOString(), banks };
+  return library;
+}
+
+/**
+ * Loads a search hit into the ACTIVE DSP: bank PUT, program PUT, load
+ * trigger — each step settled (the device re-lists between steps).
+ *
+ * @param {{bankIdx: string, programIdx: string, programName: string}} hit
+ * @param {Function} [onDone] - Called after the load trigger fires (the
+ *   caller refreshes the screen / root names).
+ */
+export async function loadSearchHit(hit, onDone) {
+  log(`Search load: '${hit.programName}' (bank ${hit.bankIdx})`, 'info', 'general');
+  sendValuePut(KEY.BANK_SELECT, hit.bankIdx);
+  await sleep(LIBRARY.LOAD_SETTLE_MS);
+  sendValuePut(KEY.PROGRAM_SELECT, hit.programIdx);
+  await sleep(LIBRARY.LOAD_SETTLE_MS);
+  const trigger = appState.presetKey.startsWith(KEY_PREFIX.DSP_A)
+    ? KEY.LOAD_TRIGGER_A
+    : KEY.LOAD_TRIGGER_B;
+  sendValuePut(trigger, '1');
+  await sleep(LIBRARY.LOAD_SETTLE_MS);
+  onDone?.();
+}
+
+// Keep the library's bank entries refreshed from live memo updates: when a
+// visit (or the scan) re-records a bank's list, a synced library entry for
+// that bank follows it. Registered once at module load; events.js handlers
+// live for the session.
+on('objectinfo:received', ({ key }) => {
+  if (key !== KEY.FAVORITES || !library) return;
+  const loadMenu = getNode(KEY.FAVORITES);
+  const bankSub = loadMenu?.find((s) => s.key === KEY.BANK_SELECT);
+  const bankIdx = parseInt(String(bankSub?.value || '').split(' ')[0], 16);
+  if (isNaN(bankIdx)) return;
+  const memo = bankProgramsFor(bankIdx);
+  const entry = library.banks.find((b) => parseInt(b.idx, 10) === bankIdx);
+  if (memo && entry) {
+    entry.programs = memo.options.map((o) => ({ idx: o.index, name: o.desc.trim() }));
+  }
+});

--- a/src/main.js
+++ b/src/main.js
@@ -6,11 +6,21 @@ import {
   loadConfig,
   saveConfig,
   saveThemeConfig,
+  saveLibraryConfig,
   clearConfig,
   mergeLogCategories,
 } from './config.js';
 import { setupThemeEditor } from './theme.js';
 import { createDemoPorts, DEMO_NODE_COUNT } from './demo.js';
+import {
+  getLibrary,
+  setLibrary,
+  searchLibrary,
+  syncLibrary,
+  isSyncing,
+  cancelSync,
+  loadSearchHit,
+} from './library.js';
 import { setupKeypressControls, setupDataKnob, testKeypress, meterPollTick } from './controls.js';
 import {
   setMidiPorts,
@@ -451,6 +461,100 @@ setState(
   },
   'main:boot-init'
 );
+// Preset library + search (#142). The library hydrates from persisted
+// config; Sync Library runs the full bank scan (several minutes, progress
+// on the button, click again to cancel); search results load into the
+// active DSP.
+function setupLibraryUI() {
+  const searchInput = document.getElementById('preset-search');
+  const resultsEl = document.getElementById('search-results');
+  const syncBtn = document.getElementById('sync-library');
+  if (!searchInput || !resultsEl || !syncBtn) return;
+
+  setLibrary(cachedConfig?.presetLibrary);
+  const refreshPlaceholder = () => {
+    const lib = getLibrary();
+    searchInput.placeholder = lib
+      ? `Search ${lib.banks.reduce((n, b) => n + b.programs.length, 0)} presets`
+      : 'Search presets (sync first)';
+  };
+  refreshPlaceholder();
+
+  const hideResults = () => {
+    resultsEl.hidden = true;
+  };
+  const renderResults = () => {
+    const query = searchInput.value;
+    if (!query.trim()) {
+      hideResults();
+      return;
+    }
+    const hits = searchLibrary(query);
+    resultsEl.innerHTML = '';
+    if (!getLibrary()) {
+      const empty = document.createElement('div');
+      empty.className = 'search-empty';
+      empty.textContent = 'No library yet - run Sync Library first.';
+      resultsEl.appendChild(empty);
+    } else if (hits.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'search-empty';
+      empty.textContent = 'No matching presets.';
+      resultsEl.appendChild(empty);
+    } else {
+      for (const hit of hits) {
+        const row = document.createElement('button');
+        row.type = 'button';
+        row.className = 'search-hit';
+        row.innerHTML = `<span class="hit-bank">${hit.bankName} &rsaquo;</span> ${hit.programName}`;
+        // mousedown, not click: it fires before the input's blur hides
+        // the dropdown.
+        row.addEventListener('mousedown', (ev) => {
+          ev.preventDefault();
+          hideResults();
+          searchInput.value = '';
+          loadSearchHit(hit, () => {
+            sendObjectInfoDump(KEY.ROOT); // refresh the DSP preset names
+            updateScreen(log);
+            if (appState.fetchBitmap) sendSysEx(CMD.GET_SCREEN, []);
+          });
+        });
+        resultsEl.appendChild(row);
+      }
+    }
+    resultsEl.hidden = false;
+  };
+  searchInput.addEventListener('input', renderResults);
+  searchInput.addEventListener('focus', renderResults);
+  searchInput.addEventListener('blur', hideResults);
+  searchInput.addEventListener('keydown', (ev) => {
+    if (ev.key === 'Escape') {
+      searchInput.value = '';
+      hideResults();
+    }
+  });
+
+  syncBtn.addEventListener('click', async () => {
+    if (isSyncing()) {
+      cancelSync();
+      syncBtn.textContent = 'Cancelling...';
+      return;
+    }
+    const library = await syncLibrary((done, total, bankName) => {
+      syncBtn.textContent = `Syncing ${done + 1}/${total}: ${bankName.slice(0, 18)}`;
+    });
+    if (library) {
+      saveLibraryConfig(library);
+      log(`Library synced: ${library.banks.length} banks`, 'info', 'general');
+    } else if (!getLibrary()) {
+      log('Library sync produced nothing - is the program page loaded?', 'error', 'error');
+    }
+    syncBtn.textContent = 'Sync Library';
+    refreshPlaceholder();
+  });
+}
+setupLibraryUI();
+
 // Theme editor (theme.js): applies the persisted theme at boot, then saves
 // on every preset/swatch change — independent of the Save Config button.
 setupThemeEditor(

--- a/src/main.js
+++ b/src/main.js
@@ -26,6 +26,7 @@ import {
   setMidiPorts,
   addSysexListener,
   sendSysEx,
+  sendObjectInfoDump,
   sendValueDump,
   sendValuePut,
   isOutputConnected,
@@ -506,11 +507,13 @@ function setupLibraryUI() {
         const row = document.createElement('button');
         row.type = 'button';
         row.className = 'search-hit';
-        row.innerHTML = `<span class="hit-bank">${hit.bankName} &rsaquo;</span> ${hit.programName}`;
-        // mousedown, not click: it fires before the input's blur hides
-        // the dropdown.
-        row.addEventListener('mousedown', (ev) => {
-          ev.preventDefault();
+        // textContent, never innerHTML: program/bank names are
+        // device-supplied strings (review).
+        const bankSpan = document.createElement('span');
+        bankSpan.className = 'hit-bank';
+        bankSpan.textContent = `${hit.bankName} › `;
+        row.append(bankSpan, document.createTextNode(hit.programName));
+        row.addEventListener('mousedown', () => {
           hideResults();
           searchInput.value = '';
           loadSearchHit(hit, () => {
@@ -524,6 +527,10 @@ function setupLibraryUI() {
     }
     resultsEl.hidden = false;
   };
+  // preventDefault on the CONTAINER's mousedown (review): a mousedown on
+  // the scrollbar or between rows must not blur the input and close the
+  // dropdown mid-scroll — only the input keeps focus.
+  resultsEl.addEventListener('mousedown', (ev) => ev.preventDefault());
   searchInput.addEventListener('input', renderResults);
   searchInput.addEventListener('focus', renderResults);
   searchInput.addEventListener('blur', hideResults);

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -15,6 +15,7 @@ import {
   GANG_MAX_DEPTH,
 } from './tree.js';
 import { log } from './logger.js';
+import { isSyncing } from './library.js';
 
 /**
  * Updates the current screen by requesting OBJECTINFO_DUMP and VALUE_DUMP for the current key.
@@ -153,6 +154,13 @@ const handleLcdClick = (e) => {
  * @param {Event} e - The change event.
  */
 const handleSelectChange = (e) => {
+  // The library scan owns the bank/program selection while it runs — a
+  // user put interleaved with it lands in whatever bank the scan happens
+  // to be visiting, and the program auto-load would fire there (review).
+  if (isSyncing()) {
+    log('Value change ignored: library sync in progress', 'error', 'error');
+    return;
+  }
   const key = e.target.dataset.key;
   const selectedIndex = e.target.value;
   const selectedDesc = e.target.options[e.target.selectedIndex].text;
@@ -342,6 +350,10 @@ function beginInlineEdit(span, sub, { validate, maxLength }) {
 }
 
 const handleParamClick = (e) => {
+  if (isSyncing()) {
+    log('Edit ignored: library sync in progress', 'error', 'error');
+    return;
+  }
   if (e.target.classList.contains('param-value')) {
     const key = e.target.dataset.key;
     // Find the sub for title and limits (tree lookup for embedded children)

--- a/src/styles.css
+++ b/src/styles.css
@@ -815,6 +815,53 @@ body {
   flex: 1;
   min-width: 240px;
 }
+/* Preset search (#142): results drop below the conn-strip input. */
+.search-wrap {
+  position: relative;
+}
+.util-search {
+  width: 240px;
+}
+.search-results {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  width: 340px;
+  max-height: 380px;
+  overflow-y: auto;
+  background: #121315;
+  border: 1px solid var(--panel-line);
+  border-radius: 4px;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.6);
+  z-index: 10; /* above the faceplate */
+}
+.search-hit {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 7px 10px;
+  font-family: var(--legend-font);
+  font-size: 12px;
+  color: var(--legend);
+  background: none;
+  border: none;
+  border-bottom: 1px solid #1b1d20;
+  cursor: pointer;
+}
+.search-hit:hover {
+  background: var(--btn-cap);
+}
+.search-hit .hit-bank {
+  color: var(--legend-dim);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+}
+.search-empty {
+  padding: 8px 10px;
+  font-size: 11px;
+  color: var(--legend-dim);
+}
+
 .util-label {
   font-size: 10px;
   font-weight: 600;

--- a/tests/library.test.js
+++ b/tests/library.test.js
@@ -1,0 +1,144 @@
+// tests/library.test.js
+// Pins the preset library (#142): search semantics, the serialized bank
+// scan (memo-driven arrival detection, cancel, original-bank restore),
+// and the search-hit load sequence.
+
+jest.mock('../src/midi.js', () => ({
+  sendValuePut: jest.fn(),
+  sendObjectInfoDump: jest.fn(),
+  sendValueDump: jest.fn(),
+}));
+
+jest.mock('../src/logger.js', () => ({
+  log: jest.fn(),
+}));
+
+jest.mock('../src/tree.js', () => ({
+  getNode: jest.fn(),
+  bankProgramsFor: jest.fn(),
+}));
+
+jest.mock('../src/constants.js', () => {
+  const actual = jest.requireActual('../src/constants.js');
+  return {
+    ...actual,
+    // Millisecond-scale waits so the serialized scan runs in test time.
+    LIBRARY: { ...actual.LIBRARY, BANK_SETTLE_MS: 1, BANK_DUMP_TIMEOUT_MS: 50, LOAD_SETTLE_MS: 1 },
+  };
+});
+
+import {
+  setLibrary,
+  getLibrary,
+  searchLibrary,
+  syncLibrary,
+  loadSearchHit,
+} from '../src/library.js';
+import { sendValuePut, sendObjectInfoDump } from '../src/midi.js';
+import { getNode, bankProgramsFor } from '../src/tree.js';
+import { appState } from '../src/state.js';
+
+const sampleLibrary = {
+  syncedAt: 'test',
+  banks: [
+    {
+      idx: '0',
+      name: '0 Favorites',
+      programs: [
+        { idx: '0', name: '0 Techno Rumble' },
+        { idx: '1', name: '1 Black Hole' },
+      ],
+    },
+    {
+      idx: '50',
+      name: '50 Reverbs - Unusual',
+      programs: [{ idx: '12', name: '12 Black Hole' }],
+    },
+  ],
+};
+
+describe('library search', () => {
+  beforeEach(() => setLibrary(sampleLibrary));
+
+  test('case-insensitive substring search across all banks', () => {
+    const hits = searchLibrary('black hole');
+    expect(hits).toHaveLength(2);
+    expect(hits[0]).toEqual({
+      bankIdx: '0',
+      bankName: '0 Favorites',
+      programIdx: '1',
+      programName: '1 Black Hole',
+    });
+    expect(hits[1].bankIdx).toBe('50');
+  });
+
+  test('empty query returns nothing', () => {
+    expect(searchLibrary('   ')).toEqual([]);
+  });
+});
+
+describe('syncLibrary', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const loadMenuNode = [
+    { type: 'COL', key: '10020010' },
+    {
+      type: 'SET',
+      key: '10020012',
+      value: '0 0 Favorites', // originally on bank 0
+      options: [
+        { index: '0', desc: '0 Favorites' },
+        { index: '1', desc: '1 A Taste' },
+      ],
+    },
+  ];
+
+  test('scans every bank via the memo and restores the original bank', async () => {
+    getNode.mockReturnValue(loadMenuNode);
+    // Bank 0 already memoized (no fetch needed); bank 1 memoizes after
+    // the scan requests it.
+    const memos = {
+      0: { options: [{ index: '0', desc: '0 Techno Rumble' }], value: '0' },
+    };
+    bankProgramsFor.mockImplementation((idx) => memos[idx]);
+    setTimeout(() => {
+      memos[1] = { options: [{ index: '0', desc: '0 Delaytaps' }], value: '0' };
+    }, 5);
+
+    const progress = jest.fn();
+    const library = await syncLibrary(progress);
+
+    expect(library.banks.map((b) => b.name)).toEqual(['0 Favorites', '1 A Taste']);
+    expect(library.banks[1].programs).toEqual([{ idx: '0', name: '0 Delaytaps' }]);
+    // Bank 0 was memoized — no PUT for it; bank 1 was selected; the
+    // original bank (0) was restored at the end.
+    const puts = sendValuePut.mock.calls.map((c) => c.join(':'));
+    expect(puts).toContain('10020012:1');
+    expect(puts[puts.length - 1]).toBe('10020012:0'); // restore
+    expect(sendObjectInfoDump).toHaveBeenCalledWith('10020010');
+    expect(progress).toHaveBeenCalledWith(0, 2, '0 Favorites');
+    expect(getLibrary()).toBe(library);
+  });
+
+  test('returns null without a load-menu dump', async () => {
+    getNode.mockReturnValue(undefined);
+    expect(await syncLibrary()).toBeNull();
+  });
+});
+
+describe('loadSearchHit', () => {
+  test('puts bank, program, then the active-DSP load trigger', async () => {
+    jest.clearAllMocks();
+    appState.presetKey = '401000b'; // DSP A active
+    const done = jest.fn();
+    await loadSearchHit({ bankIdx: '50', programIdx: '12', programName: '12 Black Hole' }, done);
+    expect(sendValuePut.mock.calls.map((c) => c.join(':'))).toEqual([
+      '10020012:50',
+      '10020011:12',
+      '1002001c:1', // LOAD_TRIGGER_A
+    ]);
+    expect(done).toHaveBeenCalled();
+  });
+});

--- a/tests/library.test.js
+++ b/tests/library.test.js
@@ -7,6 +7,7 @@ jest.mock('../src/midi.js', () => ({
   sendValuePut: jest.fn(),
   sendObjectInfoDump: jest.fn(),
   sendValueDump: jest.fn(),
+  isOutputConnected: jest.fn(() => true),
 }));
 
 jest.mock('../src/logger.js', () => ({
@@ -80,6 +81,7 @@ describe('library search', () => {
 describe('syncLibrary', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    setLibrary(null);
   });
 
   const loadMenuNode = [
@@ -125,6 +127,41 @@ describe('syncLibrary', () => {
   test('returns null without a load-menu dump', async () => {
     getNode.mockReturnValue(undefined);
     expect(await syncLibrary()).toBeNull();
+  });
+
+  test('a partial scan MERGES over the existing library, never replaces it (review)', async () => {
+    setLibrary(sampleLibrary); // a previous full sync, incl. bank 50
+    getNode.mockReturnValue(loadMenuNode);
+    const memos = {
+      0: { options: [{ index: '0', desc: '0 Fresh Favorites' }], value: '0' },
+      1: { options: [{ index: '0', desc: '0 Delaytaps' }], value: '0' },
+    };
+    bankProgramsFor.mockImplementation((idx) => memos[idx]);
+
+    const library = await syncLibrary();
+    // Banks 0 and 1 refreshed; bank 50 (not in this scan's bank list)
+    // survives from the previous sync.
+    expect(library.banks.map((b) => b.idx)).toEqual(['0', '1', '50']);
+    expect(library.banks[0].programs[0].name).toBe('0 Fresh Favorites');
+    expect(library.banks[2].programs[0].name).toBe('12 Black Hole');
+  });
+
+  test('the original bank restore uses the value token as HEX (review radix pin)', async () => {
+    // Originally on bank 50: the dump's value token is hex '32'; the
+    // restore PUT must be decimal '50' (the device parses puts decimal).
+    getNode.mockReturnValue([
+      { type: 'COL', key: '10020010' },
+      {
+        type: 'SET',
+        key: '10020012',
+        value: '32 50 Reverbs - Unusual',
+        options: [{ index: '0', desc: '0 Favorites' }],
+      },
+    ]);
+    bankProgramsFor.mockReturnValue({ options: [{ index: '0', desc: '0 X' }], value: '0' });
+    await syncLibrary();
+    const puts = sendValuePut.mock.calls.map((c) => c.join(':'));
+    expect(puts[puts.length - 1]).toBe('10020012:50');
   });
 });
 


### PR DESCRIPTION
Maintainer asks: search any preset by name and load it, plus a proper end-user sync over programs/banks (they change rarely; search needs the dataset anyway).

- **Sync Library** (connection strip): serialized scan over every bank — select bank, fetch the load-menu dump, observe arrival via the #141 memo — with live progress on the button, click-again-to-cancel, original-bank restore, and MERGE semantics (a cancelled/partial scan never replaces a previous full library). Persists in midiConfig; hydrates at boot, so search works across sessions.
- **Search** input: case-insensitive name search across every synced bank, results dropdown (bank › program), click loads into the active DSP (bank put → program put → readback → load trigger).
- Scan/UI mutual exclusion: while syncing, in-LCD selects/edits and search-loads are ignored with a log — the scan owns the bank selection.

Live acceptance against the device: **70 banks / 1,044 programs synced in 5:44** (logs/probe-library.log); search hits across banks; loading hits left DSP A running the picked preset ('Black Hole', then 'Delaytaps' with device echoes confirming bank+program selection).

Reviewed: one blocker (missing import in the result-click callback — caught by lint, fixed) + should-fixes (merge-on-partial, scan lockout, readback before trigger, scrollbar-safe dropdown, escaped names) all addressed.

Tests 221/221, lint explicitly clean.

Closes #142