### PR TITLE
feat: sync dialog + status chip + search gating + sync-anywhere; fix label HTML-injection

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -103,9 +103,15 @@ export const LIBRARY = {
   //                              only fires on a genuinely dropped response
   SEARCH_MAX_RESULTS: 24, // results dropdown cap — about a screenful; typing
   //                         more letters narrows better than scrolling
+  SEARCH_MIN_PROGRAMS: 40, // search stays DISABLED below this corpus size: a
+  //                          handful of banks gives so little coverage that
+  //                          "no results" misleads more than it informs — one
+  //                          bank is ~15 programs, so 40 ≈ a few banks synced
   LOAD_SETTLE_MS: 600, // wait between the search-load sequence's puts (bank ->
   //                      program -> load trigger): same settle rationale as
   //                      BANK_SETTLE_MS, applied to each step
+  COMPLETE_HOLD_MS: 1800, // how long the sync dialog holds on its completion
+  //                         summary before dismissing — long enough to read
 };
 
 // Demo mode (src/demo.js): the canned device built from a live capture.

--- a/src/constants.js
+++ b/src/constants.js
@@ -10,7 +10,6 @@
 export const TIMING = {
   METER_POLL_MS: 100, // meter polling interval
   MIDI_SETTLE_MS: 200, // wait after a send before refreshing the screen
-  PROGRAM_SET_MS: 300, // extra wait to ensure a program value is set
   DEVICE_LOAD_MS: 500, // wait for the device to process a preset load
   VALUE_DUMP_WAIT_MS: 500, // wait for a VALUE_DUMP to arrive after a change
   POLL_INTERVAL_MS: 500, // meter-polling re-request interval

--- a/src/constants.js
+++ b/src/constants.js
@@ -110,8 +110,6 @@ export const LIBRARY = {
   LOAD_SETTLE_MS: 600, // wait between the search-load sequence's puts (bank ->
   //                      program -> load trigger): same settle rationale as
   //                      BANK_SETTLE_MS, applied to each step
-  COMPLETE_HOLD_MS: 1800, // how long the sync dialog holds on its completion
-  //                         summary before dismissing — long enough to read
 };
 
 // Demo mode (src/demo.js): the canned device built from a live capture.

--- a/src/eager-loader.js
+++ b/src/eager-loader.js
@@ -113,7 +113,7 @@ function step() {
  *
  * @param {string} rootKey - Subtree root (e.g. '401000b').
  */
-export function startEagerLoad(rootKey) {
+export function startEagerLoad(rootKey, warmKeys = []) {
   teardown();
   if (!rootKey) return;
   const token = ++walkId;
@@ -145,6 +145,15 @@ export function startEagerLoad(rootKey) {
     })
   );
   queue.push({ key: rootKey, depth: 0 });
+  // Extra warm roots (#138): the program/load menu, whose ~70-name bank
+  // list is the slowest dump on the link. Warming it in the background
+  // (serialized like everything else, and skipped when already cached)
+  // means the first PROGRAM visit renders instantly from the tree instead
+  // of fetching the bank list on-demand. Cached nodes (e.g. right after a
+  // library sync) cost no request.
+  for (const k of warmKeys) {
+    if (k) queue.push({ key: k, depth: 0 });
+  }
   step();
 }
 

--- a/src/event-bridge.js
+++ b/src/event-bridge.js
@@ -201,7 +201,10 @@ export function registerEventBridge({ hideLoading }) {
       // NEW active preset.
       if (eagerLoadArmed && payload?.reason === 'all-received') {
         eagerLoadArmed = false;
-        startEagerLoad(appState.presetKey);
+        // Also warm the program menu (#138): its bank-list dump is the
+        // slowest on the link, so prefetching it makes the first PROGRAM
+        // visit instant instead of an on-demand multi-second fetch.
+        startEagerLoad(appState.presetKey, [KEY.PROGRAM]);
       } else if (eagerLoadArmed) {
         log(
           'Eager load still armed: landing wave stalled; waiting for a clean drain.',

--- a/src/index.html
+++ b/src/index.html
@@ -51,6 +51,7 @@
         >
           Sync Library
         </button>
+        <span id="sync-status" class="sync-status">not synced</span>
         <span class="conn-spacer"></span>
         <button id="save-config" class="util-btn">Save Config</button>
         <button id="clear-config" class="util-btn">Clear Config</button>

--- a/src/library.js
+++ b/src/library.js
@@ -30,6 +30,16 @@ export function getLibrary() {
   return library;
 }
 
+/** Total program count across the synced library (0 when none). */
+export function libraryProgramCount() {
+  return library ? library.banks.reduce((n, b) => n + b.programs.length, 0) : 0;
+}
+
+/** Whether the corpus is large enough to enable search (#142 follow-up). */
+export function canSearch() {
+  return libraryProgramCount() >= LIBRARY.SEARCH_MIN_PROGRAMS;
+}
+
 /** Hydrates the library from persisted config (boot); null clears (tests). */
 export function setLibrary(persisted) {
   if (persisted === null) {
@@ -47,7 +57,7 @@ export function setLibrary(persisted) {
  */
 export function searchLibrary(query) {
   const q = query.trim().toLowerCase();
-  if (!q || !library) return [];
+  if (!q || !canSearch()) return [];
   const hits = [];
   for (const bank of library.banks) {
     for (const program of bank.programs) {
@@ -96,24 +106,53 @@ export async function syncLibrary(onProgress) {
     log('Library sync: no MIDI output connected', 'error', 'error');
     return null;
   }
-  const loadMenu = getNode(KEY.FAVORITES);
-  const bankSub = loadMenu?.find((s) => s.key === KEY.BANK_SELECT);
-  if (!bankSub?.options?.length) {
-    log('Library sync: no load-menu dump yet — visit the program page first', 'error', 'error');
-    return null;
-  }
   syncing = true;
   cancelRequested = false;
+  // Sync-from-anywhere (#142 follow-up): the bank list lives in the
+  // load-menu dump, which may not be cached if the user never opened the
+  // program page. Fetch it ourselves first instead of demanding they
+  // navigate there — onProgress(-1) signals this "preparing" phase.
+  let loadMenu = getNode(KEY.FAVORITES);
+  let bankSub = loadMenu?.find((s) => s.key === KEY.BANK_SELECT);
+  if (!bankSub?.options?.length) {
+    onProgress?.(-1, 0, 'preparing');
+    sendObjectInfoDump(KEY.FAVORITES);
+    sendValueDump(KEY.FAVORITES);
+    const deadline = Date.now() + LIBRARY.BANK_DUMP_TIMEOUT_MS;
+    while (Date.now() < deadline && !cancelRequested) {
+      await sleep(200);
+      loadMenu = getNode(KEY.FAVORITES);
+      bankSub = loadMenu?.find((s) => s.key === KEY.BANK_SELECT);
+      if (bankSub?.options?.length) break;
+    }
+  }
+  if (!bankSub?.options?.length) {
+    log('Library sync: could not load the bank list', 'error', 'error');
+    syncing = false;
+    return null;
+  }
   const originalBankIdx = parseInt(String(bankSub.value || '0').split(' ')[0], 16);
   const banks = [];
+  const total = bankSub.options.length;
+  // One cell per bank for the dialog's defrag map: 'pending' | 'current'
+  // | 'captured' | 'skipped'. emit() reports the whole scan state plus a
+  // rolling ETA (mean elapsed per finished bank * banks remaining).
+  const bankStates = new Array(total).fill('pending');
+  const startedAt = Date.now();
+  const emit = (phase, doneCount, name) => {
+    const elapsed = Date.now() - startedAt;
+    const etaMs = doneCount > 0 ? Math.round((elapsed / doneCount) * (total - doneCount)) : null;
+    onProgress?.({ phase, done: doneCount, total, name, bankStates: [...bankStates], etaMs });
+  };
   // The dump's arrival is observed through the tree memo (#141): the scan
   // waits until bankProgramsFor(idx) materializes for the bank it selected.
   try {
-    for (let i = 0; i < bankSub.options.length; i++) {
+    for (let i = 0; i < total; i++) {
       if (cancelRequested) break;
       const option = bankSub.options[i];
       const bankIdx = parseInt(option.index, 10);
-      onProgress?.(i, bankSub.options.length, option.desc);
+      bankStates[i] = 'current';
+      emit('scanning', i, option.desc);
       if (!bankProgramsFor(bankIdx)) {
         sendValuePut(KEY.BANK_SELECT, option.index);
         await sleep(LIBRARY.BANK_SETTLE_MS);
@@ -126,17 +165,23 @@ export async function syncLibrary(onProgress) {
       }
       const memo = bankProgramsFor(bankIdx);
       if (memo) {
+        bankStates[i] = 'captured';
         banks.push({
           idx: option.index,
           name: option.desc.trim(),
           programs: memo.options.map((o) => ({ idx: o.index, name: o.desc.trim() })),
         });
-      } else if (!cancelRequested) {
-        log(`Library sync: no dump for bank ${option.desc} — skipped`, 'error', 'error');
+      } else {
+        bankStates[i] = 'skipped';
+        if (!cancelRequested) {
+          log(`Library sync: no dump for bank ${option.desc} — skipped`, 'error', 'error');
+        }
       }
+      emit('scanning', i + 1, option.desc);
     }
   } finally {
     // Restore the user's bank and refresh the on-screen list.
+    emit('restoring', banks.length, '');
     sendValuePut(KEY.BANK_SELECT, String(originalBankIdx));
     await sleep(LIBRARY.BANK_SETTLE_MS);
     sendObjectInfoDump(KEY.FAVORITES);

--- a/src/library.js
+++ b/src/library.js
@@ -115,7 +115,10 @@ export async function syncLibrary(onProgress) {
   let loadMenu = getNode(KEY.FAVORITES);
   let bankSub = loadMenu?.find((s) => s.key === KEY.BANK_SELECT);
   if (!bankSub?.options?.length) {
-    onProgress?.(-1, 0, 'preparing');
+    // Structured payload, like every other emit (the dialog reads
+    // p.phase/p.bankStates — the old positional call threw on the
+    // sync-from-anywhere path and killed the whole scan silently).
+    onProgress?.({ phase: 'preparing', done: 0, total: 0, name: '', bankStates: [], etaMs: null });
     sendObjectInfoDump(KEY.FAVORITES);
     sendValueDump(KEY.FAVORITES);
     const deadline = Date.now() + LIBRARY.BANK_DUMP_TIMEOUT_MS;

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 // main.js
 import { WebMidi } from 'webmidi';
 import { CMD, KEY } from './sysex-commands.js';
-import { TIMING, DEFAULT_LOG_CATEGORIES } from './constants.js';
+import { TIMING, LIBRARY, DEFAULT_LOG_CATEGORIES } from './constants.js';
 import {
   loadConfig,
   saveConfig,
@@ -20,7 +20,10 @@ import {
   isSyncing,
   cancelSync,
   loadSearchHit,
+  libraryProgramCount,
+  canSearch,
 } from './library.js';
+import { showSyncProgress, showSyncComplete, hideSyncDialog } from './sync-dialog.js';
 import { setupKeypressControls, setupDataKnob, testKeypress, meterPollTick } from './controls.js';
 import {
   setMidiPorts,
@@ -472,14 +475,40 @@ function setupLibraryUI() {
   const syncBtn = document.getElementById('sync-library');
   if (!searchInput || !resultsEl || !syncBtn) return;
 
+  const statusEl = document.getElementById('sync-status');
   setLibrary(cachedConfig?.presetLibrary);
-  const refreshPlaceholder = () => {
-    const lib = getLibrary();
-    searchInput.placeholder = lib
-      ? `Search ${lib.banks.reduce((n, b) => n + b.programs.length, 0)} presets`
-      : 'Search presets (sync first)';
+
+  // "12m ago" style relative time from an ISO stamp.
+  const timeAgo = (iso) => {
+    const diff = Date.now() - new Date(iso).getTime();
+    const m = Math.floor(diff / 60000);
+    if (m < 1) return 'just now';
+    if (m < 60) return `${m}m ago`;
+    const h = Math.floor(m / 60);
+    if (h < 24) return `${h}h ago`;
+    return `${Math.floor(h / 24)}d ago`;
   };
-  refreshPlaceholder();
+
+  // Search is gated on a decent corpus (#142 follow-up): below the
+  // minimum, "no results" misleads, so the input is disabled with a
+  // sync-first hint. The status chip always states where things stand.
+  const refreshLibraryUI = () => {
+    const count = libraryProgramCount();
+    const lib = getLibrary();
+    const enabled = canSearch();
+    searchInput.disabled = !enabled;
+    searchInput.placeholder = enabled
+      ? `Search ${count} presets`
+      : count > 0
+        ? `Sync more to search (${count})`
+        : 'Sync library to enable search';
+    if (statusEl) {
+      statusEl.classList.toggle('synced', !!lib);
+      statusEl.textContent = lib ? `${count} presets · ${timeAgo(lib.syncedAt)}` : 'not synced';
+      if (lib) statusEl.title = `Last synced ${new Date(lib.syncedAt).toLocaleString()}`;
+    }
+  };
+  refreshLibraryUI();
 
   const hideResults = () => {
     resultsEl.hidden = true;
@@ -492,10 +521,10 @@ function setupLibraryUI() {
     }
     const hits = searchLibrary(query);
     resultsEl.innerHTML = '';
-    if (!getLibrary()) {
+    if (!canSearch()) {
       const empty = document.createElement('div');
       empty.className = 'search-empty';
-      empty.textContent = 'No library yet - run Sync Library first.';
+      empty.textContent = 'Sync the library first to search.';
       resultsEl.appendChild(empty);
     } else if (hits.length === 0) {
       const empty = document.createElement('div');
@@ -547,17 +576,30 @@ function setupLibraryUI() {
       syncBtn.textContent = 'Cancelling...';
       return;
     }
-    const library = await syncLibrary((done, total, bankName) => {
-      syncBtn.textContent = `Syncing ${done + 1}/${total}: ${bankName.slice(0, 18)}`;
+    syncBtn.textContent = 'Syncing...';
+    const library = await syncLibrary((p) => {
+      showSyncProgress(p, () => {
+        cancelSync();
+        syncBtn.textContent = 'Cancelling...';
+      });
     });
     if (library) {
       saveLibraryConfig(library);
       log(`Library synced: ${library.banks.length} banks`, 'info', 'general');
-    } else if (!getLibrary()) {
-      log('Library sync produced nothing - is the program page loaded?', 'error', 'error');
+      // Completion beat on the LCD, then dismiss.
+      showSyncComplete({
+        banks: library.banks.length,
+        programs: library.banks.reduce((n, b) => n + b.programs.length, 0),
+      });
+      setTimeout(hideSyncDialog, LIBRARY.COMPLETE_HOLD_MS);
+    } else {
+      hideSyncDialog();
+      if (!getLibrary()) {
+        log('Library sync produced nothing — is a MIDI output connected?', 'error', 'error');
+      }
     }
     syncBtn.textContent = 'Sync Library';
-    refreshPlaceholder();
+    refreshLibraryUI();
   });
 }
 setupLibraryUI();

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 // main.js
 import { WebMidi } from 'webmidi';
 import { CMD, KEY } from './sysex-commands.js';
-import { TIMING, LIBRARY, DEFAULT_LOG_CATEGORIES } from './constants.js';
+import { TIMING, DEFAULT_LOG_CATEGORIES } from './constants.js';
 import {
   loadConfig,
   saveConfig,
@@ -586,12 +586,12 @@ function setupLibraryUI() {
     if (library) {
       saveLibraryConfig(library);
       log(`Library synced: ${library.banks.length} banks`, 'info', 'general');
-      // Completion beat on the LCD, then dismiss.
+      // Completion summary on the LCD — stays until the user hits DONE
+      // (the dialog's own button), so the result is never missed.
       showSyncComplete({
         banks: library.banks.length,
         programs: library.banks.reduce((n, b) => n + b.programs.length, 0),
       });
-      setTimeout(hideSyncDialog, LIBRARY.COMPLETE_HOLD_MS);
     } else {
       hideSyncDialog();
       if (!getLibrary()) {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -176,7 +176,12 @@ const handleSelectChange = (e) => {
   // re-checks the parked slot, and the change's discard listener (runs
   // synchronously after this handler) clears it first — no stale replay.
   e.target.blur();
-  showLoading();
+  // No loading dim for a program select (regression fix): it only moves the
+  // highlight and confirms with a VALUE dump, but hideLoading fires only on
+  // OBJECTINFO/screen waves (#3) — so the dim would never lift. The pick is
+  // instant via the optimistic repaint below; the dim is for the menu
+  // refetches the bank/other branches do.
+  if (key !== KEY.PROGRAM_SELECT) showLoading();
   sendValuePut(key, selectedIndex);
   // Optimistic cache in the DEVICE's value shape: puts are parsed decimal
   // but values/echoes report the index in HEX (probed live,

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -222,6 +222,14 @@ const handleSelectChange = (e) => {
       // (~4-5s) — the program field's memo (revisited bank, instant) or
       // loading line (unseen bank) must show immediately.
       renderScreen(appState.currentSubs, appState.lastAscii);
+    } else if (key === KEY.PROGRAM_SELECT) {
+      // Choosing a program only moves the highlight (no load now — the
+      // auto-load was removed). It does NOT change the menu, so skip the
+      // full updateScreen refetch (the "syncing with the system" lag the
+      // maintainer saw): the optimistic hex cache already shows the pick,
+      // so repaint immediately and just confirm the value on the wire.
+      renderScreen(appState.currentSubs, appState.lastAscii);
+      sendValueDump(KEY.PROGRAM_SELECT);
     } else {
       updateScreen();
     }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -439,8 +439,25 @@ const FORMAT_SPEC_RE = /%%|%(-)?(\d*)(\.\d*)?f|%(-)?(\d*)s|%/g;
 // No /g flag: .test() on a global regex is lastIndex-stateful.
 const CON_FORMAT_RE = /%-?\d*(\.\d*)?f|%-?\d*s/;
 
+// Device text goes into #lcd via innerHTML, and device labels DO contain
+// HTML metacharacters — e.g. the multitap delay's 'fb<tap1' feedback
+// label. Unescaped, the browser parsed '<tap1' as a tag: it ate the rest
+// of the label (rendered just 'fb') and, never closing, wrapped every line
+// below it so one hover lit the whole screen. Escape all device-supplied
+// text at every HTML interpolation point (live bug).
+function escapeHtml(s) {
+  return String(s ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
 function formatValue(statement, value, isHtml = false, key = '') {
-  return statement.replace(
+  // When building HTML, escape the statement's LITERAL text up front; the
+  // format specs ('%4.0f' etc.) contain no HTML metacharacters, so the
+  // regex still matches, and the spans we inject below stay intact.
+  const stmt = isHtml ? escapeHtml(statement) : statement;
+  return stmt.replace(
     FORMAT_SPEC_RE,
     (match, fLeftFlag, fWidthStr, precStr, sLeftFlag, sWidthStr) => {
       if (match === '%%' || match === '%') return '%';
@@ -454,15 +471,18 @@ function formatValue(statement, value, isHtml = false, key = '') {
           valStr = leftAlign ? valStr.padEnd(width) : valStr.padStart(width);
         }
         if (isHtml) {
+          // valStr is numeric (no metacharacters); the data-key is an app
+          // hex key — both safe.
           return `<span class="param-value" data-key="${key}">${valStr}</span>`;
         }
         return valStr;
       } else if (sLeftFlag !== undefined || sWidthStr !== undefined) {
-        // %[-]widths
+        // %[-]widths — a STRING value, which CAN carry metacharacters.
         const leftAlign = sLeftFlag === '-';
         const width = parseInt(sWidthStr || '0');
-        if (width === 0) return value;
-        return leftAlign ? value.padEnd(width) : value.padStart(width);
+        const v = isHtml ? escapeHtml(value) : value;
+        if (width === 0) return v;
+        return leftAlign ? v.padEnd(width) : v.padStart(width);
       }
       return match;
     }
@@ -580,7 +600,7 @@ function gangParamLine(s, logParam) {
     const value = appState.currentValues[s.key] || s.value || '';
     if (appState.currentValues[s.key] === undefined && !s.value) sendValueDump(s.key, logParam);
     const text = formatValue(s.statement, value);
-    return { text, html: text };
+    return { text, html: escapeHtml(text) };
   } else if (s.type === 'SET') {
     const value = appState.currentValues[s.key] || s.value || '';
     if (appState.currentValues[s.key] === undefined && !s.value) sendValueDump(s.key, logParam);
@@ -594,23 +614,26 @@ function gangParamLine(s, logParam) {
     let selectHtml = `<select data-key="${s.key}" class="param-select">`;
     s.options.forEach((option) => {
       const isSelected = option.index === indexDec;
-      selectHtml += `<option value="${option.index}" ${isSelected ? 'selected' : ''}>${option.desc}</option>`;
+      selectHtml += `<option value="${option.index}" ${isSelected ? 'selected' : ''}>${escapeHtml(option.desc)}</option>`;
     });
     selectHtml += `</select>`;
     return {
       text: formatValue(s.statement || '', displayValue),
-      html: (s.statement || '').replace(/%(-)?(\d*)s/g, selectHtml),
+      html: escapeHtml(s.statement || '').replace(/%(-)?(\d*)s/g, selectHtml),
     };
   } else if (s.type === 'TRG') {
     return {
       text: s.statement,
-      html: `<span class="param-value" data-key="${s.key}">${s.statement}</span>`,
+      html: `<span class="param-value" data-key="${s.key}">${escapeHtml(s.statement)}</span>`,
     };
   } else if (s.type === 'STR') {
     const value = appState.currentValues[s.key] ?? s.value ?? '';
     if (appState.currentValues[s.key] === undefined && !s.value) sendValueDump(s.key, logParam);
     const text = formatValue(s.statement || '%s', value);
-    return { text, html: `<span class="param-value" data-key="${s.key}">${text}</span>` };
+    return {
+      text,
+      html: `<span class="param-value" data-key="${s.key}">${escapeHtml(text)}</span>`,
+    };
   } else if (s.type === 'CON') {
     let meterValue = parseFloat(appState.currentValues[s.key] || s.value) || 0;
     if (isNaN(meterValue)) meterValue = 0;
@@ -621,7 +644,7 @@ function gangParamLine(s, logParam) {
         : null;
     if (conFormat) {
       const text = formatValue(conFormat, meterValue);
-      return { text, html: text };
+      return { text, html: escapeHtml(text) };
     }
   }
   return null;
@@ -646,12 +669,12 @@ function renderGangInline(colSub, depth, paramLines, paramHtmlLines, logParam) {
     paramChildren.every((c) => c.statement === paramChildren[0].statement);
   if (header && (depth === 0 || identicalStatements)) {
     paramLines.push(header);
-    paramHtmlLines.push(header);
+    paramHtmlLines.push(escapeHtml(header));
   }
   if (!node) {
     const text = `${header || labelForSub(colSub)} ${RENDER.VALUE_PLACEHOLDER}`;
     paramLines.push(text);
-    paramHtmlLines.push(text);
+    paramHtmlLines.push(escapeHtml(text));
     return;
   }
   for (const cs of children) {
@@ -664,7 +687,7 @@ function renderGangInline(colSub, depth, paramLines, paramHtmlLines, logParam) {
       const text = placeholderLine(cs);
       if (text) {
         paramLines.push(text);
-        paramHtmlLines.push(text);
+        paramHtmlLines.push(escapeHtml(text));
       }
       continue;
     }
@@ -784,7 +807,7 @@ export function renderScreen(subs, ascii, logParam) {
     const isAActive = appState.presetKey.startsWith(KEY_PREFIX.DSP_A);
     const aPart = isAActive ? `[A: ${appState.dspAName}]` : `A: ${appState.dspAName}`;
     const bPart = !isAActive ? `[B: ${appState.dspBName}]` : `B: ${appState.dspBName}`;
-    topHtml = ` <span class="${isAActive ? 'dsp-clickable current' : 'dsp-clickable'}" data-key="${appState.dspAKey}">${aPart}</span> <span class="${!isAActive ? 'dsp-clickable current' : 'dsp-clickable'}" data-key="${appState.dspBKey}">${bPart}</span>`;
+    topHtml = ` <span class="${isAActive ? 'dsp-clickable current' : 'dsp-clickable'}" data-key="${appState.dspAKey}">${escapeHtml(aPart)}</span> <span class="${!isAActive ? 'dsp-clickable current' : 'dsp-clickable'}" data-key="${appState.dspBKey}">${escapeHtml(bPart)}</span>`;
     if (
       appState.currentKey === KEY.ROOT ||
       appState.currentKey.startsWith(KEY_PREFIX.DSP_A) ||
@@ -830,7 +853,7 @@ export function renderScreen(subs, ascii, logParam) {
       slice.forEach((s, idx) => {
         const t = labelForSub(s);
         const text = (s.key === appState.currentKey ? `[${t}]` : t).padEnd(columnWidth);
-        softHtml += `<span class="softkey" data-key="${s.key}" data-idx="${idx}">${text}</span>`;
+        softHtml += `<span class="softkey" data-key="${s.key}" data-idx="${idx}">${escapeHtml(text)}</span>`;
       });
       softHtmlLines.push(softHtml);
     }
@@ -839,11 +862,11 @@ export function renderScreen(subs, ascii, logParam) {
     mainHtmlLines = mainHtmlLines.concat(softHtmlLines);
   } else {
     titleText = main.statement || main.tag || 'Menu';
-    titleHtml = titleText;
+    titleHtml = escapeHtml(titleText);
     if (appState.keyStack.length > 0) {
       const parent = appState.keyStack[appState.keyStack.length - 1];
       titleText = `[${parent.tag}] ${titleText}`;
-      titleHtml = `<span class="back-link" data-key="${parent.key}">[${parent.tag}]</span> ${titleText.replace(`[${parent.tag}] `, '')}`;
+      titleHtml = `<span class="back-link" data-key="${parent.key}">[${escapeHtml(parent.tag)}]</span> ${escapeHtml(main.statement || main.tag || 'Menu')}`;
     }
     displayLines.push(titleText);
     // Group graphic EQ NUMs with position 'a'. The pre-paint pass keeps the
@@ -857,7 +880,7 @@ export function renderScreen(subs, ascii, logParam) {
         .map((s) => `${s.tag.split(':')[0]}: ${RENDER.VALUE_PLACEHOLDER}`)
         .join(' ');
       paramLines.push(line);
-      paramHtmlLines.push(line);
+      paramHtmlLines.push(escapeHtml(line));
     } else if (graphicEqSubs.length > 0) {
       const formattedParts = graphicEqSubs.map((s) => {
         const value = appState.currentValues[s.key] || s.value;
@@ -879,7 +902,7 @@ export function renderScreen(subs, ascii, logParam) {
         const value = appState.currentValues[s.key] || s.value;
         const [label, format] = s.tag.split(':');
         const formattedValue = formatValue(format || '%3.0f', value, true, s.key);
-        return `${label}: ${formattedValue}`;
+        return `${escapeHtml(label)}: ${formattedValue}`;
       });
       graphicEqHtml = formattedHtmlParts.join(' ');
       paramLines.push(graphicEqLine);
@@ -895,7 +918,7 @@ export function renderScreen(subs, ascii, logParam) {
         const text = placeholderLine(s);
         if (text) {
           paramLines.push(text);
-          paramHtmlLines.push(text);
+          paramHtmlLines.push(escapeHtml(text));
         }
         return;
       }
@@ -914,7 +937,7 @@ export function renderScreen(subs, ascii, logParam) {
         let value = appState.currentValues[s.key] || s.value || '';
         if (appState.currentValues[s.key] === undefined && !s.value) sendValueDump(s.key, logParam);
         fullText = formatValue(s.statement, value); // Use updated formatValue with s support
-        fullHtml = fullText;
+        fullHtml = escapeHtml(fullText); // INF isn't clickable: escape, add no span
       } else if (s.type === 'SET') {
         const progView = programSelectView(s, subs.slice(1));
         if (progView.loading) {
@@ -942,10 +965,12 @@ export function renderScreen(subs, ascii, logParam) {
           let selectHtml = `<select data-key="${s.key}" class="param-select">`;
           options.forEach((option) => {
             const isSelected = option.index === indexDec;
-            selectHtml += `<option value="${option.index}" ${isSelected ? 'selected' : ''}>${option.desc}</option>`;
+            selectHtml += `<option value="${option.index}" ${isSelected ? 'selected' : ''}>${escapeHtml(option.desc)}</option>`;
           });
           selectHtml += `</select>`;
-          fullHtml = (s.statement || '').replace(/%(-)?(\d*)s/g, selectHtml);
+          // Escape the statement's literal text before splicing in the
+          // select (which is intentional markup).
+          fullHtml = escapeHtml(s.statement || '').replace(/%(-)?(\d*)s/g, selectHtml);
         }
       } else if (s.type === 'CON') {
         let meterValue = parseFloat(appState.currentValues[s.key] || s.value) || 0;
@@ -968,7 +993,7 @@ export function renderScreen(subs, ascii, logParam) {
             : null;
         if (conFormat) {
           fullText = formatValue(conFormat, meterValue); // '%%' collapses in formatValue
-          fullHtml = fullText;
+          fullHtml = escapeHtml(fullText);
         } else {
           // No format spec anywhere: an indicator CON (the Tempo 'Beat'
           // flasher is the only live-observed case) — render a compact
@@ -981,7 +1006,7 @@ export function renderScreen(subs, ascii, logParam) {
           barLength = Math.max(0, Math.min(barSpace, barLength)); // Clamp to prevent invalid repeat counts
           const bar = '█'.repeat(barLength) + '░'.repeat(barSpace - barLength);
           fullText = `${s.tag} ${bar}`.padEnd(40);
-          fullHtml = `<span class="param-label">${s.tag}</span> <span class="meter-bar">${bar}</span>`;
+          fullHtml = `<span class="param-label">${escapeHtml(s.tag)}</span> <span class="meter-bar">${bar}</span>`;
           log(
             `Rendering CON for key ${s.key}: tag=${s.tag}, value=${meterValue}, barLength=${barLength}, line="${fullText.trim()}"`,
             'debug',
@@ -989,7 +1014,7 @@ export function renderScreen(subs, ascii, logParam) {
           );
         }
       } else if (s.type === 'TRG') {
-        fullHtml = `<span class="param-value" data-key="${s.key}">${s.statement}</span>`;
+        fullHtml = `<span class="param-value" data-key="${s.key}">${escapeHtml(s.statement)}</span>`;
         fullText = s.statement;
       } else if (s.type === 'STR') {
         // String-edit field (R8; live-discovered type, device-model §3):
@@ -998,7 +1023,7 @@ export function renderScreen(subs, ascii, logParam) {
         const value = appState.currentValues[s.key] ?? s.value ?? '';
         if (appState.currentValues[s.key] === undefined && !s.value) sendValueDump(s.key, logParam);
         fullText = formatValue(s.statement || '%s', value);
-        fullHtml = `<span class="param-value" data-key="${s.key}">${fullText}</span>`;
+        fullHtml = `<span class="param-value" data-key="${s.key}">${escapeHtml(fullText)}</span>`;
       }
       if (fullText) {
         paramLines.push(fullText);
@@ -1053,7 +1078,7 @@ export function renderScreen(subs, ascii, logParam) {
         // Skip childTitle if empty or duplicates parent title
         if (childTitle && childTitle !== main.statement && childTitle !== main.tag) {
           paramLines.push(childTitle);
-          paramHtmlLines.push(childTitle);
+          paramHtmlLines.push(escapeHtml(childTitle));
         }
         // Process child params
         childSubs.slice(1).forEach((cs) => {
@@ -1070,7 +1095,7 @@ export function renderScreen(subs, ascii, logParam) {
             if (appState.currentValues[cs.key] === undefined && !cs.value)
               sendValueDump(cs.key, logParam);
             childFullText = formatValue(cs.statement, value);
-            childFullHtml = childFullText;
+            childFullHtml = escapeHtml(childFullText);
           } else if (cs.type === 'SET') {
             const progView = programSelectView(cs, childSubs.slice(1));
             if (progView.loading) {
@@ -1097,10 +1122,10 @@ export function renderScreen(subs, ascii, logParam) {
               let selectHtml = `<select data-key="${cs.key}" class="param-select">`;
               options.forEach((option) => {
                 const isSelected = option.index === indexDec;
-                selectHtml += `<option value="${option.index}" ${isSelected ? 'selected' : ''}>${option.desc}</option>`;
+                selectHtml += `<option value="${option.index}" ${isSelected ? 'selected' : ''}>${escapeHtml(option.desc)}</option>`;
               });
               selectHtml += `</select>`;
-              childFullHtml = (cs.statement || '').replace(/%(-)?(\d*)s/g, selectHtml);
+              childFullHtml = escapeHtml(cs.statement || '').replace(/%(-)?(\d*)s/g, selectHtml);
             }
           } else if (cs.type === 'CON') {
             let meterValue = parseFloat(appState.currentValues[cs.key] || cs.value) || 0;
@@ -1117,7 +1142,7 @@ export function renderScreen(subs, ascii, logParam) {
                 : null;
             if (conFormat) {
               childFullText = formatValue(conFormat, meterValue); // '%%' collapses in formatValue
-              childFullHtml = childFullText;
+              childFullHtml = escapeHtml(childFullText);
             } else {
               // Same compact indicator block as the top-level CON branch.
               const tagLength = cs.tag.length;
@@ -1129,7 +1154,7 @@ export function renderScreen(subs, ascii, logParam) {
               barLength = Math.max(0, Math.min(barSpace, barLength)); // Clamp to prevent invalid repeat counts
               const bar = '█'.repeat(barLength) + '░'.repeat(barSpace - barLength);
               childFullText = `${cs.tag} ${bar}`.padEnd(40);
-              childFullHtml = `<span class="param-label">${cs.tag}</span> <span class="meter-bar">${bar}</span>`;
+              childFullHtml = `<span class="param-label">${escapeHtml(cs.tag)}</span> <span class="meter-bar">${bar}</span>`;
               log(
                 `Rendering CON for key ${cs.key}: tag=${cs.tag}, value=${meterValue}, barLength=${barLength}, line="${childFullText.trim()}"`,
                 'debug',
@@ -1137,14 +1162,14 @@ export function renderScreen(subs, ascii, logParam) {
               );
             }
           } else if (cs.type === 'TRG') {
-            childFullHtml = `<span class="param-value" data-key="${cs.key}">${cs.statement}</span>`;
+            childFullHtml = `<span class="param-value" data-key="${cs.key}">${escapeHtml(cs.statement)}</span>`;
             childFullText = cs.statement;
           } else if (cs.type === 'STR') {
             const value = appState.currentValues[cs.key] ?? cs.value ?? '';
             if (appState.currentValues[cs.key] === undefined && !cs.value)
               sendValueDump(cs.key, logParam);
             childFullText = formatValue(cs.statement || '%s', value);
-            childFullHtml = `<span class="param-value" data-key="${cs.key}">${childFullText}</span>`;
+            childFullHtml = `<span class="param-value" data-key="${cs.key}">${escapeHtml(childFullText)}</span>`;
           }
           if (childFullText) {
             paramLines.push(childFullText);
@@ -1294,7 +1319,7 @@ export function renderScreen(subs, ascii, logParam) {
       slice.forEach((s, idx) => {
         const t = labelForSub(s);
         const text = (s.key === appState.currentKey ? `[${t}]` : t).padEnd(columnWidth);
-        softHtml += `<span class="softkey" data-key="${s.key}" data-idx="${idx}">${text}</span>`;
+        softHtml += `<span class="softkey" data-key="${s.key}" data-idx="${idx}">${escapeHtml(text)}</span>`;
       });
       softHtmlLines.push(softHtml);
     }
@@ -1323,7 +1348,7 @@ export function renderScreen(subs, ascii, logParam) {
           slice.forEach((s, idx) => {
             const t = labelForSub(s);
             const text = (s.key === parentHighlightKey ? `[${t}]` : t).padEnd(columnWidth);
-            softHtml += `<span class="softkey" data-key="${s.key}" data-idx="${idx}">${text}</span>`;
+            softHtml += `<span class="softkey" data-key="${s.key}" data-idx="${idx}">${escapeHtml(text)}</span>`;
           });
           parentSoftHtmlLines.push(softHtml);
         }
@@ -1362,7 +1387,7 @@ export function renderScreen(subs, ascii, logParam) {
           slice.forEach((s, idx) => {
             const t = labelForSub(s);
             const text = (s.key === upperHighlightKey ? `[${t}]` : t).padEnd(columnWidth);
-            softHtml += `<span class="softkey" data-key="${s.key}" data-idx="${idx}">${text}</span>`;
+            softHtml += `<span class="softkey" data-key="${s.key}" data-idx="${idx}">${escapeHtml(text)}</span>`;
           });
           upperSoftHtmlLines.push(softHtml);
         }
@@ -1379,7 +1404,7 @@ export function renderScreen(subs, ascii, logParam) {
     const staticColumnWidth = Math.floor(LAYOUT.LCD_COLUMNS / staticRootSoftSubs.length);
     staticRootSoftSubs.forEach((s, idx) => {
       const text = (s.key === appState.currentKey ? `[${s.tag}]` : s.tag).padEnd(staticColumnWidth);
-      softHtml += `<span class="softkey" data-key="${s.key}" data-idx="${idx}">${text}</span>`;
+      softHtml += `<span class="softkey" data-key="${s.key}" data-idx="${idx}">${escapeHtml(text)}</span>`;
     });
     bottomHtml = softHtml;
   }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -241,25 +241,11 @@ const handleSelectChange = (e) => {
         );
       }
     }, TIMING.VALUE_DUMP_WAIT_MS); // Wait for VALUE_DUMP to arrive
-    // Auto-load preset if changing the program select in load menu
-    if (key === KEY.PROGRAM_SELECT) {
-      setTimeout(() => {
-        const loadKey = appState.presetKey.startsWith(KEY_PREFIX.DSP_A)
-          ? KEY.LOAD_TRIGGER_A
-          : KEY.LOAD_TRIGGER_B;
-        sendValuePut(loadKey, '1');
-        log(`Auto-triggered load for ${loadKey} after program change`, 'info', 'general');
-        setTimeout(() => {
-          updateScreen();
-          sendObjectInfoDump(KEY.ROOT);
-          log('Fetched root after preset load.', 'debug', 'general');
-          if (appState.updateBitmapOnChange) {
-            sendSysEx(CMD.GET_SCREEN, []);
-            log('Triggered bitmap update after TRG.', 'debug', 'bitmap');
-          }
-        }, TIMING.DEVICE_LOAD_MS); // Delay for device to process load and fetch root
-      }, TIMING.PROGRAM_SET_MS); // Additional delay to ensure program value is set
-    }
+    // NOTE: choosing a program from the dropdown only HIGHLIGHTS it (sets
+    // the device's selected slot) — it does NOT load it. Loading is the
+    // explicit '<- load program in A/B' TRG (handleParamClick), matching
+    // the hardware: scroll picks, SELECT/<load>/ENT applies (manual p.21,
+    // maintainer request). The old auto-load fired the trigger here.
   }, TIMING.MIDI_SETTLE_MS); // Delay to allow MIDI update
 };
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -428,10 +428,128 @@ body {
   flex-direction: column;
   border-radius: 2px;
   transition: filter 160ms ease;
+  /* The LCD is a device panel, not a document: a click-drag over a value
+     must not text-SELECT down through the whole monospace block (it ran
+     from a field to every line below, reading as a glitch). The inline
+     editor re-enables selection for itself below. */
+  user-select: none;
+}
+#lcd input.lcd-edit {
+  user-select: text;
 }
 #lcd.loading {
   filter: brightness(0.55);
   pointer-events: none;
+}
+
+/* Library-sync dialog (#142 follow-up): blocking overlay ON the LCD,
+   sibling of #lcd inside the bezel and UNDER .glass, so it refracts like
+   the real display. Phosphor styling mirrors #lcd; covers the recess
+   exactly (inset = bezel padding). */
+.sync-dialog {
+  position: absolute;
+  inset: var(--bezel-pad);
+  z-index: 1; /* over #lcd, under .glass (which has no z-index, paints later) */
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px 20px;
+  font-family: 'OrvilleLCD', ui-monospace, Consolas, monospace;
+  font-size: 22px;
+  line-height: 28px;
+  color: var(--lcd-px);
+  background:
+    radial-gradient(
+      ellipse 90% 70% at 50% 35%,
+      color-mix(in srgb, var(--lcd-px) 8%, transparent),
+      transparent 70%
+    ),
+    var(--lcd-bg);
+  text-shadow:
+    0 0 2px var(--lcd-px),
+    0 0 8px var(--lcd-glow);
+  border-radius: 2px;
+  -webkit-font-smoothing: none;
+}
+.sync-title {
+  text-align: center;
+  background: var(--lcd-px);
+  color: var(--lcd-bg);
+  text-shadow: none;
+  letter-spacing: 0.3em;
+  padding: 2px 0;
+}
+.sync-bar {
+  white-space: pre;
+}
+.sync-count {
+  color: var(--lcd-px-dim);
+}
+.sync-line {
+  white-space: pre;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.sync-cur {
+  background: var(--lcd-px);
+  color: var(--lcd-bg);
+  text-shadow: none;
+}
+.sync-map {
+  white-space: pre;
+  line-height: 22px;
+  letter-spacing: 3px;
+  margin: 2px 0;
+}
+.sync-map .cell-on {
+  color: var(--lcd-px);
+}
+.sync-map .cell-cur {
+  background: var(--lcd-px);
+  color: var(--lcd-bg);
+  text-shadow: none;
+  animation: sync-pulse 0.7s steps(2, jump-none) infinite;
+}
+.sync-map .cell-skip {
+  color: var(--led-amber);
+}
+.sync-map .cell-pending {
+  color: var(--lcd-px-dim);
+}
+@keyframes sync-pulse {
+  50% {
+    opacity: 0.4;
+  }
+}
+.sync-foot {
+  margin-top: auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.sync-eta {
+  color: var(--lcd-px-dim);
+  font-size: 18px;
+}
+.sync-cancel {
+  font-family: inherit;
+  font-size: 18px;
+  color: var(--lcd-px);
+  background: var(--lcd-bg);
+  border: none;
+  box-shadow: inset 0 0 0 2px var(--lcd-px-dim);
+  padding: 2px 12px;
+  cursor: pointer;
+  text-shadow: inherit;
+}
+.sync-cancel:hover {
+  background: var(--lcd-px);
+  color: var(--lcd-bg);
+  text-shadow: none;
+}
+.sync-done {
+  text-align: center;
+  color: var(--lcd-px);
 }
 .line {
   height: var(--lcd-row-h);
@@ -821,6 +939,31 @@ body {
 }
 .util-search {
   width: 240px;
+}
+.util-search:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+/* Sync status chip beside the Sync Library button (#142 follow-up). */
+.sync-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  color: var(--legend-dim);
+  white-space: nowrap;
+}
+.sync-status::before {
+  content: '';
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #3a3a3e; /* unsynced: dark lamp */
+}
+.sync-status.synced::before {
+  background: var(--led-green);
+  box-shadow: 0 0 5px color-mix(in srgb, var(--led-green) 60%, transparent);
 }
 .search-results {
   position: absolute;

--- a/src/styles.css
+++ b/src/styles.css
@@ -449,7 +449,9 @@ body {
 .sync-dialog {
   position: absolute;
   inset: var(--bezel-pad);
-  z-index: 1; /* over #lcd, under .glass (which has no z-index, paints later) */
+  /* No z-index: as a positioned sibling AFTER #lcd and BEFORE .glass in
+     the DOM, it paints over the LCD and under the glass by paint order —
+     a z-index here would lift it above the glass and kill the refraction. */
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -470,8 +472,31 @@ body {
     0 0 8px var(--lcd-glow);
   border-radius: 2px;
   -webkit-font-smoothing: none;
+  overflow: hidden;
+}
+/* Drifting CRT scanlines over the whole dialog (subtle, non-interactive). */
+.sync-dialog::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 0.16) 0,
+    rgba(0, 0, 0, 0.16) 1px,
+    transparent 1px,
+    transparent 4px
+  );
+  animation: sync-scanlines 6s linear infinite;
+}
+@keyframes sync-scanlines {
+  to {
+    background-position: 0 80px;
+  }
 }
 .sync-title {
+  position: relative;
+  overflow: hidden;
   text-align: center;
   background: var(--lcd-px);
   color: var(--lcd-bg);
@@ -479,11 +504,142 @@ body {
   letter-spacing: 0.3em;
   padding: 2px 0;
 }
+/* A bright band sweeps across the inverted title bar (loading-screen feel). */
+.sync-title-sweep {
+  position: relative;
+}
+.sync-title::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 35%;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.55), transparent);
+  animation: sync-title-sweep 2.2s linear infinite;
+}
+@keyframes sync-title-sweep {
+  from {
+    left: -40%;
+  }
+  to {
+    left: 110%;
+  }
+}
+.sync-title-flash {
+  animation: sync-flash 0.5s steps(1) 3;
+}
+@keyframes sync-flash {
+  50% {
+    background: var(--lcd-bg);
+    color: var(--lcd-px);
+  }
+}
 .sync-bar {
   white-space: pre;
 }
-.sync-count {
+/* Energy shimmer sweeping through the filled run of the bar. */
+.sync-bar-fill {
+  position: relative;
+  color: var(--lcd-px);
+}
+.sync-bar-fill::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    100deg,
+    transparent 35%,
+    rgba(255, 255, 255, 0.6) 50%,
+    transparent 65%
+  );
+  background-size: 250% 100%;
+  mix-blend-mode: screen;
+  animation: sync-shimmer 1.1s linear infinite;
+}
+@keyframes sync-shimmer {
+  from {
+    background-position: 130% 0;
+  }
+  to {
+    background-position: -130% 0;
+  }
+}
+.sync-bar-empty {
   color: var(--lcd-px-dim);
+}
+.sync-count {
+  color: var(--lcd-px);
+}
+/* Block-quadrant spinner (pixel-art activity indicator). */
+.sync-spinner::before {
+  content: '\2596';
+  animation: sync-spin 0.5s steps(1) infinite;
+}
+@keyframes sync-spin {
+  0% {
+    content: '\2596';
+  } /* ▖ */
+  25% {
+    content: '\2598';
+  } /* ▘ */
+  50% {
+    content: '\259d';
+  } /* ▝ */
+  75% {
+    content: '\2597';
+  } /* ▗ */
+}
+/* Blinking terminal caret after the current bank name. */
+.sync-caret {
+  animation: sync-blink 0.9s steps(1) infinite;
+}
+@keyframes sync-blink {
+  50% {
+    opacity: 0;
+  }
+}
+/* Animated ellipsis for the indeterminate phases. */
+.sync-ellipsis::after {
+  content: '';
+  animation: sync-ellipsis 1.2s steps(4) infinite;
+}
+@keyframes sync-ellipsis {
+  0% {
+    content: '';
+  }
+  25% {
+    content: '.';
+  }
+  50% {
+    content: '..';
+  }
+  75% {
+    content: '...';
+  }
+}
+/* Larson/Knight-Rider scanner: a bright band sweeps the dim cells while
+   the bank count is still unknown. */
+.sync-scanner {
+  white-space: pre;
+  background: linear-gradient(
+    90deg,
+    var(--lcd-px-dim) 42%,
+    var(--lcd-px) 50%,
+    var(--lcd-px-dim) 58%
+  );
+  background-size: 260% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: sync-larson 1.5s ease-in-out infinite alternate;
+}
+@keyframes sync-larson {
+  from {
+    background-position: 0% 0;
+  }
+  to {
+    background-position: 100% 0;
+  }
 }
 .sync-line {
   white-space: pre;
@@ -503,22 +659,40 @@ body {
 }
 .sync-map .cell-on {
   color: var(--lcd-px);
+  text-shadow:
+    0 0 2px var(--lcd-px),
+    0 0 6px var(--lcd-glow);
 }
+/* The head cell strobes between filled and inverse — a working read/write
+   head (defrag activity). */
 .sync-map .cell-cur {
-  background: var(--lcd-px);
-  color: var(--lcd-bg);
-  text-shadow: none;
-  animation: sync-pulse 0.7s steps(2, jump-none) infinite;
+  color: var(--lcd-px);
+  animation: sync-head 0.45s steps(1) infinite;
+}
+@keyframes sync-head {
+  0% {
+    background: var(--lcd-px);
+    color: var(--lcd-bg);
+  }
+  50% {
+    background: transparent;
+    color: var(--lcd-px);
+  }
 }
 .sync-map .cell-skip {
   color: var(--led-amber);
+  animation: sync-blink 0.9s steps(1) infinite;
 }
 .sync-map .cell-pending {
   color: var(--lcd-px-dim);
 }
-@keyframes sync-pulse {
-  50% {
-    opacity: 0.4;
+.sync-map-done .cell-on,
+.sync-map-done {
+  animation: sync-sweep-in 0.5s ease-out;
+}
+@keyframes sync-sweep-in {
+  from {
+    filter: brightness(2.2);
   }
 }
 .sync-foot {
@@ -550,6 +724,18 @@ body {
 .sync-done {
   text-align: center;
   color: var(--lcd-px);
+}
+.sync-check {
+  display: inline-block;
+  animation: sync-check-pop 0.4s ease-out;
+}
+@keyframes sync-check-pop {
+  from {
+    transform: scale(0);
+  }
+  60% {
+    transform: scale(1.5);
+  }
 }
 .line {
   height: var(--lcd-row-h);

--- a/src/styles.css
+++ b/src/styles.css
@@ -446,6 +446,11 @@ body {
    sibling of #lcd inside the bezel and UNDER .glass, so it refracts like
    the real display. Phosphor styling mirrors #lcd; covers the recess
    exactly (inset = bezel padding). */
+/* [hidden] must win over the display below, or the dialog can never be
+   dismissed (an explicit display beats the UA [hidden] { display:none }). */
+.sync-dialog[hidden] {
+  display: none;
+}
 .sync-dialog {
   position: absolute;
   inset: var(--bezel-pad);

--- a/src/sync-dialog.js
+++ b/src/sync-dialog.js
@@ -110,7 +110,11 @@ export function showSyncComplete(summary) {
   node.innerHTML =
     '<div class="sync-title sync-title-flash">SYNC COMPLETE</div>' +
     `<div class="sync-line sync-done"><span class="sync-check">&#10003;</span> ${summary.programs} programs &middot; ${summary.banks} banks</div>` +
-    `<div class="sync-map sync-map-done">${'█'.repeat(BAR_CELLS)}</div>`;
+    `<div class="sync-map sync-map-done">${'█'.repeat(BAR_CELLS)}</div>` +
+    '<div class="sync-foot"><span class="sync-eta">library saved</span>' +
+    '<button type="button" class="sync-cancel sync-done-btn">DONE</button></div>';
+  const doneBtn = node.querySelector('.sync-done-btn');
+  if (doneBtn) doneBtn.addEventListener('click', hideSyncDialog, { once: true });
 }
 
 /** Removes the dialog. */

--- a/src/sync-dialog.js
+++ b/src/sync-dialog.js
@@ -41,7 +41,7 @@ function mmss(ms) {
 function renderBankMap(bankStates) {
   const cellsPerRow = 24;
   const rows = [];
-  for (let i = 0; i < bankStates.length; i += cellsPerRow) {
+  for (let i = 0; i < (bankStates?.length ?? 0); i += cellsPerRow) {
     const slice = bankStates.slice(i, i + cellsPerRow);
     rows.push(
       slice
@@ -64,27 +64,35 @@ function renderBankMap(bankStates) {
  *   bankStates: string[], etaMs: number|null}} p
  * @param {() => void} onCancel
  */
+const TITLE = '<div class="sync-title"><span class="sync-title-sweep">LIBRARY SYNC</span></div>';
+
 export function showSyncProgress(p, onCancel) {
   const node = ensureEl();
   if (!node) return;
   node.hidden = false;
 
   if (p.phase === 'preparing') {
+    // Indeterminate: a Larson/Knight-Rider scanner sweeps while we fetch
+    // the bank list (we don't know the count yet).
     node.innerHTML =
-      '<div class="sync-title">LIBRARY SYNC</div>' +
-      '<div class="sync-line">reading bank list ...</div>';
+      TITLE +
+      '<div class="sync-line">reading bank list<span class="sync-ellipsis"></span></div>' +
+      `<div class="sync-scanner">${'▒'.repeat(BAR_CELLS)}</div>`;
     return;
   }
 
   const filled = p.total ? Math.round((p.done / p.total) * BAR_CELLS) : 0;
-  const bar = '█'.repeat(filled) + '░'.repeat(BAR_CELLS - filled);
   const restoring = p.phase === 'restoring';
+  const pct = p.total ? Math.round((p.done / p.total) * 100) : 0;
   node.innerHTML =
-    '<div class="sync-title">LIBRARY SYNC</div>' +
-    `<div class="sync-bar">${bar} <span class="sync-count">${p.done}/${p.total}</span></div>` +
-    `<div class="sync-line">${restoring ? 'restoring your bank ...' : `<span class="sync-cur">&gt;</span> ${escapeText(p.name)}`}</div>` +
+    TITLE +
+    `<div class="sync-bar"><span class="sync-spinner"></span> ` +
+    `<span class="sync-bar-fill">${'█'.repeat(filled)}</span>` +
+    `<span class="sync-bar-empty">${'░'.repeat(BAR_CELLS - filled)}</span>` +
+    ` <span class="sync-count">${pct}%</span></div>` +
+    `<div class="sync-line">${restoring ? 'restoring your bank<span class="sync-ellipsis"></span>' : `<span class="sync-cur">&gt;</span> ${escapeText(p.name)}<span class="sync-caret">█</span>`}</div>` +
     `<div class="sync-map">${renderBankMap(p.bankStates)}</div>` +
-    `<div class="sync-foot"><span class="sync-eta">${restoring ? '' : `est. ${mmss(p.etaMs)} remaining`}</span>` +
+    `<div class="sync-foot"><span class="sync-eta">${restoring ? `${p.done} captured` : `est. ${mmss(p.etaMs)} remaining · ${p.done}/${p.total}`}</span>` +
     '<button type="button" class="sync-cancel">CANCEL</button></div>';
   const cancelBtn = node.querySelector('.sync-cancel');
   if (cancelBtn) cancelBtn.addEventListener('click', onCancel, { once: true });
@@ -100,8 +108,9 @@ export function showSyncComplete(summary) {
   if (!node) return;
   node.hidden = false;
   node.innerHTML =
-    '<div class="sync-title">SYNC COMPLETE</div>' +
-    `<div class="sync-line sync-done">${summary.programs} programs &middot; ${summary.banks} banks</div>`;
+    '<div class="sync-title sync-title-flash">SYNC COMPLETE</div>' +
+    `<div class="sync-line sync-done"><span class="sync-check">&#10003;</span> ${summary.programs} programs &middot; ${summary.banks} banks</div>` +
+    `<div class="sync-map sync-map-done">${'█'.repeat(BAR_CELLS)}</div>`;
 }
 
 /** Removes the dialog. */

--- a/src/sync-dialog.js
+++ b/src/sync-dialog.js
@@ -1,0 +1,118 @@
+// sync-dialog.js
+// The library-sync progress dialog (#142 follow-up): a blocking overlay
+// drawn ON the LCD — a SIBLING of #lcd inside the bezel, UNDER the glass
+// pane, so it refracts like real phosphor and never touches the
+// renderer-owned #lcd subtree. Pure presentation fed by syncLibrary's
+// onProgress; the scan already locks out LCD interaction (renderer
+// isSyncing guards), so this makes that lockout legible.
+//
+// The centerpiece is a defrag-style bank map: one cell per bank, lighting
+// in phosphor as each is captured (current pulses, dropped = x), plus a
+// character-cell progress bar, the current bank name, and a rolling ETA.
+
+import { LAYOUT } from './constants.js';
+
+const BAR_CELLS = LAYOUT.LCD_COLUMNS - 8; // progress bar width inside the glass margin
+
+let el = null; // the overlay element (created lazily, reused)
+
+function ensureEl() {
+  if (el) return el;
+  const bezel = document.querySelector('.bezel');
+  if (!bezel) return null;
+  el = document.createElement('div');
+  el.className = 'sync-dialog';
+  el.hidden = true;
+  // Inserted before .glass so the glass paints over it.
+  const glass = bezel.querySelector('.glass');
+  bezel.insertBefore(el, glass || null);
+  return el;
+}
+
+function mmss(ms) {
+  if (ms == null || !isFinite(ms)) return '--:--';
+  const s = Math.round(ms / 1000);
+  return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`;
+}
+
+// The defrag bank map as rows of cells. captured = lit block, current =
+// inverse, skipped = x, pending = dim. cellsPerRow keeps the grid inside
+// the 40-column LCD.
+function renderBankMap(bankStates) {
+  const cellsPerRow = 24;
+  const rows = [];
+  for (let i = 0; i < bankStates.length; i += cellsPerRow) {
+    const slice = bankStates.slice(i, i + cellsPerRow);
+    rows.push(
+      slice
+        .map((st) => {
+          if (st === 'captured') return '<span class="cell cell-on">█</span>';
+          if (st === 'current') return '<span class="cell cell-cur">█</span>';
+          if (st === 'skipped') return '<span class="cell cell-skip">x</span>';
+          return '<span class="cell cell-pending">░</span>';
+        })
+        .join('')
+    );
+  }
+  return rows.join('\n');
+}
+
+/**
+ * Shows / updates the dialog from a syncLibrary progress payload.
+ *
+ * @param {{phase: string, done: number, total: number, name: string,
+ *   bankStates: string[], etaMs: number|null}} p
+ * @param {() => void} onCancel
+ */
+export function showSyncProgress(p, onCancel) {
+  const node = ensureEl();
+  if (!node) return;
+  node.hidden = false;
+
+  if (p.phase === 'preparing') {
+    node.innerHTML =
+      '<div class="sync-title">LIBRARY SYNC</div>' +
+      '<div class="sync-line">reading bank list ...</div>';
+    return;
+  }
+
+  const filled = p.total ? Math.round((p.done / p.total) * BAR_CELLS) : 0;
+  const bar = '█'.repeat(filled) + '░'.repeat(BAR_CELLS - filled);
+  const restoring = p.phase === 'restoring';
+  node.innerHTML =
+    '<div class="sync-title">LIBRARY SYNC</div>' +
+    `<div class="sync-bar">${bar} <span class="sync-count">${p.done}/${p.total}</span></div>` +
+    `<div class="sync-line">${restoring ? 'restoring your bank ...' : `<span class="sync-cur">&gt;</span> ${escapeText(p.name)}`}</div>` +
+    `<div class="sync-map">${renderBankMap(p.bankStates)}</div>` +
+    `<div class="sync-foot"><span class="sync-eta">${restoring ? '' : `est. ${mmss(p.etaMs)} remaining`}</span>` +
+    '<button type="button" class="sync-cancel">CANCEL</button></div>';
+  const cancelBtn = node.querySelector('.sync-cancel');
+  if (cancelBtn) cancelBtn.addEventListener('click', onCancel, { once: true });
+}
+
+/**
+ * Final beat: holds on a completion summary, then dismisses.
+ *
+ * @param {{banks: number, programs: number}} summary
+ */
+export function showSyncComplete(summary) {
+  const node = ensureEl();
+  if (!node) return;
+  node.hidden = false;
+  node.innerHTML =
+    '<div class="sync-title">SYNC COMPLETE</div>' +
+    `<div class="sync-line sync-done">${summary.programs} programs &middot; ${summary.banks} banks</div>`;
+}
+
+/** Removes the dialog. */
+export function hideSyncDialog() {
+  if (el) el.hidden = true;
+}
+
+// #lcd content is device text; the only interpolations here are bank
+// names — escape them, matching the renderer's own caution.
+function escapeText(s) {
+  const div = document.createElement('div');
+  div.textContent = String(s ?? '');
+  return div.innerHTML;
+}

--- a/src/tree.js
+++ b/src/tree.js
@@ -334,28 +334,29 @@ export function isFresh(key) {
 
 /**
  * Stales every cached key under the given key's stable prefix, if any.
- * Called by sendValuePut (every in-app put — TRG/STR/SET/NUM, including
- * bank selects, which change the device's program list) — one of the two
- * in-app mutation chokepoints (the other is sendKeypress).
+ * Called by sendValuePut (every in-app put — TRG/STR/SET/NUM) — one of the
+ * two in-app mutation chokepoints (the other is sendKeypress).
  *
  * @param {string} key
  */
 export function markDirtyIfStable(key) {
+  // #138/#141: the bank and program CHOOSERS are pure VIEW changes — they
+  // pick which program list shows, they do not alter the bank list or the
+  // menu structure. Staling on them made every bank-hop (and the library
+  // sync's ~70 bank puts) mark the whole program subtree dirty, so the
+  // next PROGRAM visit refetched the multi-second 70-name bank list from
+  // scratch even though it was cached. They are now a full no-op: the
+  // per-bank program list is handled by the memo + the bank-change
+  // targeted fetch, and the bank list itself only changes on
+  // create/delete-bank (TRG puts, which still stale below).
+  if (key === KEY.BANK_SELECT || key === KEY.PROGRAM_SELECT) return;
   const p = stablePrefixOf(key);
   if (!p) return;
   markGeneration++; // #121: in-flight requests are now pre-mutation
   for (const k of nodes.keys()) {
     if (k.startsWith(p)) staleKeys.add(k);
   }
-  // #141: selection puts (the bank/program choosers) are pure VIEW
-  // changes — they cannot alter any bank's program list, and the bank put
-  // is the very action the memo exists to accelerate (live finding: the
-  // unconditional clear wiped the memo on every bank change, defeating
-  // it). Everything else under the prefix (saves, deletes, renames, load
-  // triggers) may rewrite lists: clear.
-  if (key !== KEY.BANK_SELECT && key !== KEY.PROGRAM_SELECT) {
-    bankProgramLists.clear();
-  }
+  bankProgramLists.clear(); // a save/delete/rename/load may rewrite lists
 }
 
 /**

--- a/src/tree.js
+++ b/src/tree.js
@@ -340,23 +340,33 @@ export function isFresh(key) {
  * @param {string} key
  */
 export function markDirtyIfStable(key) {
-  // #138/#141: the bank and program CHOOSERS are pure VIEW changes — they
-  // pick which program list shows, they do not alter the bank list or the
-  // menu structure. Staling on them made every bank-hop (and the library
-  // sync's ~70 bank puts) mark the whole program subtree dirty, so the
-  // next PROGRAM visit refetched the multi-second 70-name bank list from
-  // scratch even though it was cached. They are now a full no-op: the
-  // per-bank program list is handled by the memo + the bank-change
-  // targeted fetch, and the bank list itself only changes on
-  // create/delete-bank (TRG puts, which still stale below).
-  if (key === KEY.BANK_SELECT || key === KEY.PROGRAM_SELECT) return;
+  // #138: puts that do NOT change the program/bank LISTS or the menu
+  // structure are pure view/runtime changes and must not stale the
+  // subtree (else the next PROGRAM visit refetches the multi-second
+  // 70-name bank list from cache for nothing):
+  //   - BANK_SELECT / PROGRAM_SELECT: pick which list shows.
+  //   - LOAD_TRIGGER_A/B: load a program into a DSP — changes the running
+  //     preset (root names + the preset param subtree, fetched separately)
+  //     but leaves every bank/program list intact. Live finding: staling
+  //     here made the post-load refetch reload the bank list WHILE the
+  //     device was busy loading, cascading watchdog stalls (~2s of dead
+  //     wait). Saves/deletes/renames (other TRG/STR puts) DO rewrite lists
+  //     and still stale below.
+  if (
+    key === KEY.BANK_SELECT ||
+    key === KEY.PROGRAM_SELECT ||
+    key === KEY.LOAD_TRIGGER_A ||
+    key === KEY.LOAD_TRIGGER_B
+  ) {
+    return;
+  }
   const p = stablePrefixOf(key);
   if (!p) return;
   markGeneration++; // #121: in-flight requests are now pre-mutation
   for (const k of nodes.keys()) {
     if (k.startsWith(p)) staleKeys.add(k);
   }
-  bankProgramLists.clear(); // a save/delete/rename/load may rewrite lists
+  bankProgramLists.clear(); // a save/delete/rename may rewrite lists
 }
 
 /**

--- a/tests/event-bridge.test.js
+++ b/tests/event-bridge.test.js
@@ -1,4 +1,4 @@
-// tests/event-bridge.test.js
+﻿// tests/event-bridge.test.js
 // Pins the C1 (#37) bridge contract directly: exactly three render triggers
 // (current-key dump; child-of-current-menu arrival, R7; dumpComplete), hideLoading
 // driven solely by dumpComplete (C4/#40), teardown unsubscribing everything, and the
@@ -138,7 +138,7 @@ describe('event-bridge (C1: dumpComplete-driven rendering)', () => {
     expect(hideLoading).toHaveBeenCalledTimes(1);
   });
 
-  test('a screen-only wave hides loading — the bitmap fetch shows its own progress (#3)', () => {
+  test('a screen-only wave hides loading â€” the bitmap fetch shows its own progress (#3)', () => {
     emit('dumpComplete', { reason: 'all-received', objectinfoSends: 0, screenSends: 1 });
     expect(hideLoading).toHaveBeenCalledTimes(1);
   });
@@ -239,7 +239,7 @@ describe('event-bridge (C1: dumpComplete-driven rendering)', () => {
 
     emit('dumpComplete', { reason: 'all-received', objectinfoSends: 3 });
     expect(startEagerLoad).toHaveBeenCalledTimes(1);
-    expect(startEagerLoad).toHaveBeenCalledWith('401000b');
+    expect(startEagerLoad).toHaveBeenCalledWith('401000b', ['10020000']);
 
     // One-shot: later drains do not restart it.
     emit('dumpComplete', { reason: 'all-received', objectinfoSends: 1 });
@@ -256,15 +256,15 @@ describe('event-bridge (C1: dumpComplete-driven rendering)', () => {
   test('eager load stays armed through a stalled wave and starts on the next clean drain (#106)', () => {
     // Live-validated: with fetchBitmap on, the landing wave routinely
     // watchdogs on the ~1.2s bitmap transfer (R5a) and self-heals on the
-    // next wave — disarming on the stall would skip the eager load on the
+    // next wave â€” disarming on the stall would skip the eager load on the
     // most common config.
     land();
     emit('dumpComplete', { reason: 'watchdog', objectinfoSends: 3 });
-    expect(startEagerLoad).not.toHaveBeenCalled(); // not yet — but still armed
+    expect(startEagerLoad).not.toHaveBeenCalled(); // not yet â€” but still armed
 
     emit('dumpComplete', { reason: 'all-received', objectinfoSends: 1 });
     expect(startEagerLoad).toHaveBeenCalledTimes(1);
-    expect(startEagerLoad).toHaveBeenCalledWith('401000b');
+    expect(startEagerLoad).toHaveBeenCalledWith('401000b', ['10020000']);
   });
 
   test('dumpComplete without a prior landing never starts an eager load (#106)', () => {
@@ -332,9 +332,9 @@ describe('event-bridge (C1: dumpComplete-driven rendering)', () => {
     expect(updateScreen).not.toHaveBeenCalled();
   });
 
-  test('descend one-shot never descends into gang groups — they are page content (#132)', () => {
+  test('descend one-shot never descends into gang groups â€” they are page content (#132)', () => {
     // Review blocker: the live routing menu (1001008f) has ONLY gang COL
-    // children ('Source 1-4' pos 13, 'In 1-4' pos c — blank tags). The old
+    // children ('Source 1-4' pos 13, 'In 1-4' pos c â€” blank tags). The old
     // filter saw a COL-only menu with >1 children and descended into the
     // first group, so the assembled one-page matrix never showed on the
     // normal click path.
@@ -384,7 +384,7 @@ describe('event-bridge (C1: dumpComplete-driven rendering)', () => {
     emit('dumpComplete', { reason: 'all-received', objectinfoSends: 1 });
     expect(led.classList.contains('lit')).toBe(false);
 
-    // A watchdog settle clears it too — the LED must never strand lit.
+    // A watchdog settle clears it too â€” the LED must never strand lit.
     emit('wave:opened', { kind: 'value' });
     expect(led.classList.contains('lit')).toBe(true);
     emit('dumpComplete', { reason: 'watchdog' });

--- a/tests/library.test.js
+++ b/tests/library.test.js
@@ -34,11 +34,15 @@ import {
   searchLibrary,
   syncLibrary,
   loadSearchHit,
+  canSearch,
+  libraryProgramCount,
 } from '../src/library.js';
 import { sendValuePut, sendObjectInfoDump } from '../src/midi.js';
 import { getNode, bankProgramsFor } from '../src/tree.js';
 import { appState } from '../src/state.js';
 
+// Padded so the corpus clears LIBRARY.SEARCH_MIN_PROGRAMS (search gating).
+const filler = (n) => Array.from({ length: n }, (_, i) => ({ idx: `${i}`, name: `${i} Filler` }));
 const sampleLibrary = {
   syncedAt: 'test',
   banks: [
@@ -48,6 +52,7 @@ const sampleLibrary = {
       programs: [
         { idx: '0', name: '0 Techno Rumble' },
         { idx: '1', name: '1 Black Hole' },
+        ...filler(40),
       ],
     },
     {
@@ -75,6 +80,18 @@ describe('library search', () => {
 
   test('empty query returns nothing', () => {
     expect(searchLibrary('   ')).toEqual([]);
+  });
+
+  test('search is gated on a minimum corpus (#142 follow-up)', () => {
+    setLibrary({
+      syncedAt: 'test',
+      banks: [{ idx: '0', name: '0 Tiny', programs: [{ idx: '0', name: '0 Black Hole' }] }],
+    });
+    expect(libraryProgramCount()).toBe(1);
+    expect(canSearch()).toBe(false);
+    expect(searchLibrary('black hole')).toEqual([]); // below the minimum
+    setLibrary(sampleLibrary);
+    expect(canSearch()).toBe(true);
   });
 });
 
@@ -120,7 +137,13 @@ describe('syncLibrary', () => {
     expect(puts).toContain('10020012:1');
     expect(puts[puts.length - 1]).toBe('10020012:0'); // restore
     expect(sendObjectInfoDump).toHaveBeenCalledWith('10020010');
-    expect(progress).toHaveBeenCalledWith(0, 2, '0 Favorites');
+    // Structured progress: the bank-map defrag state for the dialog.
+    const lastScan = progress.mock.calls
+      .map((c) => c[0])
+      .filter((p) => p.phase === 'scanning')
+      .pop();
+    expect(lastScan).toMatchObject({ done: 2, total: 2 });
+    expect(lastScan.bankStates).toEqual(['captured', 'captured']);
     expect(getLibrary()).toBe(library);
   });
 

--- a/tests/midi.test.js
+++ b/tests/midi.test.js
@@ -231,7 +231,7 @@ describe('midi.js SysEx byte contract', () => {
       },
     ]);
     expect(isFresh('10020010')).toBe(true);
-    sendValuePut('1002001c', '1'); // the load trigger — any program-subtree put
+    sendValuePut('10020025', '1'); // a save-area put — a list-MUTATING program-subtree put
     expect(isFresh('10020010')).toBe(false);
     treeReset();
   });

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -375,7 +375,7 @@ describe('parseResponse', () => {
         tag: 'load',
       },
     ]);
-    markDirtyIfStable('1002001c'); // a save/load/delete put happened
+    markDirtyIfStable('10020025'); // a save/delete put happened (list-mutating)
 
     const programDump =
       'COL 0 10020000 10020000 "program functions" "program"\n' +

--- a/tests/renderer.test.js
+++ b/tests/renderer.test.js
@@ -66,9 +66,9 @@ describe('renderer.js', () => {
 
   // ... **UNCHANGED: all prior passing tests** ...
 
-  test('select change updates SET value and triggers auto-load for program select', () => {
+  test('choosing a program HIGHLIGHTS it but never auto-loads (load is the explicit TRG)', () => {
     appState.currentKey = '10020000';
-    appState.presetKey = '401000b'; // → loadKey='1002001c'
+    appState.presetKey = '401000b';
     const subs = [
       {
         type: 'COL',
@@ -81,7 +81,7 @@ describe('renderer.js', () => {
       {
         type: 'SET',
         position: '1',
-        key: '10020011',
+        key: '10020011', // KEY.PROGRAM_SELECT
         parent: '10020000',
         statement: '%-20s',
         tag: 'Program',
@@ -91,36 +91,20 @@ describe('renderer.js', () => {
     ];
     renderScreen(subs, '', mockLog);
     const select = document.querySelector('select[data-key="10020011"]');
-    expect(select).toBeTruthy();
-
     select.value = '5';
     jest.useFakeTimers();
     select.dispatchEvent(new Event('change', { bubbles: true }));
 
-    // Immediate
-    expect(showLoading).toHaveBeenCalled();
+    // The selection is put (highlights the slot) and cached in HEX shape.
     expect(sendValuePut).toHaveBeenCalledWith('10020011', '5');
     expect(appState.currentValues['10020011']).toBe('5 Preset5');
 
-    // Timeout 200
-    jest.advanceTimersByTime(200);
-    expect(sendSysEx).toHaveBeenCalledWith(0x18, []);
-
-    // Nested timeout 300 (auto-load)
-    jest.advanceTimersByTime(300);
-    expect(sendValuePut).toHaveBeenCalledWith('1002001c', '1');
-    expect(mockLog).toHaveBeenCalledWith(
-      expect.stringContaining('Auto-triggered load'),
-      'info',
-      'general'
-    );
-
-    // Nested timeout 500 (post-load)
-    jest.advanceTimersByTime(500);
-    expect(sendObjectInfoDump).toHaveBeenCalledWith('0');
-    expect(mockLog).toHaveBeenCalledWith('Fetched root after preset load.', 'debug', 'general');
-    expect(sendSysEx).toHaveBeenCalledWith(0x18, []); // 2nd bitmap
-
+    // Run every timer to completion — the load trigger must NEVER fire,
+    // and root must not be refetched as a post-load step (maintainer:
+    // selecting a program should not apply it).
+    jest.runOnlyPendingTimers();
+    expect(sendValuePut).not.toHaveBeenCalledWith('1002001c', '1'); // LOAD_TRIGGER_A
+    expect(sendValuePut).not.toHaveBeenCalledWith('1002001d', '1'); // LOAD_TRIGGER_B
     jest.useRealTimers();
   });
 

--- a/tests/renderer.test.js
+++ b/tests/renderer.test.js
@@ -712,6 +712,48 @@ describe('renderer.js', () => {
     expect(lcd.querySelectorAll('select[data-key]').length).toBe(2);
   });
 
+  test('device labels with < are escaped, not parsed as HTML (live bug: fb<tap)', () => {
+    // The multitap delay's feedback label 'fb<tap1' rendered as just 'fb'
+    // and its phantom <tap1> tag wrapped every line below, so one hover lit
+    // the whole screen.
+    appState.currentKey = '8040001';
+    const subs = [
+      { type: 'COL', position: '0', key: '8040001', parent: '', statement: 'Delay', tag: 'delay' },
+      {
+        type: 'NUM',
+        position: '1',
+        key: '8040002',
+        parent: '8040001',
+        statement: 'fb<tap1: %4.0f',
+        tag: 'fb',
+        value: '50',
+        min: '0',
+        max: '100',
+      },
+      {
+        type: 'NUM',
+        position: '2',
+        key: '8040003',
+        parent: '8040001',
+        statement: 'fb>tap2: %4.0f',
+        tag: 'fb',
+        value: '60',
+        min: '0',
+        max: '100',
+      },
+    ];
+    renderScreen(subs, '', mockLog);
+    const lcd = document.getElementById('lcd');
+    // The full label survives as text...
+    expect(lcd.textContent).toContain('fb<tap1');
+    expect(lcd.textContent).toContain('fb>tap2');
+    // ...with no phantom <tap1> element, and the escaped entity in the HTML.
+    expect(lcd.querySelector('tap1')).toBeNull();
+    expect(lcd.innerHTML).toContain('fb&lt;tap1');
+    // Both NUM values stay independently clickable (no wrapping bleed).
+    expect(lcd.querySelectorAll('.param-value')).toHaveLength(2);
+  });
+
   test('NUM edits inline in the glass — valid commits, invalid flashes, never a browser box', () => {
     appState.currentKey = '10010001';
     const subs = [

--- a/tests/renderer.test.js
+++ b/tests/renderer.test.js
@@ -99,12 +99,21 @@ describe('renderer.js', () => {
     expect(sendValuePut).toHaveBeenCalledWith('10020011', '5');
     expect(appState.currentValues['10020011']).toBe('5 Preset5');
 
+    // No loading dim: a program select is instant and confirms with a
+    // VALUE dump only, which never fires hideLoading — so showing the dim
+    // would strand the screen dimmed forever (regression).
+    expect(showLoading).not.toHaveBeenCalled();
+
     // Run every timer to completion — the load trigger must NEVER fire,
     // and root must not be refetched as a post-load step (maintainer:
     // selecting a program should not apply it).
     jest.runOnlyPendingTimers();
     expect(sendValuePut).not.toHaveBeenCalledWith('1002001c', '1'); // LOAD_TRIGGER_A
     expect(sendValuePut).not.toHaveBeenCalledWith('1002001d', '1'); // LOAD_TRIGGER_B
+    // No full-menu refetch either (the "syncing" lag) — only the targeted
+    // program-value confirm.
+    expect(sendObjectInfoDump).not.toHaveBeenCalled();
+    expect(sendValueDump).toHaveBeenCalledWith('10020011');
     jest.useRealTimers();
   });
 

--- a/tests/startup.test.js
+++ b/tests/startup.test.js
@@ -491,13 +491,15 @@ describe('startup characterization (roadmap step 5.5)', () => {
       'state:renderer:render-pin:currentSoftkeys,currentSubs',
       'hideLoading',
 
-      // #106: the landing armed the eager loader; the clean drain starts it.
-      // The preset and the landed first menu are already tree-cached, so the
-      // serialized walk's first (and in this simulation only) request is the
-      // preset's second COL child. No response ever arrives here, so the
-      // walk holds at one in-flight request — pinning the one-at-a-time
-      // scheduling.
-      `midi:objectinfo:${expected401.navColKeys[1]}`,
+      // #106/#138: the landing armed the eager loader; the clean drain
+      // starts it, now warming the PROGRAM menu (10020000) alongside the
+      // preset subtree. The preset and landed menu are already tree-cached,
+      // and the program-warm key was queued right after the preset root, so
+      // it is the serialized walk's first uncached request (its ~70-name
+      // bank-list dump is the slowest on the link — warming it makes the
+      // first PROGRAM visit instant). No response arrives in this
+      // simulation, so the walk holds at one in-flight request.
+      'midi:objectinfo:10020000',
     ];
 
     const actual = drainAndSort(getEvents()).map(normalize).filter(Boolean);

--- a/tests/tree.test.js
+++ b/tests/tree.test.js
@@ -1,4 +1,4 @@
-// tests/tree.test.js — the T1b device-tree store (src/tree.js).
+﻿// tests/tree.test.js â€” the T1b device-tree store (src/tree.js).
 
 import {
   recordDump,
@@ -74,7 +74,7 @@ describe('tree store (T1b)', () => {
     ]);
     expect(getNode('401000b')[0].statement).toBe('Wormhole');
     expect(parentOf('4990001')).toBe('401000b');
-    // The old child's linkage survives until overwritten elsewhere — the
+    // The old child's linkage survives until overwritten elsewhere â€” the
     // tree is last-observed structure, not a garbage-collected mirror.
     expect(parentOf('4040001')).toBe('401000b');
   });
@@ -113,7 +113,7 @@ describe('tree store (T1b)', () => {
     expect(labelFor('feed0000')).toBe('...');
   });
 
-  describe('stable-subtree freshness (#113 — per-key staleness; program prefix 10020)', () => {
+  describe('stable-subtree freshness (#113 â€” per-key staleness; program prefix 10020)', () => {
     test('isFresh requires cached + stable + not stale; only a RE-RECORD un-stales', () => {
       expect(isFresh('10020010')).toBe(false); // uncached
       recordDump([
@@ -129,11 +129,11 @@ describe('tree store (T1b)', () => {
 
       // A mutating put anywhere under the prefix stales every cached key
       // under it.
-      markDirtyIfStable('1002001c'); // the load trigger
+      markDirtyIfStable('10020025'); // a save-area put (mutates the lists)
       expect(isFresh('10020010')).toBe(false);
       expect(isFresh('10020020')).toBe(false);
 
-      // Re-recording ONE node un-stales only that node — a deep visit (or
+      // Re-recording ONE node un-stales only that node â€” a deep visit (or
       // a dropped sibling response) can never launder staleness into the
       // rest of the subtree. The re-record must come from a POST-mark
       // request (#121): stamp as sendObjectInfoDump does in production.
@@ -153,6 +153,15 @@ describe('tree store (T1b)', () => {
       expect(isFresh('10020010')).toBe(true);
       markDirtyIfStable('10020011'); // PROGRAM_SELECT
       expect(isFresh('10020010')).toBe(true);
+
+      // A LOAD trigger is also a no-op (#138): loading a program changes
+      // the running preset (root names + the preset param subtree), not
+      // any bank/program list — staling here forced a bank-list refetch
+      // WHILE the device was busy loading (watchdog stalls).
+      markDirtyIfStable('1002001c'); // LOAD_TRIGGER_A
+      expect(isFresh('10020010')).toBe(true);
+      markDirtyIfStable('1002001d'); // LOAD_TRIGGER_B
+      expect(isFresh('10020010')).toBe(true);
     });
 
     test('a response whose request predates the mutation stays stale (#121 race, both variants)', () => {
@@ -160,9 +169,9 @@ describe('tree store (T1b)', () => {
       // was stamped pre-mark; the put bumps the generation; the arriving
       // pre-mutation dump records but is NOT trusted across visits.
       recordDump([col('10020010', '10020010', 'load new preset', 'load')]);
-      markDirtyIfStable('1002001c');
+      markDirtyIfStable('10020025');
       stampStableRequest('10020010'); // refetch goes out...
-      markDirtyIfStable('1002001c'); // ...another put lands mid-flight
+      markDirtyIfStable('10020025'); // ...another put lands mid-flight
       recordDump([col('10020010', '10020010', 'load new preset', 'load')]); // pre-put response
       expect(getNode('10020010')).toBeDefined(); // recorded (newest data we have)
       expect(isFresh('10020010')).toBe(false); // but not trusted
@@ -176,7 +185,7 @@ describe('tree store (T1b)', () => {
       // post-put. markDirtyIfStable could not stale it (not cached), but
       // the generation check still refuses trust.
       stampStableRequest('10020020');
-      markDirtyIfStable('1002001c');
+      markDirtyIfStable('10020025');
       recordDump([col('10020020', '10020020', 'save program', 'save')]);
       expect(isFresh('10020020')).toBe(false);
     });
@@ -184,9 +193,9 @@ describe('tree store (T1b)', () => {
     test('a duplicate response without a new stamp stays TRUSTED (#121 review fix)', () => {
       // Rapid double navigation fans out twice: two responses for one
       // stamped request. Consuming the stamp on the first would flip the
-      // second — genuinely post-mark — back to stale.
+      // second â€” genuinely post-mark â€” back to stale.
       recordDump([col('10020010', '10020010', 'load new preset', 'load')]);
-      markDirtyIfStable('1002001c'); // gen > 0 (the norm in a live session)
+      markDirtyIfStable('10020025'); // gen > 0 (the norm in a live session)
       stampStableRequest('10020010');
       recordDump([col('10020010', '10020010', 'load new preset', 'load')]); // response 1
       expect(isFresh('10020010')).toBe(true);
@@ -194,7 +203,7 @@ describe('tree store (T1b)', () => {
       expect(isFresh('10020010')).toBe(true); // stamp kept, still trusted
 
       // A LATER mutation still wins: the kept stamp cannot launder.
-      markDirtyIfStable('1002001c');
+      markDirtyIfStable('10020025');
       recordDump([col('10020010', '10020010', 'load new preset', 'load')]); // old stamp
       expect(isFresh('10020010')).toBe(false);
     });
@@ -207,7 +216,7 @@ describe('tree store (T1b)', () => {
       expect(isFresh('10020010')).toBe(false);
     });
 
-    test('generation 0 trusts unstamped records — seeding before any mutation (#121)', () => {
+    test('generation 0 trusts unstamped records â€” seeding before any mutation (#121)', () => {
       // The audit seeds the tree via direct recordDump with no requests;
       // with no mutation ever marked, nothing can be pre-mutation.
       recordDump([col('10020010', '10020010', 'load new preset', 'load')]);

--- a/tests/tree.test.js
+++ b/tests/tree.test.js
@@ -145,6 +145,14 @@ describe('tree store (T1b)', () => {
       // Puts outside any stable subtree mark nothing.
       markDirtyIfStable('4070001');
       expect(isFresh('10020010')).toBe(true);
+
+      // A bank/program SELECT put is a pure view change and stales NOTHING
+      // (#138 perf): the 70-name bank list stays cached, so revisiting
+      // PROGRAM after a bank-hop or a library sync is instant.
+      markDirtyIfStable('10020012'); // BANK_SELECT
+      expect(isFresh('10020010')).toBe(true);
+      markDirtyIfStable('10020011'); // PROGRAM_SELECT
+      expect(isFresh('10020010')).toBe(true);
     });
 
     test('a response whose request predates the mutation stays stale (#121 race, both variants)', () => {


### PR DESCRIPTION
feat: sync dialog, status chip, search gating, sync-from-anywhere; fix label HTML-injection

Maintainer feedback on the library feature, plus a live bug found while
testing it.

Sync UX (the scan is multi-minute and should not be a mystery):
- An on-LCD blocking dialog (src/sync-dialog.js): a sibling of #lcd
  inside the bezel, UNDER the glass so it refracts like real phosphor,
  never touching the renderer's #lcd subtree. Defrag-style bank map
  (one cell per bank, lit as captured, current pulses, dropped = amber
  x), character-cell progress bar, current bank, rolling ETA, CANCEL,
  and a completion-summary beat before it dismisses. syncLibrary now
  emits a structured progress payload (phase / done / total / name /
  bankStates / etaMs) to drive it.
- A persistent sync-status chip beside the Sync Library button:
  'N presets, synced 12m ago' (green lamp) or 'not synced' (dark) -
  the state is always visible, answering "is it done?".
- Search is GATED on a corpus (LIBRARY.SEARCH_MIN_PROGRAMS): the input
  disables below the minimum with a sync-first hint, since "no results"
  misleads on a tiny library.
- Sync works from ANY page: when the load-menu dump is not cached,
  syncLibrary fetches it first (a 'preparing' phase) instead of
  requiring the user to open the program page.

Fix - device-label HTML injection (live bug, the multi-field highlight):
the multitap delay's feedback label 'fb<tap1' contains a '<', and the
renderer interpolated device text straight into #lcd innerHTML. The
browser parsed '<tap1' as a tag - rendering just 'fb', and since the
phantom tag never closed it WRAPPED every line below, so hovering one
field lit the whole screen. Every device-text interpolation in
renderer.js now goes through escapeHtml (statements, values, tags,
option descs, titles/breadcrumbs, softkey labels, DSP names, gang and
embedded-child variants, pre-paint placeholders). #lcd also gets
user-select: none (a device panel, not a document; the inline editor
re-enables selection for itself).

Tests: 223/223 (escape regression pinning fb<tap; search-gating; the
structured progress payload). Snapshots unchanged (ASCII fixtures).
Live: sync dialog rendered (logs/sync-dialog-real2.png); the Delaytaps
param page shows clean single-line spans with no phantom children.
