### PR TITLE
refactor: single-source-of-truth load menu, no more dropdown races (#138)

### DIFF
--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -808,6 +808,32 @@ device-ID poisoning, corrupt-localStorage hardening, demo SET hex echo). Tests 2
 blocked on the WinMM port: bank select does not refilter the program list (probe ready at
 logs/probe-bank.mjs). OPEN BOARD: #9, #10, #12, #14, #45 (gated), #135.
 
+2026-06-11 night — LOAD-MENU ARCHITECTURE REDESIGN (branch feat/preset-loader, PR open).
+Maintainer report: "lots of race conditions ... the dropdowns keep swapping themselves and
+things take a while to commit." ROOT CAUSE: the program/load-menu bank+program dropdowns were
+reconciled at RENDER time from five competing sources (live dump, optimistic hex cache, session
+memo, synced library, a module-state bank index) and repainted by several async triggers, so any
+repaint could resolve a different source (swap) and every commit waited on a device round-trip
+(slow). FIX: a single source of truth — new DOM-free src/preset-loader.js holds one local
+{bankIdx, programIdx} selection backed by the synced library. Picking a bank/program is PURE LOCAL
+staging (no device I/O), like scrolling on the hardware; the device is touched ONLY when the user
+hits "load program in A/B" (library.js loadProgram: bank->program->trigger PUTs + optimistic
+top-bar name). Every async repaint reads the same selection, so repaints are idempotent — nothing
+swaps. renderer.js: renderLoadMenuSelect sources options/selection from the loader+library and
+seeds once from the live dump (ensureInitialized); handleSelectChange routes the load menu to local
+staging; the LOAD_TRIGGER routes through loadProgram. UNSYNCED fallback: the legacy dump-driven
+current-bank path plus a "sync to browse all banks" hint (RENDER.SYNC_TO_BROWSE). tree.js/parser.js/
+event-bridge.js unchanged (the memo, stale-exemptions, and 0x2e early-return still back the scan,
+the load PUT sequence, and the fallback). main.js resetPresetLoader() on reconnect + Sync so the
+next open re-seeds. VALIDATED LIVE against the powered Orville (logs/probe-loadmenu.mjs, raw output
+in session): [1] no-swap — staged bank held through 3 repaints; [2] instant — bank/program picks
+emit zero PUT/bank/program traffic; [3] load — ordered bank->program->trigger PUTs, optimistic name
+same-tick, device-confirmed after settle (load persisted: device reported the new DSP-A program);
+[4] fallback — legacy put+targeted-fetch fires with no library. Tests 234/234, lint clean. New
+coverage: tests/preset-loader.test.js (8), library.js helpers + loadProgram, renderer load-menu
+library/fallback paths. Foundation for #153 (preset browser) and #152 (inbound Program Change),
+which can reuse the DOM-free loader.
+
 ## Done (verified merged — do not redo)
 - A1  main.js debug-upload slice bounds — PR #24
 - 8-step decoupling refactor — PR #23

--- a/src/constants.js
+++ b/src/constants.js
@@ -44,6 +44,8 @@ export const RENDER = {
   LOADING_STATEMENT: 'loading ...',
   LOADING_PROGRAMS: 'loading programs ...', // the program field while an unseen
   //                   bank's list is on the wire (#141) — never the old bank's list
+  SYNC_TO_BROWSE: 'sync to browse all banks', // load-menu hint when unsynced (#138):
+  //                   the device lists only the current bank's programs at a time
   INDICATOR_BAR_CELLS: 8, // max bar width for spec-less indicator CONs: the only live-observed
   //                         case (the Tempo 'Beat' flasher) is binary 0/1, and a full-LCD-width
   //                         flashing slab overwhelmed the page (maintainer report, external-clock

--- a/src/eager-loader.js
+++ b/src/eager-loader.js
@@ -112,6 +112,10 @@ function step() {
  * event never reaches the walk's own just-added listener.
  *
  * @param {string} rootKey - Subtree root (e.g. '401000b').
+ * @param {string[]} [warmKeys=[]] - Extra roots to warm at depth 0 after the
+ *   subtree walk (#138: the program/load menu, whose ~70-name bank list is the
+ *   slowest dump on the link). Serialized like everything else; cached nodes
+ *   cost no request.
  */
 export function startEagerLoad(rootKey, warmKeys = []) {
   teardown();

--- a/src/library.js
+++ b/src/library.js
@@ -12,6 +12,7 @@
 // wire shape), name is the option desc as listed.
 
 import { appState } from './state.js';
+import { setState } from './store.js';
 import { sendValuePut, sendObjectInfoDump, sendValueDump, isOutputConnected } from './midi.js';
 import { KEY, KEY_PREFIX } from './sysex-commands.js';
 import { LIBRARY } from './constants.js';
@@ -38,6 +39,32 @@ export function libraryProgramCount() {
 /** Whether the corpus is large enough to enable search (#142 follow-up). */
 export function canSearch() {
   return libraryProgramCount() >= LIBRARY.SEARCH_MIN_PROGRAMS;
+}
+
+/**
+ * All bank options for the load-menu BANK select, in SET-option shape
+ * ({ index, desc }; index is the decimal-string PUT shape). The
+ * preset-loader (#138 redesign) renders the bank dropdown from this
+ * instead of the slow per-visit device dump. Empty when unsynced.
+ *
+ * @returns {Array<{index: string, desc: string}>}
+ */
+export function libraryBankOptions() {
+  return library ? library.banks.map((b) => ({ index: b.idx, desc: b.name })) : [];
+}
+
+/**
+ * The program options for one bank (decimal index), SET-option shape. The
+ * device exposes only one bank's list at a time, so this library lookup is
+ * what makes bank-hopping instant and race-free (#138). Empty when the bank
+ * is not in the library.
+ *
+ * @param {number} bankIdx
+ * @returns {Array<{index: string, desc: string}>}
+ */
+export function libraryProgramsForBank(bankIdx) {
+  const bank = library?.banks.find((b) => parseInt(b.idx, 10) === bankIdx);
+  return bank ? bank.programs.map((p) => ({ index: p.idx, desc: p.name })) : [];
 }
 
 /** Hydrates the library from persisted config (boot); null clears (tests). */
@@ -205,37 +232,60 @@ export async function syncLibrary(onProgress) {
 }
 
 /**
- * Loads a search hit into the ACTIVE DSP: bank PUT, program PUT, load
- * trigger — each step settled (the device re-lists between steps).
+ * Loads a bank+program into the ACTIVE DSP: bank PUT, program PUT (with a
+ * readback), then the active-DSP load trigger — each step settled (the
+ * device re-lists between steps). The single device-touching action for
+ * BOTH search hits and the preset-loader dropdowns (#138). Optimistically
+ * updates the top-bar DSP name so the load feels immediate; the caller's
+ * root refetch (onDone) reconciles the real name (~2s, device-bound).
  *
- * @param {{bankIdx: string, programIdx: string, programName: string}} hit
+ * @param {{bankIdx: string, programIdx: string, programName: string}} target
  * @param {Function} [onDone] - Called after the load trigger fires (the
  *   caller refreshes the screen / root names).
  */
-export async function loadSearchHit(hit, onDone) {
+export async function loadProgram(target, onDone) {
   if (syncing) {
     // The scan owns the bank selection: a load interleaved with it would
     // land in whatever bank the scan happens to be visiting (review).
-    log('Search load ignored: library sync in progress', 'error', 'error');
+    log('Load ignored: library sync in progress', 'error', 'error');
     return;
   }
-  log(`Search load: '${hit.programName}' (bank ${hit.bankIdx})`, 'info', 'general');
-  sendValuePut(KEY.BANK_SELECT, hit.bankIdx);
+  const activeIsA = appState.presetKey.startsWith(KEY_PREFIX.DSP_A);
+  log(
+    `Load: '${target.programName}' (bank ${target.bankIdx}) -> DSP ${activeIsA ? 'A' : 'B'}`,
+    'info',
+    'general'
+  );
+  // Optimistic top-bar name: show the loaded program on the active DSP at
+  // once; the root refetch in onDone confirms or corrects it.
+  if (target.programName) {
+    const cleanName = String(target.programName)
+      .trim()
+      .replace(/^\d+\s+/, ''); // strip a leading index token if present
+    setState({ [activeIsA ? 'dspAName' : 'dspBName']: cleanName }, 'library:load-optimistic-name');
+  }
+  sendValuePut(KEY.BANK_SELECT, target.bankIdx);
   await sleep(LIBRARY.LOAD_SETTLE_MS);
-  sendValuePut(KEY.PROGRAM_SELECT, hit.programIdx);
-  // Readback before the trigger: the device clamps out-of-range puts, so
-  // a stale library hit would otherwise load a DIFFERENT program silently
-  // — the echo lands in currentValues/the log for the eye to catch
-  // (review; full verify-or-abort is more wire round-trips than the
-  // explicit-resync freshness model warrants).
+  sendValuePut(KEY.PROGRAM_SELECT, target.programIdx);
+  // Readback before the trigger: the device clamps out-of-range puts, so a
+  // stale library target would otherwise load a DIFFERENT program silently
+  // — the echo lands in currentValues/the log for the eye to catch.
   sendValueDump(KEY.PROGRAM_SELECT);
   await sleep(LIBRARY.LOAD_SETTLE_MS);
-  const trigger = appState.presetKey.startsWith(KEY_PREFIX.DSP_A)
-    ? KEY.LOAD_TRIGGER_A
-    : KEY.LOAD_TRIGGER_B;
-  sendValuePut(trigger, '1');
+  sendValuePut(activeIsA ? KEY.LOAD_TRIGGER_A : KEY.LOAD_TRIGGER_B, '1');
   await sleep(LIBRARY.LOAD_SETTLE_MS);
   onDone?.();
+}
+
+/**
+ * Loads a search hit — thin delegate to loadProgram so search and the
+ * preset-loader dropdowns share one apply path.
+ *
+ * @param {{bankIdx: string, programIdx: string, programName: string}} hit
+ * @param {Function} [onDone]
+ */
+export function loadSearchHit(hit, onDone) {
+  return loadProgram(hit, onDone);
 }
 
 // Keep the library's bank entries refreshed from live memo updates: when a

--- a/src/library.js
+++ b/src/library.js
@@ -123,7 +123,10 @@ export function isSyncing() {
  * in flight; ~70 banks at the ~4-5s wire floor each is a several-minute
  * scan, hence onProgress for UI.
  *
- * @param {(done: number, total: number, bankName: string) => void} onProgress
+ * @param {(p: {phase: string, done: number, total: number, name: string,
+ *   bankStates: string[], etaMs: number|null}) => void} onProgress Structured
+ *   progress payload (the dialog reads p.phase/p.bankStates); phase is
+ *   'preparing' while the bank list is fetched, then per-bank during the scan.
  * @returns {Promise<{syncedAt: string, banks: Object[]}|null>} The new
  *   library, or null when no load-menu dump is available / already syncing.
  */
@@ -138,7 +141,7 @@ export async function syncLibrary(onProgress) {
   // Sync-from-anywhere (#142 follow-up): the bank list lives in the
   // load-menu dump, which may not be cached if the user never opened the
   // program page. Fetch it ourselves first instead of demanding they
-  // navigate there — onProgress(-1) signals this "preparing" phase.
+  // navigate there — onProgress emits phase:'preparing' for this phase.
   let loadMenu = getNode(KEY.FAVORITES);
   let bankSub = loadMenu?.find((s) => s.key === KEY.BANK_SELECT);
   if (!bankSub?.options?.length) {

--- a/src/main.js
+++ b/src/main.js
@@ -42,6 +42,7 @@ import { log, setLogLevel, setLogCategories, getLogCategories } from './logger.j
 import { registerEventBridge } from './event-bridge.js';
 import { extractNibblesFromHex } from './hex-extract.js';
 import { deriveKeyStack, markAllStableDirty } from './tree.js';
+import { resetPresetLoader } from './preset-loader.js';
 
 const lcdEl = document.getElementById('lcd');
 const logArea = document.getElementById('log-area');
@@ -174,6 +175,10 @@ function resetAndLand() {
   lcdEl.innerText = 'Connected. Fetching root screen...';
   showLoading();
   markAllStableDirty();
+  // A (re)connect re-seeds the load menu from the freshly-read device: drop
+  // any staged bank/program selection so the next load-menu render takes its
+  // one-shot seed from the new dump (#138), not the previous session's pick.
+  resetPresetLoader();
   setState(
     {
       currentKey: KEY.ROOT,
@@ -273,6 +278,9 @@ syncBtn.addEventListener('click', () => {
   // Sync is the explicit "re-read the device" affordance: distrust every
   // stable-subtree cache (#113 — the front-panel-changes answer).
   markAllStableDirty();
+  // Sync is the explicit re-read: drop the staged load-menu selection too so
+  // it re-seeds from the device's current bank/program (#138).
+  resetPresetLoader();
   setState({ currentKey: KEY.ROOT, keyStack: [] }, 'main:sync-root');
   updateScreen(log);
   log('Synced to root', 'info', 'general');

--- a/src/preset-loader.js
+++ b/src/preset-loader.js
@@ -1,0 +1,116 @@
+// preset-loader.js
+// Single source of truth for the LOAD-MENU dropdowns (#138 redesign).
+//
+// The program/bank load menu used to reconcile its two dropdowns from five
+// competing sources at render time (live dump, optimistic cache, session
+// memo, library, a module-state bank index) repainted by several async
+// triggers — so the dropdowns "swapped" between intermediate states and
+// commits lagged behind device round-trips. This module replaces that with
+// one explicit local selection backed by the synced library: picking a
+// bank/program is pure LOCAL staging (no device I/O), like scrolling on the
+// hardware (manual p.21 — scroll picks, SELECT/<load>/ENT applies). The
+// device is touched only when the user hits "load program in A/B"
+// (library.js loadProgram). Every async repaint reads this same selection,
+// so they are idempotent — nothing swaps.
+//
+// DOM-free module state (like tree.js/logger.js): the renderer reads it,
+// handlers mutate it; it imports only library data + protocol keys.
+
+import { appState } from './state.js';
+import { KEY } from './sysex-commands.js';
+import { getLibrary, libraryBankOptions, libraryProgramsForBank } from './library.js';
+
+// The user's staged selection (DECIMAL indices). initialized guards the
+// one-shot seed from the device's live current bank/program.
+let selection = { bankIdx: 0, programIdx: 0 };
+let initialized = false;
+
+/** True when the on-screen menu is the program/load menu (#138). */
+export function isLoadMenuActive() {
+  return appState.currentKey === KEY.PROGRAM || appState.currentKey === KEY.FAVORITES;
+}
+
+/**
+ * Whether a synced library exists to drive the load menu. A small library
+ * is enough to browse/load (canSearch() gates the bigger SEARCH corpus).
+ *
+ * @returns {boolean}
+ */
+export function hasLibrary() {
+  return getLibrary() != null;
+}
+
+/** Bank options for the BANK dropdown (library-sourced, SET-option shape). */
+export function bankOptions() {
+  return libraryBankOptions();
+}
+
+/** Program options for the staged (or given) bank. */
+export function programsForBank(bankIdx = selection.bankIdx) {
+  return libraryProgramsForBank(bankIdx);
+}
+
+/** The staged selection { bankIdx, programIdx } (decimal ints). */
+export function getSelection() {
+  return { ...selection };
+}
+
+/**
+ * Stage a bank (decimal). Resets the program to the bank's first entry —
+ * the device would show a fresh list. Pure local: no device I/O.
+ *
+ * @param {number} bankIdx
+ */
+export function selectBank(bankIdx) {
+  const programs = libraryProgramsForBank(bankIdx);
+  const firstProgram = programs.length ? parseInt(programs[0].index, 10) : 0;
+  selection = { bankIdx, programIdx: firstProgram };
+  initialized = true;
+}
+
+/**
+ * Stage a program (decimal) within the current bank. Pure local.
+ *
+ * @param {number} programIdx
+ */
+export function selectProgram(programIdx) {
+  selection = { ...selection, programIdx };
+  initialized = true;
+}
+
+/**
+ * One-shot seed from the device's live current bank/program the first time
+ * the load menu renders; thereafter the staged selection is authoritative
+ * (so async repaints never overwrite the user's pick). Idempotent.
+ *
+ * @param {number} liveBankIdx
+ * @param {number} liveProgramIdx
+ */
+export function ensureInitialized(liveBankIdx, liveProgramIdx) {
+  if (initialized) return;
+  selection = {
+    bankIdx: isNaN(liveBankIdx) ? 0 : liveBankIdx,
+    programIdx: isNaN(liveProgramIdx) ? 0 : liveProgramIdx,
+  };
+  initialized = true;
+}
+
+/**
+ * The staged selection with the display names, for loadProgram(). null
+ * when the staged bank/program is not in the library.
+ *
+ * @returns {{bankIdx: string, programIdx: string, programName: string}|null}
+ */
+export function selectionTarget() {
+  const bank = getLibrary()?.banks.find((b) => parseInt(b.idx, 10) === selection.bankIdx);
+  if (!bank) return null;
+  const program = bank.programs.find((p) => parseInt(p.idx, 10) === selection.programIdx);
+  if (!program) return null;
+  return { bankIdx: bank.idx, programIdx: program.idx, programName: program.name };
+}
+
+/** Resets staged state — disconnect / Sync-to-Hardware / tests. */
+export function resetPresetLoader() {
+  selection = { bankIdx: 0, programIdx: 0 };
+  initialized = false;
+}

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -11,11 +11,21 @@ import {
   findParamUnder,
   labelForSub,
   isGangCol,
-  bankProgramsFor,
   GANG_MAX_DEPTH,
 } from './tree.js';
 import { log } from './logger.js';
-import { isSyncing } from './library.js';
+import { isSyncing, loadProgram } from './library.js';
+import {
+  isLoadMenuActive,
+  hasLibrary,
+  bankOptions,
+  programsForBank,
+  getSelection,
+  selectBank,
+  selectProgram,
+  ensureInitialized,
+  selectionTarget,
+} from './preset-loader.js';
 
 /**
  * Updates the current screen by requesting OBJECTINFO_DUMP and VALUE_DUMP for the current key.
@@ -154,9 +164,7 @@ const handleLcdClick = (e) => {
  * @param {Event} e - The change event.
  */
 const handleSelectChange = (e) => {
-  // The library scan owns the bank/program selection while it runs — a
-  // user put interleaved with it lands in whatever bank the scan happens
-  // to be visiting, and the program auto-load would fire there (review).
+  // The library scan owns the bank/program selection while it runs (review).
   if (isSyncing()) {
     log('Value change ignored: library sync in progress', 'error', 'error');
     return;
@@ -164,75 +172,53 @@ const handleSelectChange = (e) => {
   const key = e.target.dataset.key;
   const selectedIndex = e.target.value;
   const selectedDesc = e.target.options[e.target.selectedIndex].text;
-  log(
-    `Selected option for key ${key}: index ${selectedIndex}, desc ${selectedDesc}`,
-    'debug',
-    'valueChange'
-  );
-  // Release focus (review): a closed select that keeps focus would park
-  // every subsequent repaint (#131 defer guard) until the user happens to
-  // click elsewhere — the post-change refresh and gang-sibling updates
-  // must paint. Safe ordering: the blur-flush replays one tick later and
-  // re-checks the parked slot, and the change's discard listener (runs
-  // synchronously after this handler) clears it first — no stale replay.
+  log(`Selected ${key}: index ${selectedIndex}, desc ${selectedDesc}`, 'debug', 'valueChange');
+  // Release focus so the #131 defer guard does not park subsequent repaints.
   e.target.blur();
-  // No loading dim for a program select (regression fix): it only moves the
-  // highlight and confirms with a VALUE dump, but hideLoading fires only on
-  // OBJECTINFO/screen waves (#3) — so the dim would never lift. The pick is
-  // instant via the optimistic repaint below; the dim is for the menu
-  // refetches the bank/other branches do.
+
+  // #138 LIBRARY PATH: the load-menu choosers are PURE LOCAL STAGING — pick
+  // a bank/program like scrolling on the hardware (manual p.21), sending
+  // NOTHING to the device. Options come from the library, the selection is
+  // explicit local state, so a synchronous repaint shows it instantly and
+  // every async repaint is idempotent. The device is touched only by the
+  // explicit '<- load program in A/B' TRG (handleParamClick -> loadProgram).
+  if (isLoadMenuActive() && hasLibrary() && isLoadMenuChooser({ key })) {
+    if (key === KEY.BANK_SELECT) selectBank(parseInt(selectedIndex, 10));
+    else selectProgram(parseInt(selectedIndex, 10));
+    renderScreen(appState.currentSubs, appState.lastAscii);
+    return;
+  }
+
+  // GENERIC PATH (params, gangs, and the load menu when UNSYNCED): the
+  // dump-driven model with the optimistic value cache. PROGRAM_SELECT shows
+  // no loading dim (it only confirms with a value dump, which never clears
+  // the dim — #3); everything else does.
   if (key !== KEY.PROGRAM_SELECT) showLoading();
   sendValuePut(key, selectedIndex);
-  // Optimistic cache in the DEVICE's value shape: puts are parsed decimal
-  // but values/echoes report the index in HEX (probed live,
-  // logs/probe-bank-radix.mjs) — and renderScreen decodes the first token
-  // with parseInt(_, 16). Caching the decimal index mis-selected options
-  // >= 10 on every repaint until the echo corrected it.
+  // Optimistic cache in the device's value shape: puts are parsed decimal
+  // but values/echoes report the index in HEX (probed live), and the render
+  // decodes the first token with parseInt(_, 16).
   const optimisticValue = `${parseInt(selectedIndex, 10).toString(16)} ${selectedDesc}`;
   setState(
     { currentValues: { ...appState.currentValues, [key]: optimisticValue } },
     'renderer:select-change-value-cache'
-  ); // Removed immediate renderScreen to avoid old subs with new value
+  );
   setTimeout(() => {
     if (key === KEY.BANK_SELECT) {
-      // Bank scroll: the ONLY node whose options change is the load menu
-      // (both of its SETs re-list for the new bank). The generic
-      // updateScreen path refetches EVERY child of the staled program
-      // subtree — measured live at 13.3s before the program list updated
-      // (#138). One targeted dump is a single wave; the R7 child-arrival
-      // repaint (or the progressive paint, if the load menu IS the current
-      // key) updates the dropdowns the moment it lands.
-      // Prune the load menu's STALE cached values (review blocker): this
-      // branch skips updateScreen's full currentValues clear, and a stale
-      // cache entry shadows the fresh dump's value in the render
-      // precedence (currentValues[key] || s.value) — the program dropdown
-      // would keep the OLD bank's selection and never self-correct.
-      // The BANK key itself is deliberately KEPT: it holds the user's
-      // just-made choice (optimistic hex cache above, confirmed by the
-      // echo) — pruning it made the dropdown visibly SNAP BACK to the old
-      // bank for the ~5s dump transfer, which the maintainer read as the
-      // selection not taking at all (live-reproduced).
+      // Unsynced bank scroll: one targeted load-menu dump (not the whole
+      // staled subtree — #138). Prune the stale program value so the old
+      // bank's list cannot shadow the fresh dump; keep the bank value (the
+      // user's just-made choice).
       const pruned = { ...appState.currentValues };
       delete pruned[KEY.PROGRAM_SELECT];
       delete pruned[KEY.FAVORITES];
       setState({ currentValues: pruned }, 'renderer:bank-change-prune');
-      // Wipe-proof copy of the choice (#141 review): currentValues can be
-      // cleared mid-transfer by any updateScreen; programSelectView falls
-      // back to this until the load-menu dump converges.
-      chosenBankIdx = parseInt(selectedIndex, 10);
       sendObjectInfoDump(KEY.FAVORITES);
       sendValueDump(KEY.FAVORITES);
-      // Paint NOW (#141, live finding): puts do not join waves, so without
-      // an explicit repaint nothing paints until the targeted dump drains
-      // (~4-5s) — the program field's memo (revisited bank, instant) or
-      // loading line (unseen bank) must show immediately.
       renderScreen(appState.currentSubs, appState.lastAscii);
     } else if (key === KEY.PROGRAM_SELECT) {
-      // Choosing a program only moves the highlight (no load now — the
-      // auto-load was removed). It does NOT change the menu, so skip the
-      // full updateScreen refetch (the "syncing with the system" lag the
-      // maintainer saw): the optimistic hex cache already shows the pick,
-      // so repaint immediately and just confirm the value on the wire.
+      // Unsynced program pick: lightweight optimistic repaint + value
+      // confirm (no full refetch).
       renderScreen(appState.currentSubs, appState.lastAscii);
       sendValueDump(KEY.PROGRAM_SELECT);
     } else {
@@ -242,24 +228,7 @@ const handleSelectChange = (e) => {
       sendSysEx(CMD.GET_SCREEN, []);
       log('Triggered bitmap update after value change.', 'debug', 'bitmap');
     }
-    setTimeout(() => {
-      const newValue = appState.currentValues[key];
-      if (newValue && newValue.includes(selectedDesc)) {
-        log(`Value update successful for key ${key}: ${newValue}`, 'debug', 'valueChange');
-      } else {
-        log(
-          `Value update failed for key ${key}. Expected desc: ${selectedDesc}, got: ${newValue}`,
-          'debug',
-          'valueChange'
-        );
-      }
-    }, TIMING.VALUE_DUMP_WAIT_MS); // Wait for VALUE_DUMP to arrive
-    // NOTE: choosing a program from the dropdown only HIGHLIGHTS it (sets
-    // the device's selected slot) — it does NOT load it. Loading is the
-    // explicit '<- load program in A/B' TRG (handleParamClick), matching
-    // the hardware: scroll picks, SELECT/<load>/ENT applies (manual p.21,
-    // maintainer request). The old auto-load fired the trigger here.
-  }, TIMING.MIDI_SETTLE_MS); // Delay to allow MIDI update
+  }, TIMING.MIDI_SETTLE_MS);
 };
 
 /**
@@ -369,25 +338,38 @@ const handleParamClick = (e) => {
           },
         });
       } else if (sub.type === 'TRG') {
-        showLoading();
-        if (key === KEY.LOAD_TRIGGER_A || key === KEY.LOAD_TRIGGER_B) {
-          log('Started loading preset.', 'info', 'general');
-        }
-        sendValuePut(key, '1');
-        log(`Triggered TRG for key ${key}: ${sub.statement}`, 'info', 'general');
-        renderScreen(appState.currentSubs, appState.lastAscii); // Immediate local update
-        setTimeout(() => {
+        const isLoadTrigger = key === KEY.LOAD_TRIGGER_A || key === KEY.LOAD_TRIGGER_B;
+        const onLoadDone = () => {
           updateScreen();
-          if (key === KEY.LOAD_TRIGGER_A || key === KEY.LOAD_TRIGGER_B) {
-            // Fetch root to update preset names after loading a new program
-            sendObjectInfoDump(KEY.ROOT);
+          if (isLoadTrigger) {
+            sendObjectInfoDump(KEY.ROOT); // refresh DSP names after a load
             log('Fetched root after preset load.', 'debug', 'general');
           }
           if (appState.updateBitmapOnChange) {
             sendSysEx(CMD.GET_SCREEN, []);
             log('Triggered bitmap update after TRG.', 'debug', 'bitmap');
           }
-        }, TIMING.DEVICE_LOAD_MS); // Increased delay for device to process load
+        };
+        // #138 LIBRARY PATH: the load triggers apply the STAGED preset-loader
+        // selection via loadProgram (bank -> program -> trigger, with the
+        // optimistic top-bar name). This is the ONLY device-touching action
+        // for the library load menu.
+        if (isLoadTrigger && isLoadMenuActive() && hasLibrary()) {
+          const target = selectionTarget();
+          if (target) {
+            showLoading();
+            log('Started loading preset (staged).', 'info', 'general');
+            loadProgram(target, onLoadDone);
+            return;
+          }
+          // No resolvable staged selection: fall through to the raw trigger.
+        }
+        showLoading();
+        if (isLoadTrigger) log('Started loading preset.', 'info', 'general');
+        sendValuePut(key, '1');
+        log(`Triggered TRG for key ${key}: ${sub.statement}`, 'info', 'general');
+        renderScreen(appState.currentSubs, appState.lastAscii); // Immediate local update
+        setTimeout(onLoadDone, TIMING.DEVICE_LOAD_MS);
       } else if (sub.type === 'STR') {
         // String-edit (R8): free-text put, confirmed live (the device echoes
         // the new value as a 0x2e). Multi-word strings confirmed on hardware
@@ -698,44 +680,39 @@ function renderGangInline(colSub, depth, paramLines, paramHtmlLines, logParam) {
   }
 }
 
-// Program-select view resolution (#141): the device's load-menu dump
-// carries ONLY the currently-selected bank's program list, so when the
-// user's chosen bank differs from the bank the dump was taken in, the
-// dump's options are the OLD bank's — never show them. Serve the session
-// memo (tree.js) when this bank has been seen, else an honest loading
-// line until the targeted dump lands ("its the fact we keep the old
-// stuff around thats the issue" — maintainer).
-// Returns: {stale:false} = render the dump as usual; {loading:true} =
-// render RENDER.LOADING_PROGRAMS; {options,value} = render the memo.
-//
-// The chosen bank lives in MODULE state, not only the optimistic cache
-// (review): a program pick from the memoized list runs the generic
-// updateScreen refresh, which wipes currentValues wholesale mid-transfer
-// — the cache-only check then fell back to the dump and repainted the
-// old bank's list. Set by the bank-change handler; self-clears when the
-// load-menu dump converges on the chosen bank.
-let chosenBankIdx = null;
-
-/** Clears the chosen-bank module state (tests). */
-export function resetProgramSelectView() {
-  chosenBankIdx = null;
+// Whether a SET sub is one of the load-menu CHOOSERS (#138 redesign).
+function isLoadMenuChooser(s) {
+  return s.key === KEY.BANK_SELECT || s.key === KEY.PROGRAM_SELECT;
 }
 
-function programSelectView(s, siblings) {
-  if (s.key !== KEY.PROGRAM_SELECT) return { stale: false };
-  const bankSub = siblings.find((x) => x.key === KEY.BANK_SELECT);
-  if (!bankSub?.value) return { stale: false };
-  const cachedRaw = appState.currentValues[KEY.BANK_SELECT];
-  const cached = cachedRaw ? parseInt(String(cachedRaw).split(' ')[0], 16) : NaN;
-  const chosen = !isNaN(cached) ? cached : chosenBankIdx;
-  const inDump = parseInt(String(bankSub.value).split(' ')[0], 16);
-  if (chosen === null || isNaN(inDump) || chosen === inDump) {
-    if (chosen !== null && chosen === inDump) chosenBankIdx = null; // converged
-    return { stale: false };
-  }
-  const memo = bankProgramsFor(chosen);
-  if (memo) return { stale: true, options: memo.options, value: memo.value };
-  return { stale: true, loading: true };
+// Render a load-menu bank/program dropdown from the preset-loader's staged
+// selection + the synced library — the SINGLE source of truth (#138). The
+// device's load-menu dump only ever lists the current bank, and reconciling
+// five sources at render time made the dropdowns "swap"; now options come
+// from the library and the selected value from the local staged selection,
+// so async repaints are idempotent. Same <select class="param-select">
+// markup as the generic SET path, spliced into the statement, so it renders
+// inside #lcd. Only reached when isLoadMenuActive() && hasLibrary().
+//
+// Seeds the staged selection once from the live dump (siblings carry the
+// device's current bank/program), then local state wins.
+function renderLoadMenuSelect(s, siblings) {
+  const bankSub = siblings.find((x) => x.key === KEY.BANK_SELECT) || s;
+  const progSub = siblings.find((x) => x.key === KEY.PROGRAM_SELECT) || s;
+  ensureInitialized(
+    parseInt(String(bankSub?.value || '').split(' ')[0], 16),
+    parseInt(String(progSub?.value || '').split(' ')[0], 16)
+  );
+  const sel = getSelection();
+  const options = s.key === KEY.BANK_SELECT ? bankOptions() : programsForBank(sel.bankIdx);
+  const selectedIdx = String(s.key === KEY.BANK_SELECT ? sel.bankIdx : sel.programIdx);
+  let selectHtml = `<select data-key="${s.key}" class="param-select">`;
+  options.forEach((option) => {
+    const isSelected = String(parseInt(option.index, 10)) === selectedIdx;
+    selectHtml += `<option value="${option.index}" ${isSelected ? 'selected' : ''}>${escapeHtml(option.desc)}</option>`;
+  });
+  selectHtml += `</select>`;
+  return escapeHtml(s.statement || '%s').replace(/%(-)?(\d*)s/g, selectHtml);
 }
 
 export function renderScreen(subs, ascii, logParam) {
@@ -937,40 +914,31 @@ export function renderScreen(subs, ascii, logParam) {
         if (appState.currentValues[s.key] === undefined && !s.value) sendValueDump(s.key, logParam);
         fullText = formatValue(s.statement, value); // Use updated formatValue with s support
         fullHtml = escapeHtml(fullText); // INF isn't clickable: escape, add no span
+      } else if (s.type === 'SET' && isLoadMenuActive() && hasLibrary() && isLoadMenuChooser(s)) {
+        // #138: the load-menu choosers render from the library-backed
+        // preset-loader (single source of truth) — instant, race-free.
+        fullText = s.statement || '';
+        fullHtml = renderLoadMenuSelect(s, subs.slice(1));
       } else if (s.type === 'SET') {
-        const progView = programSelectView(s, subs.slice(1));
-        if (progView.loading) {
-          // #141: the chosen bank's list is on the wire and unseen — an
-          // honest loading line, never the old bank's options.
-          fullText = RENDER.LOADING_PROGRAMS;
-          fullHtml = fullText;
-        } else {
-          const options = progView.options ?? s.options;
-          // Stale branch: a program the user just picked from the memoized
-          // list (optimistic cache) beats the memo's remembered selection.
-          let value = progView.stale
-            ? appState.currentValues[s.key] || progView.value
-            : appState.currentValues[s.key] || s.value || '';
-          if (!progView.stale && appState.currentValues[s.key] === undefined && !s.value)
-            sendValueDump(s.key, logParam);
-          let displayValue = value;
-          let indexHex = '0';
-          if (value) {
-            indexHex = value.split(' ')[0];
-            displayValue = value.substring(indexHex.length + 1);
-          }
-          const indexDec = parseInt(indexHex, 16).toString(10);
-          fullText = formatValue(s.statement || '', displayValue); // Use formatValue for %-width s
-          let selectHtml = `<select data-key="${s.key}" class="param-select">`;
-          options.forEach((option) => {
-            const isSelected = option.index === indexDec;
-            selectHtml += `<option value="${option.index}" ${isSelected ? 'selected' : ''}>${escapeHtml(option.desc)}</option>`;
-          });
-          selectHtml += `</select>`;
-          // Escape the statement's literal text before splicing in the
-          // select (which is intentional markup).
-          fullHtml = escapeHtml(s.statement || '').replace(/%(-)?(\d*)s/g, selectHtml);
+        // Generic SET (params, gangs, and the load menu when UNSYNCED):
+        // dump-driven, with the optimistic value cache.
+        let value = appState.currentValues[s.key] || s.value || '';
+        if (appState.currentValues[s.key] === undefined && !s.value) sendValueDump(s.key, logParam);
+        let displayValue = value;
+        let indexHex = '0';
+        if (value) {
+          indexHex = value.split(' ')[0];
+          displayValue = value.substring(indexHex.length + 1);
         }
+        const indexDec = parseInt(indexHex, 16).toString(10);
+        fullText = formatValue(s.statement || '', displayValue);
+        let selectHtml = `<select data-key="${s.key}" class="param-select">`;
+        s.options.forEach((option) => {
+          const isSelected = option.index === indexDec;
+          selectHtml += `<option value="${option.index}" ${isSelected ? 'selected' : ''}>${escapeHtml(option.desc)}</option>`;
+        });
+        selectHtml += `</select>`;
+        fullHtml = escapeHtml(s.statement || '').replace(/%(-)?(\d*)s/g, selectHtml);
       } else if (s.type === 'CON') {
         let meterValue = parseFloat(appState.currentValues[s.key] || s.value) || 0;
         if (isNaN(meterValue)) {
@@ -1095,37 +1063,37 @@ export function renderScreen(subs, ascii, logParam) {
               sendValueDump(cs.key, logParam);
             childFullText = formatValue(cs.statement, value);
             childFullHtml = escapeHtml(childFullText);
+          } else if (
+            cs.type === 'SET' &&
+            isLoadMenuActive() &&
+            hasLibrary() &&
+            isLoadMenuChooser(cs)
+          ) {
+            // #138: the embedded load-menu choosers (the common case — the
+            // load menu embeds under the program page) render from the
+            // library-backed preset-loader. childSubs are the load menu's
+            // own children, so they carry BANK_SELECT/PROGRAM_SELECT.
+            childFullText = cs.statement || '';
+            childFullHtml = renderLoadMenuSelect(cs, childSubs.slice(1));
           } else if (cs.type === 'SET') {
-            const progView = programSelectView(cs, childSubs.slice(1));
-            if (progView.loading) {
-              // #141: honest loading line — never the old bank's options.
-              childFullText = RENDER.LOADING_PROGRAMS;
-              childFullHtml = childFullText;
-            } else {
-              const options = progView.options ?? cs.options;
-              // A just-picked program (optimistic cache) beats the memo's
-              // remembered selection — same rule as the top-level branch.
-              let value = progView.stale
-                ? appState.currentValues[cs.key] || progView.value
-                : appState.currentValues[cs.key] || cs.value || '';
-              if (!progView.stale && appState.currentValues[cs.key] === undefined && !cs.value)
-                sendValueDump(cs.key, logParam);
-              let displayValue = value;
-              let indexHex = '0';
-              if (value) {
-                indexHex = value.split(' ')[0];
-                displayValue = value.substring(indexHex.length + 1);
-              }
-              const indexDec = parseInt(indexHex, 16).toString(10);
-              childFullText = formatValue(cs.statement || '', displayValue);
-              let selectHtml = `<select data-key="${cs.key}" class="param-select">`;
-              options.forEach((option) => {
-                const isSelected = option.index === indexDec;
-                selectHtml += `<option value="${option.index}" ${isSelected ? 'selected' : ''}>${escapeHtml(option.desc)}</option>`;
-              });
-              selectHtml += `</select>`;
-              childFullHtml = escapeHtml(cs.statement || '').replace(/%(-)?(\d*)s/g, selectHtml);
+            let value = appState.currentValues[cs.key] || cs.value || '';
+            if (appState.currentValues[cs.key] === undefined && !cs.value)
+              sendValueDump(cs.key, logParam);
+            let displayValue = value;
+            let indexHex = '0';
+            if (value) {
+              indexHex = value.split(' ')[0];
+              displayValue = value.substring(indexHex.length + 1);
             }
+            const indexDec = parseInt(indexHex, 16).toString(10);
+            childFullText = formatValue(cs.statement || '', displayValue);
+            let selectHtml = `<select data-key="${cs.key}" class="param-select">`;
+            cs.options.forEach((option) => {
+              const isSelected = option.index === indexDec;
+              selectHtml += `<option value="${option.index}" ${isSelected ? 'selected' : ''}>${escapeHtml(option.desc)}</option>`;
+            });
+            selectHtml += `</select>`;
+            childFullHtml = escapeHtml(cs.statement || '').replace(/%(-)?(\d*)s/g, selectHtml);
           } else if (cs.type === 'CON') {
             let meterValue = parseFloat(appState.currentValues[cs.key] || cs.value) || 0;
             if (isNaN(meterValue)) {
@@ -1177,6 +1145,12 @@ export function renderScreen(subs, ascii, logParam) {
         });
         break; // Only embed the first local COL
       }
+    }
+    // #138: unsynced load menu shows only the current bank's programs (the
+    // device lists one bank at a time) — hint that a sync unlocks browsing.
+    if (isLoadMenuActive() && !hasLibrary() && !prePainting) {
+      paramLines.push(RENDER.SYNC_TO_BROWSE);
+      paramHtmlLines.push(escapeHtml(RENDER.SYNC_TO_BROWSE));
     }
     displayLines = displayLines.concat(paramLines);
     // Filter out the embedded local COL from softkeys

--- a/tests/library.test.js
+++ b/tests/library.test.js
@@ -34,6 +34,9 @@ import {
   searchLibrary,
   syncLibrary,
   loadSearchHit,
+  loadProgram,
+  libraryBankOptions,
+  libraryProgramsForBank,
   canSearch,
   libraryProgramCount,
 } from '../src/library.js';
@@ -188,17 +191,61 @@ describe('syncLibrary', () => {
   });
 });
 
-describe('loadSearchHit', () => {
-  test('puts bank, program, then the active-DSP load trigger', async () => {
+describe('library load-menu options (#138)', () => {
+  beforeEach(() => setLibrary(sampleLibrary));
+
+  test('libraryBankOptions yields SET-option shape with decimal-string index', () => {
+    expect(libraryBankOptions()).toEqual([
+      { index: '0', desc: '0 Favorites' },
+      { index: '50', desc: '50 Reverbs - Unusual' },
+    ]);
+  });
+
+  test('libraryProgramsForBank returns the bank programs, or [] for an unknown bank', () => {
+    expect(libraryProgramsForBank(50)).toEqual([{ index: '12', desc: '12 Black Hole' }]);
+    expect(libraryProgramsForBank(99)).toEqual([]);
+  });
+
+  test('options are empty with no library', () => {
+    setLibrary(null);
+    expect(libraryBankOptions()).toEqual([]);
+    expect(libraryProgramsForBank(0)).toEqual([]);
+  });
+});
+
+describe('loadProgram / loadSearchHit', () => {
+  test('puts bank, program, then the active-DSP load trigger + optimistic name', async () => {
     jest.clearAllMocks();
     appState.presetKey = '401000b'; // DSP A active
+    appState.dspAName = 'Old';
     const done = jest.fn();
-    await loadSearchHit({ bankIdx: '50', programIdx: '12', programName: '12 Black Hole' }, done);
+    await loadProgram({ bankIdx: '50', programIdx: '12', programName: '12 Black Hole' }, done);
+    // Optimistic top-bar name (index token stripped), applied before the puts.
+    expect(appState.dspAName).toBe('Black Hole');
     expect(sendValuePut.mock.calls.map((c) => c.join(':'))).toEqual([
       '10020012:50',
       '10020011:12',
       '1002001c:1', // LOAD_TRIGGER_A
     ]);
     expect(done).toHaveBeenCalled();
+  });
+
+  test('targets DSP B when B is the active preset', async () => {
+    jest.clearAllMocks();
+    appState.presetKey = '801000b'; // DSP B active
+    await loadProgram({ bankIdx: '0', programIdx: '0', programName: '0 X' });
+    expect(appState.dspBName).toBe('X');
+    expect(sendValuePut.mock.calls.map((c) => c.join(':')).pop()).toBe('1002001d:1'); // LOAD_TRIGGER_B
+  });
+
+  test('loadSearchHit delegates to loadProgram', async () => {
+    jest.clearAllMocks();
+    appState.presetKey = '401000b';
+    await loadSearchHit({ bankIdx: '50', programIdx: '12', programName: '12 Black Hole' });
+    expect(sendValuePut.mock.calls.map((c) => c.join(':'))).toEqual([
+      '10020012:50',
+      '10020011:12',
+      '1002001c:1',
+    ]);
   });
 });

--- a/tests/preset-loader.test.js
+++ b/tests/preset-loader.test.js
@@ -1,0 +1,107 @@
+// tests/preset-loader.test.js
+// The load-menu selection model (#138): pure local staging backed by the
+// library, idempotent seed, no device I/O.
+
+jest.mock('../src/logger.js', () => ({ log: jest.fn() }));
+
+import {
+  isLoadMenuActive,
+  hasLibrary,
+  bankOptions,
+  programsForBank,
+  getSelection,
+  selectBank,
+  selectProgram,
+  ensureInitialized,
+  selectionTarget,
+  resetPresetLoader,
+} from '../src/preset-loader.js';
+import { setLibrary } from '../src/library.js';
+import { appState } from '../src/state.js';
+
+const lib = {
+  syncedAt: 'test',
+  banks: [
+    {
+      idx: '0',
+      name: '0 Favorites',
+      programs: [
+        { idx: '0', name: '0 Techno Rumble' },
+        { idx: '1', name: '1 Black Hole' },
+      ],
+    },
+    { idx: '50', name: '50 Reverbs', programs: [{ idx: '12', name: '12 Black Hole' }] },
+  ],
+};
+
+describe('preset-loader', () => {
+  beforeEach(() => {
+    resetPresetLoader();
+    setLibrary(lib);
+    appState.currentKey = '10020010'; // KEY.FAVORITES
+  });
+
+  test('isLoadMenuActive on PROGRAM / FAVORITES only', () => {
+    expect(isLoadMenuActive()).toBe(true);
+    appState.currentKey = '10020000'; // KEY.PROGRAM
+    expect(isLoadMenuActive()).toBe(true);
+    appState.currentKey = '401000b'; // a preset
+    expect(isLoadMenuActive()).toBe(false);
+  });
+
+  test('hasLibrary reflects the synced library', () => {
+    expect(hasLibrary()).toBe(true);
+    setLibrary(null);
+    expect(hasLibrary()).toBe(false);
+  });
+
+  test('bankOptions / programsForBank come from the library', () => {
+    expect(bankOptions()).toEqual([
+      { index: '0', desc: '0 Favorites' },
+      { index: '50', desc: '50 Reverbs' },
+    ]);
+    expect(programsForBank(50)).toEqual([{ index: '12', desc: '12 Black Hole' }]);
+  });
+
+  test('selectBank stages the bank and resets the program to its first', () => {
+    selectBank(50);
+    expect(getSelection()).toEqual({ bankIdx: 50, programIdx: 12 });
+    selectProgram(0); // (no-op-ish; 50 has only idx 12, but the model just stores)
+    expect(getSelection().programIdx).toBe(0);
+  });
+
+  test('ensureInitialized seeds once, then is authoritative', () => {
+    ensureInitialized(50, 12);
+    expect(getSelection()).toEqual({ bankIdx: 50, programIdx: 12 });
+    // A later seed (e.g. a stale device dump landing) must NOT overwrite.
+    ensureInitialized(0, 0);
+    expect(getSelection()).toEqual({ bankIdx: 50, programIdx: 12 });
+  });
+
+  test('a user pick wins over a subsequent device seed', () => {
+    selectBank(0);
+    selectProgram(1);
+    ensureInitialized(50, 12); // device dump arrives late
+    expect(getSelection()).toEqual({ bankIdx: 0, programIdx: 1 });
+  });
+
+  test('selectionTarget resolves names, null for an unknown selection', () => {
+    selectBank(0);
+    selectProgram(1);
+    expect(selectionTarget()).toEqual({
+      bankIdx: '0',
+      programIdx: '1',
+      programName: '1 Black Hole',
+    });
+    selectProgram(99); // not in bank 0
+    expect(selectionTarget()).toBeNull();
+  });
+
+  test('resetPresetLoader clears the seed flag and selection', () => {
+    selectBank(50);
+    resetPresetLoader();
+    expect(getSelection()).toEqual({ bankIdx: 0, programIdx: 0 });
+    ensureInitialized(0, 1); // seeds again after reset
+    expect(getSelection()).toEqual({ bankIdx: 0, programIdx: 1 });
+  });
+});

--- a/tests/renderer.test.js
+++ b/tests/renderer.test.js
@@ -1,14 +1,11 @@
-import { renderScreen, resetProgramSelectView } from '../src/renderer.js';
+import { renderScreen } from '../src/renderer.js';
 import { appState } from '../src/state.js';
 import { sendObjectInfoDump, sendValueDump, sendValuePut, sendSysEx } from '../src/midi.js';
 import { showLoading } from '../src/main.js';
 import { log as mockLog } from '../src/logger.js';
-import {
-  recordDump,
-  markAllStableDirty,
-  markDirtyIfStable,
-  reset as treeReset,
-} from '../src/tree.js';
+import { recordDump, reset as treeReset } from '../src/tree.js';
+import { setLibrary } from '../src/library.js';
+import { resetPresetLoader } from '../src/preset-loader.js';
 
 jest.mock('../src/midi.js', () => ({
   sendObjectInfoDump: jest.fn(),
@@ -57,7 +54,8 @@ describe('renderer.js', () => {
     consoleLogSpy.mockClear();
 
     document.body.innerHTML = '<div id="lcd"></div>';
-    resetProgramSelectView();
+    resetPresetLoader();
+    setLibrary(null); // default: no library -> fallback path (most tests)
   });
 
   afterEach(() => {
@@ -190,10 +188,9 @@ describe('renderer.js', () => {
     jest.useRealTimers();
   });
 
-  // #141: per-bank program-list memo + honest loading. The device's dump
-  // carries only the CURRENT bank's program list; a chosen bank that
-  // differs from the dump's bank renders its memoized list (seen this
-  // session) or a loading line — never the old bank's options.
+  // #138: the load menu renders from the library-backed preset-loader (the
+  // single source of truth) — picking is pure local staging, instant and
+  // race-free. These replace the old #141 memo/optimistic reconciliation.
   const loadMenuDump = (bankValue, programs) => [
     {
       type: 'COL',
@@ -247,115 +244,132 @@ describe('renderer.js', () => {
     },
   ];
 
-  test('program field renders the memoized list for a revisited bank (#141)', () => {
+  // The synced library used for the load-menu tests below.
+  const presetLibrary = {
+    syncedAt: 'test',
+    banks: [
+      {
+        idx: '0',
+        name: '0 Favorites',
+        programs: [
+          { idx: '0', name: '0 Techno Rumble' },
+          { idx: '1', name: '1 St DistortionTwo' },
+        ],
+      },
+      { idx: '5', name: '5 Delays', programs: [{ idx: '0', name: '0 Mono Delay' }] },
+      {
+        idx: '50',
+        name: '50 Reverbs - Unusual',
+        programs: [
+          { idx: '10', name: '10 Adaptive Reverb' },
+          { idx: '11', name: '11 AlienShift' },
+        ],
+      },
+    ],
+  };
+
+  test('load menu renders bank + program dropdowns from the library (#138)', () => {
+    setLibrary(presetLibrary);
     appState.currentKey = '10020000';
     recordDump(programMenu);
     recordDump(loadMenuDump('0 0 Favorites', ['0 Techno Rumble', '1 St DistortionTwo']));
-    // The device switched to bank 50; its dump is now the tree's latest.
-    recordDump(loadMenuDump('32 50 Reverbs - Unusual', ['10 Adaptive Reverb', '11 AlienShift']));
-
-    // The user re-chooses bank 0 (optimistic hex cache) — its list was
-    // seen this session, so it renders INSTANTLY from the memo.
-    appState.currentValues['10020012'] = '0 0 Favorites';
     renderScreen(programMenu, '', mockLog);
+
+    const bankSel = document.querySelector('select[data-key="10020012"]');
     const progSel = document.querySelector('select[data-key="10020011"]');
+    // ALL banks from the library (not just the device's current one).
+    expect([...bankSel.options].map((o) => o.text)).toEqual([
+      '0 Favorites',
+      '5 Delays',
+      '50 Reverbs - Unusual',
+    ]);
+    // The seeded bank's programs from the library.
     expect([...progSel.options].map((o) => o.text)).toEqual([
       '0 Techno Rumble',
       '1 St DistortionTwo',
     ]);
   });
 
-  test('program field shows LOADING for an unseen bank — never the old list (#141)', () => {
+  test('picking a bank refills the program list from the library, sending NOTHING (#138)', () => {
+    setLibrary(presetLibrary);
     appState.currentKey = '10020000';
     recordDump(programMenu);
-    recordDump(loadMenuDump('32 50 Reverbs - Unusual', ['10 Adaptive Reverb', '11 AlienShift']));
-
-    // The user chooses bank 5, never seen this session.
-    appState.currentValues['10020012'] = '5 5 Delays';
+    recordDump(loadMenuDump('0 0 Favorites', ['0 Techno Rumble', '1 St DistortionTwo']));
     renderScreen(programMenu, '', mockLog);
-    expect(document.querySelector('select[data-key="10020011"]')).toBeNull();
-    expect(document.getElementById('lcd').textContent).toContain('loading programs ...');
-    expect(document.getElementById('lcd').textContent).not.toContain('Adaptive Reverb');
-  });
 
-  test('the memo is keyed by the HEX bank index — a high bank revisits correctly (#141 review)', () => {
-    appState.currentKey = '10020000';
-    recordDump(programMenu);
-    // Bank 50's dump carries value token '32' (hex) — the memo key and
-    // the chosen-bank parse must agree on radix or bank >= 10 never hits.
-    recordDump(loadMenuDump('32 50 Reverbs - Unusual', ['10 Adaptive Reverb', '11 AlienShift']));
-    recordDump(loadMenuDump('0 0 Favorites', ['0 Techno Rumble']));
+    const bankSel = document.querySelector('select[data-key="10020012"]');
+    bankSel.value = '50'; // a high bank — decimal/hex diverge
+    bankSel.dispatchEvent(new Event('change', { bubbles: true }));
 
-    appState.currentValues['10020012'] = '32 50 Reverbs - Unusual';
-    renderScreen(programMenu, '', mockLog);
+    // Synchronous: the program list refilled from the library this tick...
     const progSel = document.querySelector('select[data-key="10020011"]');
     expect([...progSel.options].map((o) => o.text)).toEqual([
       '10 Adaptive Reverb',
       '11 AlienShift',
     ]);
+    // ...and the device was NOT touched (pure local staging).
+    expect(sendValuePut).not.toHaveBeenCalled();
+    expect(sendObjectInfoDump).not.toHaveBeenCalled();
+    expect(sendValueDump).not.toHaveBeenCalled();
   });
 
-  test('the top-level SET branch (descended into the load menu) resolves the memo too (#141 review)', () => {
-    recordDump(loadMenuDump('0 0 Favorites', ['0 Techno Rumble']));
-    const bank50Dump = loadMenuDump('32 50 Reverbs - Unusual', ['10 Adaptive Reverb']);
-    recordDump(bank50Dump);
-
-    appState.currentKey = '10020010'; // user descended into the load menu
-    appState.currentValues['10020012'] = '0 0 Favorites'; // chose Favorites; dump is bank 50
-    renderScreen(bank50Dump, '', mockLog);
-    const progSel = document.querySelector('select[data-key="10020011"]');
-    expect([...progSel.options].map((o) => o.text)).toEqual(['0 Techno Rumble']);
-  });
-
-  test('the chosen bank survives a currentValues wipe mid-transfer (#141 review)', () => {
+  test('picking a program is pure local staging — no device traffic (#138)', () => {
+    setLibrary(presetLibrary);
     appState.currentKey = '10020000';
     recordDump(programMenu);
-    recordDump(loadMenuDump('32 50 Reverbs - Unusual', ['10 Adaptive Reverb']));
-    recordDump(loadMenuDump('0 0 Favorites', ['0 Techno Rumble']));
-    // The dump in the tree is now bank 0; the user picks bank 50 through
-    // the REAL select path (sets the wipe-proof module state).
+    recordDump(loadMenuDump('0 0 Favorites', ['0 Techno Rumble', '1 St DistortionTwo']));
     renderScreen(programMenu, '', mockLog);
+
+    const progSel = document.querySelector('select[data-key="10020011"]');
+    progSel.value = '1';
+    progSel.dispatchEvent(new Event('change', { bubbles: true }));
+    const repainted = document.querySelector('select[data-key="10020011"]');
+    expect(repainted.options[repainted.selectedIndex].text).toBe('1 St DistortionTwo');
+    expect(sendValuePut).not.toHaveBeenCalled();
+  });
+
+  test('async repaints are idempotent — the staged selection never swaps (#138)', () => {
+    setLibrary(presetLibrary);
+    appState.currentKey = '10020000';
+    recordDump(programMenu);
+    recordDump(loadMenuDump('0 0 Favorites', ['0 Techno Rumble']));
+    renderScreen(programMenu, '', mockLog);
+
+    // Stage bank 50 / program 11.
     const bankSel = document.querySelector('select[data-key="10020012"]');
-    jest.useFakeTimers();
     bankSel.value = '50';
     bankSel.dispatchEvent(new Event('change', { bubbles: true }));
-    jest.advanceTimersByTime(200);
+    document.querySelector('select[data-key="10020011"]').value = '11';
+    document
+      .querySelector('select[data-key="10020011"]')
+      .dispatchEvent(new Event('change', { bubbles: true }));
 
-    // A program pick (or any refresh) wipes currentValues wholesale —
-    // the old-bank list must STILL not repaint (review: the cache-only
-    // check fell back to the dump here).
-    appState.currentValues = {};
+    // A late device dump for the OLD bank lands and triggers repaints —
+    // the staged selection must hold (no swap).
+    recordDump(loadMenuDump('0 0 Favorites', ['0 Techno Rumble']));
     renderScreen(programMenu, '', mockLog);
-    const progSel = document.querySelector('select[data-key="10020011"]');
-    expect([...progSel.options].map((o) => o.text)).toEqual(['10 Adaptive Reverb']);
-    jest.useRealTimers();
+    renderScreen(programMenu, '', mockLog);
+    const bank = document.querySelector('select[data-key="10020012"]');
+    const prog = document.querySelector('select[data-key="10020011"]');
+    expect(bank.options[bank.selectedIndex].text).toBe('50 Reverbs - Unusual');
+    expect(prog.options[prog.selectedIndex].text).toBe('11 AlienShift');
   });
 
-  test('a bank-selection put does NOT clear the memo — it is the action the memo accelerates (#141)', () => {
+  test('unsynced load menu falls back to the current bank + a sync hint (#138)', () => {
+    setLibrary(null);
     appState.currentKey = '10020000';
     recordDump(programMenu);
-    recordDump(loadMenuDump('0 0 Favorites', ['0 Techno Rumble']));
-    recordDump(loadMenuDump('32 50 Reverbs - Unusual', ['10 Adaptive Reverb']));
-    markDirtyIfStable('10020012'); // the bank put's own chokepoint call
-
-    appState.currentValues['10020012'] = '0 0 Favorites';
-    renderScreen(programMenu, '', mockLog);
+    renderScreen(
+      loadMenuDump('5 5 Delays', ['0 Mono Delay', '1 PingPong']).slice(0, 1),
+      '',
+      mockLog
+    );
+    appState.currentKey = '10020010'; // render the load menu directly
+    renderScreen(loadMenuDump('5 5 Delays', ['0 Mono Delay', '1 PingPong']), '', mockLog);
+    // The current bank's programs from the dump, plus the hint.
     const progSel = document.querySelector('select[data-key="10020011"]');
-    expect(progSel).toBeTruthy();
-    expect([...progSel.options].map((o) => o.text)).toEqual(['0 Techno Rumble']);
-  });
-
-  test('mutation chokepoints clear the bank memo (#141)', () => {
-    appState.currentKey = '10020000';
-    recordDump(programMenu);
-    recordDump(loadMenuDump('0 0 Favorites', ['0 Techno Rumble']));
-    recordDump(loadMenuDump('32 50 Reverbs - Unusual', ['10 Adaptive Reverb']));
-    markAllStableDirty(); // e.g. a keypress or reconnect — lists may have changed
-
-    appState.currentValues['10020012'] = '0 0 Favorites';
-    renderScreen(programMenu, '', mockLog);
-    // Memo gone: honest loading, not the (possibly stale) remembered list.
-    expect(document.getElementById('lcd').textContent).toContain('loading programs ...');
+    expect([...progSel.options].map((o) => o.text)).toEqual(['0 Mono Delay', '1 PingPong']);
+    expect(document.getElementById('lcd').textContent).toContain('sync to browse all banks');
   });
 
   // #131: progressive paints during a wave must not destroy an open SET


### PR DESCRIPTION
## Why

Maintainer report: *"lots of race conditions ... the dropdowns keep swapping themselves and things take a while to commit and move."*

The program/load-menu **bank + program dropdowns** were reconciled at **render time** from five competing sources — the live device dump, an optimistic hex cache, a session memo, the synced library, and a module-state bank index — and repainted by several async triggers. Any repaint could resolve a different source (the dropdowns *swapped*), and every selection waited on a device round-trip (*slow to commit*).

## What

Collapse the render path to **one source of truth**.

- **New `src/preset-loader.js`** (DOM-free) holds a single local `{ bankIdx, programIdx }` selection backed by the synced library. Picking a bank/program is **pure local staging — no device I/O**, like scrolling on the hardware. Every async repaint reads this same selection, so repaints are **idempotent** and nothing swaps.
- **The device is touched only on "load program in A/B"** — `library.js loadProgram` sends `bank → program → trigger` PUTs with an optimistic top-bar DSP name. `loadSearchHit` is now a thin delegate, so search and dropdown-load share one device path.
- **`renderer.js`**: `renderLoadMenuSelect` sources options + selection from the loader and library and seeds once from the live dump (`ensureInitialized`); `handleSelectChange` routes the load menu to local staging; `LOAD_TRIGGER` routes through `loadProgram`.
- **Unsynced fallback**: the legacy current-bank dump path plus a `sync to browse all banks` hint (`RENDER.SYNC_TO_BROWSE`).
- **`main.js`**: `resetPresetLoader()` on reconnect and Sync so the next open re-seeds.

`tree.js` / `parser.js` / `event-bridge.js` are **unchanged** — the bank memo, the bank/program/trigger stale-exemptions, and the `0x2e` early-return still back the library scan, the load PUT sequence, and the fallback.

## Validation

Live, against the powered Orville (`logs/probe-loadmenu.mjs`):

1. **No-swap** — staged bank held through repeated repaints.
2. **Instant** — bank/program picks emit zero PUT/bank/program traffic.
3. **Load** — ordered `bank → program → trigger` PUTs, optimistic name same-tick, device-confirmed after settle (the load *persisted* on hardware).
4. **Fallback** — with no library, the legacy put + targeted-fetch fires.

Tests **234/234**, lint clean. New coverage: `tests/preset-loader.test.js` (8) plus library helpers/`loadProgram` and renderer load-menu library/fallback paths.

Reviewed pre-merge by correctness + docs agents — no blockers, no should-fixes.

## Note

Base is `feat/sync-dialog` (PR #145), which this is stacked on. Foundation for the preset browser (#153) and inbound MIDI Program Change (#152), which can reuse the DOM-free loader.
