### PR TITLE
feat: preset browser + program preview + live Favorites (#153, #135)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,10 @@ index.html
       ├─ bitmap.js          screen-capture denibble + canvas render (pure pixel decode in framebuffer.js)
       ├─ theme.js           tokenized theme engine: presets + per-token overrides on :root, service-panel editor
       ├─ demo.js            demo mode: captured device tree (demo-data.json) served via the midi.js port contract
+      ├─ library.js         synced preset library (#142): full bank scan, name search, the device-touching load path (loadProgram/loadProgramToDsp)
+      ├─ sync-dialog.js     library-sync progress overlay drawn on the LCD (defrag-style bank map)
+      ├─ preset-loader.js   DOM-free single source of truth for the load-menu dropdowns: local staging backed by the library (#138)
+      ├─ preset-browser.js  top-level modal: browse/search the library, preview a program on the idle DSP (remember-and-restore), load to A/B (#153/#135)
       ├─ navigation.js      toggleDspKey
       ├─ tree.js            persistent device object tree: recordDump, deriveKeyStack, labels (T1b/#105)
       ├─ eager-loader.js    background preset-subtree structure warm-up, one request in flight (#106)

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -832,7 +832,33 @@ same-tick, device-confirmed after settle (load persisted: device reported the ne
 [4] fallback — legacy put+targeted-fetch fires with no library. Tests 234/234, lint clean. New
 coverage: tests/preset-loader.test.js (8), library.js helpers + loadProgram, renderer load-menu
 library/fallback paths. Foundation for #153 (preset browser) and #152 (inbound Program Change),
-which can reuse the DOM-free loader.
+which can reuse the DOM-free loader. MERGED to main (PR #155, squash 44e40c3; #145 sync-dialog
+merged first as bf60326 — the stacked #154 auto-closed when its base branch was deleted, rebased +
+reopened as #155).
+
+2026-06-12 — PRESET BROWSER + PREVIEW + LIVE FAVORITES (#153/#135, branch feat/preset-browser-153-135,
+PR open). Built on the #138 preset-loader foundation. NEW src/preset-browser.js: a top-level modal
+(theme-tokened, modeled on sync-dialog) browsing the synced library — bank list + program list +
+name search (reuses searchLibrary/canSearch), with per-program Preview / load-to-A / load-to-B.
+PREVIEW (#135) is remember-and-restore: the Orville runs BOTH DSPs, so auditioning necessarily
+overwrites the target engine — preview captures the slot's EXACT current program (indices, since
+names repeat across banks) BEFORE loading onto the IDLE engine, and offers Keep (leave it) vs Cancel
+(reload the remembered program). Explicit action only (no auto-preview — the ~2s DSP rebuild),
+controls lock during a load. library.js: loadProgramToDsp(target, dspSlot, onDone) generalizes
+loadProgram (slot-chosen trigger + optimistic name by slot; loadProgram is now a thin active-slot
+caller); lastLoadedBySlot + getRememberedProgram (exact app-load memory, best-effort running-name
+fallback) + resetLibraryLoadMemory. LIVE FAVORITES (maintainer report "favorites gets out of sync
+since that's a live menu"): bank 0 is the device's auto-generated MRU that reorders on every load,
+so its static library snapshot is always stale — isFavoritesBank + refreshFavoritesBank re-read it
+live whenever viewed (load menu bank-0 select + browser bank-0 select), while the 70 static banks
+stay on the race-free library path. main.js: BROWSE button, setupPresetBrowser({onLoadComplete}),
+resetPresetBrowser() next to both resetPresetLoader() seams. Tests 253/253 (+19: loadProgramToDsp
+slot targeting/order, getRememberedProgram exact/fallback/null, isFavoritesBank, refreshFavoritesBank,
+new tests/preset-browser.test.js render/search/empty/preview-remember-restore/keep/no-auto-preview/
+live-favorites/reset), lint clean. NEEDS-HARDWARE: logs/probe-preview-135.mjs (preview round-trip)
+is written + ready but the WinMM port was held by the live app tab this session — run with the tab
+closed to confirm the restore round-trip on hardware. The device-facing load mechanics are already
+hardware-proven via probe-loadmenu (same loadProgramToDsp path, explicit slot).
 
 ## Done (verified merged — do not redo)
 - A1  main.js debug-upload slice bounds — PR #24

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -855,10 +855,13 @@ stay on the race-free library path. main.js: BROWSE button, setupPresetBrowser({
 resetPresetBrowser() next to both resetPresetLoader() seams. Tests 253/253 (+19: loadProgramToDsp
 slot targeting/order, getRememberedProgram exact/fallback/null, isFavoritesBank, refreshFavoritesBank,
 new tests/preset-browser.test.js render/search/empty/preview-remember-restore/keep/no-auto-preview/
-live-favorites/reset), lint clean. NEEDS-HARDWARE: logs/probe-preview-135.mjs (preview round-trip)
-is written + ready but the WinMM port was held by the live app tab this session — run with the tab
-closed to confirm the restore round-trip on hardware. The device-facing load mechanics are already
-hardware-proven via probe-loadmenu (same loadProgramToDsp path, explicit slot).
+live-favorites/reset), lint clean. VALIDATED LIVE against the powered Orville
+(logs/probe-preview-135.mjs, raw output in session): with DSP A active, loaded '10 Delaytaps' into
+the IDLE slot B (explicit-slot targeting — idle name changed); getRememberedProgram returned the
+EXACT {bank 5, prog 0} just loaded (not a name guess); previewed '11 Delaytaps 2' onto B (overwrite);
+restored -> idle name back to '10 Delaytaps' (RESTORE-ROUND-TRIP PASS). Reviewed (correctness + docs);
+fixed one blocker (loadProgramToDsp now fires onDone on its sync-guard early-return so a browser load
+during a sync cannot stick the control lock — regression-tested).
 
 ## Done (verified merged — do not redo)
 - A1  main.js debug-upload slice bounds — PR #24

--- a/src/constants.js
+++ b/src/constants.js
@@ -117,9 +117,10 @@ export const LIBRARY = {
   //                        trusted from the static library snapshot — it is
   //                        re-fetched live whenever viewed (#138/#135 follow-up)
   FAVORITES_REFRESH_MS: 1200, // settle after selecting bank 0 + dumping it: the
-  //                             MRU list is tiny (8 links) so its dump lands
-  //                             fast, but 2x BANK_SETTLE_MS leaves margin for
-  //                             the objectinfo:received listener to re-record it
+  //                             MRU list is small (default 8 links, device-model.md
+  //                             §"Bank 0") so its dump lands fast, but 2x
+  //                             BANK_SETTLE_MS leaves margin for the
+  //                             objectinfo:received listener to re-record it
 };
 
 // Demo mode (src/demo.js): the canned device built from a live capture.

--- a/src/constants.js
+++ b/src/constants.js
@@ -111,6 +111,15 @@ export const LIBRARY = {
   LOAD_SETTLE_MS: 600, // wait between the search-load sequence's puts (bank ->
   //                      program -> load trigger): same settle rationale as
   //                      BANK_SETTLE_MS, applied to each step
+  FAVORITES_BANK_IDX: 0, // bank 0 is the device's LIVE most-recently-used
+  //                        "Favorites" bank (device-model.md §"Bank 0"): it
+  //                        reorders on every load, so its program list is never
+  //                        trusted from the static library snapshot — it is
+  //                        re-fetched live whenever viewed (#138/#135 follow-up)
+  FAVORITES_REFRESH_MS: 1200, // settle after selecting bank 0 + dumping it: the
+  //                             MRU list is tiny (8 links) so its dump lands
+  //                             fast, but 2x BANK_SETTLE_MS leaves margin for
+  //                             the objectinfo:received listener to re-record it
 };
 
 // Demo mode (src/demo.js): the canned device built from a live capture.

--- a/src/index.html
+++ b/src/index.html
@@ -51,6 +51,13 @@
         >
           Sync Library
         </button>
+        <button
+          id="open-browser"
+          class="util-btn"
+          title="Browse, preview, and load presets from the synced library"
+        >
+          Browse
+        </button>
         <span id="sync-status" class="sync-status">not synced</span>
         <span class="conn-spacer"></span>
         <button id="save-config" class="util-btn">Save Config</button>

--- a/src/library.js
+++ b/src/library.js
@@ -271,8 +271,11 @@ function stripIndexToken(name) {
 export async function loadProgramToDsp(target, dspSlot, onDone) {
   if (syncing) {
     // The scan owns the bank selection: a load interleaved with it would
-    // land in whatever bank the scan happens to be visiting (review).
+    // land in whatever bank the scan happens to be visiting (review). Still
+    // fire onDone — a caller holding a UI lock (the browser's withLoadLock)
+    // must unlock on this no-op, or its controls stick disabled (review B1).
     log('Load ignored: library sync in progress', 'error', 'error');
+    onDone?.();
     return;
   }
   const isA = dspSlot === 'A';

--- a/src/library.js
+++ b/src/library.js
@@ -249,7 +249,9 @@ function activeSlot() {
 
 /** Strips a leading index token ('16 Black Hole' -> 'Black Hole'). */
 function stripIndexToken(name) {
-  return String(name).trim().replace(/^\d+\s+/, '');
+  return String(name)
+    .trim()
+    .replace(/^\d+\s+/, '');
 }
 
 /**

--- a/src/library.js
+++ b/src/library.js
@@ -234,38 +234,60 @@ export async function syncLibrary(onProgress) {
   return library;
 }
 
+// Per-slot memory of the last program THIS APP loaded into each DSP (#135).
+// Preview restore needs the EXACT program a slot held before previewing, and
+// program names repeat across banks — so we remember indices, not names. Only
+// app-initiated loads are tracked (the device's own front-panel loads are not
+// observable here); getRememberedProgram falls back to a best-effort name
+// lookup when the app has not loaded into a slot this session.
+let lastLoadedBySlot = { A: null, B: null };
+
+/** The DSP slot ('A' | 'B') currently active, from the presetKey prefix. */
+function activeSlot() {
+  return appState.presetKey.startsWith(KEY_PREFIX.DSP_A) ? 'A' : 'B';
+}
+
+/** Strips a leading index token ('16 Black Hole' -> 'Black Hole'). */
+function stripIndexToken(name) {
+  return String(name).trim().replace(/^\d+\s+/, '');
+}
+
 /**
- * Loads a bank+program into the ACTIVE DSP: bank PUT, program PUT (with a
- * readback), then the active-DSP load trigger — each step settled (the
- * device re-lists between steps). The single device-touching action for
- * BOTH search hits and the preset-loader dropdowns (#138). Optimistically
- * updates the top-bar DSP name so the load feels immediate; the caller's
- * root refetch (onDone) reconciles the real name (~2s, device-bound).
+ * Loads a bank+program into a CHOSEN DSP slot: bank PUT, program PUT (with a
+ * readback), then that slot's load trigger — each step settled (the device
+ * re-lists between steps). The single device-touching apply path, shared by
+ * search hits, the preset-loader dropdowns (#138), and the preset browser /
+ * preview (#135). Optimistically updates that slot's top-bar name so the
+ * load feels immediate; the caller's root refetch (onDone) reconciles the
+ * real name (~2s, device-bound). Records the load into lastLoadedBySlot so a
+ * later preview of the same slot can restore it exactly.
  *
  * @param {{bankIdx: string, programIdx: string, programName: string}} target
+ * @param {'A'|'B'} dspSlot - Which engine to load into, regardless of which
+ *   is currently active (preview loads the non-active slot).
  * @param {Function} [onDone] - Called after the load trigger fires (the
  *   caller refreshes the screen / root names).
  */
-export async function loadProgram(target, onDone) {
+export async function loadProgramToDsp(target, dspSlot, onDone) {
   if (syncing) {
     // The scan owns the bank selection: a load interleaved with it would
     // land in whatever bank the scan happens to be visiting (review).
     log('Load ignored: library sync in progress', 'error', 'error');
     return;
   }
-  const activeIsA = appState.presetKey.startsWith(KEY_PREFIX.DSP_A);
+  const isA = dspSlot === 'A';
   log(
-    `Load: '${target.programName}' (bank ${target.bankIdx}) -> DSP ${activeIsA ? 'A' : 'B'}`,
+    `Load: '${target.programName}' (bank ${target.bankIdx}) -> DSP ${dspSlot}`,
     'info',
     'general'
   );
-  // Optimistic top-bar name: show the loaded program on the active DSP at
+  // Optimistic top-bar name: show the loaded program on the chosen DSP at
   // once; the root refetch in onDone confirms or corrects it.
   if (target.programName) {
-    const cleanName = String(target.programName)
-      .trim()
-      .replace(/^\d+\s+/, ''); // strip a leading index token if present
-    setState({ [activeIsA ? 'dspAName' : 'dspBName']: cleanName }, 'library:load-optimistic-name');
+    setState(
+      { [isA ? 'dspAName' : 'dspBName']: stripIndexToken(target.programName) },
+      'library:load-optimistic-name'
+    );
   }
   sendValuePut(KEY.BANK_SELECT, target.bankIdx);
   await sleep(LIBRARY.LOAD_SETTLE_MS);
@@ -275,8 +297,84 @@ export async function loadProgram(target, onDone) {
   // — the echo lands in currentValues/the log for the eye to catch.
   sendValueDump(KEY.PROGRAM_SELECT);
   await sleep(LIBRARY.LOAD_SETTLE_MS);
-  sendValuePut(activeIsA ? KEY.LOAD_TRIGGER_A : KEY.LOAD_TRIGGER_B, '1');
+  sendValuePut(isA ? KEY.LOAD_TRIGGER_A : KEY.LOAD_TRIGGER_B, '1');
   await sleep(LIBRARY.LOAD_SETTLE_MS);
+  // Remember (exact indices) what this slot now holds, for preview restore.
+  lastLoadedBySlot[dspSlot] = {
+    bankIdx: target.bankIdx,
+    programIdx: target.programIdx,
+    programName: target.programName,
+  };
+  onDone?.();
+}
+
+/**
+ * Loads a bank+program into the ACTIVE DSP — thin caller over
+ * loadProgramToDsp for the search hits and load-menu dropdowns, which always
+ * target whichever engine is in focus.
+ *
+ * @param {{bankIdx: string, programIdx: string, programName: string}} target
+ * @param {Function} [onDone]
+ */
+export function loadProgram(target, onDone) {
+  return loadProgramToDsp(target, activeSlot(), onDone);
+}
+
+/**
+ * The exact program to restore into a slot after a preview (#135). Prefers
+ * the indices the app last loaded into that slot this session (exact); falls
+ * back to a best-effort lookup of the slot's running name against the
+ * library (which can mis-resolve a name shared across banks — the caller
+ * surfaces this as best-effort). null when neither is available.
+ *
+ * @param {'A'|'B'} dspSlot
+ * @returns {{bankIdx: string, programIdx: string, programName: string}|null}
+ */
+export function getRememberedProgram(dspSlot) {
+  if (lastLoadedBySlot[dspSlot]) return { ...lastLoadedBySlot[dspSlot] };
+  if (!library) return null;
+  const runningName = stripIndexToken(dspSlot === 'A' ? appState.dspAName : appState.dspBName);
+  if (!runningName) return null;
+  for (const bank of library.banks) {
+    const program = bank.programs.find((p) => stripIndexToken(p.name) === runningName);
+    if (program) {
+      return { bankIdx: bank.idx, programIdx: program.idx, programName: program.name };
+    }
+  }
+  return null;
+}
+
+/** Clears the per-slot load memory (disconnect / Sync — see resetters). */
+export function resetLibraryLoadMemory() {
+  lastLoadedBySlot = { A: null, B: null };
+}
+
+/** True for the live MRU "Favorites" bank (bank 0), which must be live-read. */
+export function isFavoritesBank(bankIdx) {
+  return parseInt(bankIdx, 10) === LIBRARY.FAVORITES_BANK_IDX;
+}
+
+/**
+ * Re-reads the live Favorites bank (bank 0) from the device (#138/#135
+ * follow-up). Bank 0 is an auto-generated most-recently-used list that
+ * reorders on every load, so its static library snapshot goes stale the
+ * moment anything is loaded — both the load menu and the preset browser
+ * re-fetch it before showing it. Selects bank 0 and dumps it; the
+ * objectinfo:received listener below re-records library.banks[0] from the
+ * fresh memo. No-op (just callback) while a full sync owns the bank cursor.
+ *
+ * @param {Function} [onDone] - Called once the fresh dump has settled.
+ */
+export async function refreshFavoritesBank(onDone) {
+  if (syncing) {
+    onDone?.();
+    return;
+  }
+  sendValuePut(KEY.BANK_SELECT, String(LIBRARY.FAVORITES_BANK_IDX));
+  await sleep(LIBRARY.BANK_SETTLE_MS);
+  sendObjectInfoDump(KEY.FAVORITES);
+  sendValueDump(KEY.FAVORITES);
+  await sleep(LIBRARY.FAVORITES_REFRESH_MS);
   onDone?.();
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -24,6 +24,12 @@ import {
   canSearch,
 } from './library.js';
 import { showSyncProgress, showSyncComplete, hideSyncDialog } from './sync-dialog.js';
+import {
+  setupPresetBrowser,
+  openPresetBrowser,
+  renderBrowser,
+  resetPresetBrowser,
+} from './preset-browser.js';
 import { setupKeypressControls, setupDataKnob, testKeypress, meterPollTick } from './controls.js';
 import {
   setMidiPorts,
@@ -179,6 +185,7 @@ function resetAndLand() {
   // any staged bank/program selection so the next load-menu render takes its
   // one-shot seed from the new dump (#138), not the previous session's pick.
   resetPresetLoader();
+  resetPresetBrowser(); // also drop any open browser + in-flight preview state
   setState(
     {
       currentKey: KEY.ROOT,
@@ -281,6 +288,7 @@ syncBtn.addEventListener('click', () => {
   // Sync is the explicit re-read: drop the staged load-menu selection too so
   // it re-seeds from the device's current bank/program (#138).
   resetPresetLoader();
+  resetPresetBrowser();
   setState({ currentKey: KEY.ROOT, keyStack: [] }, 'main:sync-root');
   updateScreen(log);
   log('Synced to root', 'info', 'general');
@@ -486,6 +494,19 @@ function setupLibraryUI() {
   const statusEl = document.getElementById('sync-status');
   setLibrary(cachedConfig?.presetLibrary);
 
+  // The post-load root refetch shared by the search and the browser — keeps
+  // device I/O out of those modules (they call library.js loaders + this).
+  const afterLoad = () => {
+    sendObjectInfoDump(KEY.ROOT); // refresh the DSP preset names
+    updateScreen(log);
+    if (appState.fetchBitmap) sendSysEx(CMD.GET_SCREEN, []);
+  };
+
+  // Preset browser (#153) + preview (#135): a modal over the synced library.
+  setupPresetBrowser({ onLoadComplete: afterLoad });
+  const browseBtn = document.getElementById('open-browser');
+  if (browseBtn) browseBtn.addEventListener('click', openPresetBrowser);
+
   // "12m ago" style relative time from an ISO stamp.
   const timeAgo = (iso) => {
     const diff = Date.now() - new Date(iso).getTime();
@@ -515,6 +536,7 @@ function setupLibraryUI() {
       statusEl.textContent = lib ? `${count} presets · ${timeAgo(lib.syncedAt)}` : 'not synced';
       if (lib) statusEl.title = `Last synced ${new Date(lib.syncedAt).toLocaleString()}`;
     }
+    renderBrowser(); // keep an open browser in step with the library (post-sync)
   };
   refreshLibraryUI();
 
@@ -553,11 +575,7 @@ function setupLibraryUI() {
         row.addEventListener('mousedown', () => {
           hideResults();
           searchInput.value = '';
-          loadSearchHit(hit, () => {
-            sendObjectInfoDump(KEY.ROOT); // refresh the DSP preset names
-            updateScreen(log);
-            if (appState.fetchBitmap) sendSysEx(CMD.GET_SCREEN, []);
-          });
+          loadSearchHit(hit, afterLoad);
         });
         resultsEl.appendChild(row);
       }

--- a/src/preset-browser.js
+++ b/src/preset-browser.js
@@ -153,7 +153,9 @@ function renderBanks(lib) {
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.className =
-      'pb-bank' + (bank.idx === selectedBankIdx ? ' pb-bank-sel' : '') + (live ? ' pb-bank-live' : '');
+      'pb-bank' +
+      (bank.idx === selectedBankIdx ? ' pb-bank-sel' : '') +
+      (live ? ' pb-bank-live' : '');
     btn.textContent = bank.name;
     if (live) {
       // The Favorites bank is the device's live MRU — flag it and re-read it
@@ -250,7 +252,9 @@ function renderBanner() {
   msg.append(
     document.createTextNode('Previewing '),
     bold(previewState.previewing.programName),
-    document.createTextNode(` on DSP ${previewState.dspSlot} — Keep replaces DSP ${previewState.dspSlot}.`)
+    document.createTextNode(
+      ` on DSP ${previewState.dspSlot} — Keep replaces DSP ${previewState.dspSlot}.`
+    )
   );
   bar.append(msg);
 

--- a/src/preset-browser.js
+++ b/src/preset-browser.js
@@ -1,0 +1,415 @@
+// preset-browser.js
+// The preset browser (#153) + program preview (#135): a top-level modal over
+// the faceplate (NOT inside the bezel like the sync dialog — it is a full
+// interactive panel, not an LCD overlay) for browsing the synced library and
+// auditioning programs before committing.
+//
+// Browse: a bank list on the left, that bank's programs on the right, plus a
+// name search (the same searchLibrary corpus the conn-strip quick-search
+// uses). Each program offers Preview / load-to-A / load-to-B.
+//
+// Preview (#135) is the subtle part. The Orville runs BOTH DSP engines at
+// once, so there is no truly idle engine — auditioning a program necessarily
+// OVERWRITES whatever preset sits in the engine we load it into. We make that
+// safe with remember-and-restore: before previewing we capture the EXACT
+// bank/program the target slot holds (indices, since names repeat across
+// banks — getRememberedProgram), load the preview onto the NON-active engine
+// (so the patch you are focused on keeps playing), and offer Keep (leave it)
+// vs Cancel (reload the remembered program). Every preview load and every
+// restore costs the device's ~2s DSP rebuild, so preview is an explicit
+// action (never auto-fired on selection) and the controls lock while a load
+// is in flight.
+//
+// All device I/O goes through library.js (loadProgramToDsp); this module only
+// renders and sequences. The root refetch after a load is injected at setup
+// (onLoadComplete) so the module never sends SysEx itself.
+
+import { appState } from './state.js';
+import { KEY_PREFIX } from './sysex-commands.js';
+import {
+  getLibrary,
+  searchLibrary,
+  canSearch,
+  libraryProgramCount,
+  loadProgramToDsp,
+  getRememberedProgram,
+  isFavoritesBank,
+  refreshFavoritesBank,
+} from './library.js';
+import { log } from './logger.js';
+
+let el = null; // the modal element (created lazily, reused)
+let onLoadComplete = null; // injected root-refetch callback (no SysEx here)
+let selectedBankIdx = null; // which bank's programs are shown (decimal string)
+let searchQuery = '';
+
+// Preview session state (#135). previewing/restore are load targets
+// ({ bankIdx, programIdx, programName }); dspSlot is 'A'|'B'; loading locks
+// the controls during the ~2s device rebuild.
+let previewState = { dspSlot: null, previewing: null, restore: null, loading: false };
+
+/** The DSP slot ('A'|'B') currently in focus, from the presetKey prefix. */
+function activeSlot() {
+  return appState.presetKey.startsWith(KEY_PREFIX.DSP_A) ? 'A' : 'B';
+}
+
+/** The non-active engine — where a preview auditions (#135). */
+function previewSlot() {
+  return activeSlot() === 'A' ? 'B' : 'A';
+}
+
+/**
+ * Wires the injected post-load callback (the same root refetch the conn-strip
+ * search uses) once at boot. Kept out of this module so it never sends SysEx.
+ *
+ * @param {{onLoadComplete: () => void}} cfg
+ */
+export function setupPresetBrowser(cfg) {
+  onLoadComplete = cfg?.onLoadComplete || null;
+}
+
+function ensureEl() {
+  if (el) return el;
+  el = document.createElement('div');
+  el.className = 'preset-browser';
+  el.hidden = true;
+  document.body.appendChild(el);
+  return el;
+}
+
+/** Opens the browser (renders fresh from the current library). */
+export function openPresetBrowser() {
+  const node = ensureEl();
+  node.hidden = false;
+  renderBrowser();
+}
+
+/** Closes the browser. Leaves any preview in place (Keep is implicit). */
+export function closePresetBrowser() {
+  if (el) el.hidden = true;
+}
+
+/** Resets browser + preview state (disconnect / Sync — see main.js). */
+export function resetPresetBrowser() {
+  previewState = { dspSlot: null, previewing: null, restore: null, loading: false };
+  selectedBankIdx = null;
+  searchQuery = '';
+  // Remove the panel entirely (not just hide): the next open rebuilds it fresh
+  // from the re-read device, with no stale DOM or preview banner lingering.
+  if (el) {
+    el.remove();
+    el = null;
+  }
+}
+
+// --- rendering -----------------------------------------------------------
+
+function makeButton(label, className, onClick, disabled) {
+  const b = document.createElement('button');
+  b.type = 'button';
+  b.className = className;
+  b.textContent = label;
+  if (disabled) b.disabled = true;
+  else b.addEventListener('click', onClick);
+  return b;
+}
+
+// One program row: the name plus Preview / →A / →B. Names are device-supplied
+// strings — textContent only, never innerHTML (matches the renderer/search
+// caution). prefix shows the bank when listing search hits across banks.
+function programRow(target, prefix) {
+  const row = document.createElement('li');
+  row.className = 'pb-prog';
+
+  const name = document.createElement('span');
+  name.className = 'pb-prog-name';
+  if (prefix) {
+    const p = document.createElement('span');
+    p.className = 'pb-prog-bank';
+    p.textContent = `${prefix} › `;
+    name.append(p);
+  }
+  name.append(document.createTextNode(target.programName));
+  row.append(name);
+
+  const actions = document.createElement('span');
+  actions.className = 'pb-prog-actions';
+  const locked = previewState.loading;
+  actions.append(
+    makeButton('Preview', 'pb-btn pb-preview', () => previewProgram(target, previewSlot()), locked),
+    makeButton('→A', 'pb-btn pb-load-a', () => loadToSlot(target, 'A'), locked),
+    makeButton('→B', 'pb-btn pb-load-b', () => loadToSlot(target, 'B'), locked)
+  );
+  row.append(actions);
+  return row;
+}
+
+function renderBanks(lib) {
+  const list = document.createElement('ul');
+  list.className = 'pb-banks';
+  for (const bank of lib.banks) {
+    const li = document.createElement('li');
+    const live = isFavoritesBank(bank.idx);
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className =
+      'pb-bank' + (bank.idx === selectedBankIdx ? ' pb-bank-sel' : '') + (live ? ' pb-bank-live' : '');
+    btn.textContent = bank.name;
+    if (live) {
+      // The Favorites bank is the device's live MRU — flag it and re-read it
+      // on select so we never show a stale snapshot (#138/#135 follow-up).
+      const tag = document.createElement('span');
+      tag.className = 'pb-bank-livetag';
+      tag.textContent = 'live';
+      btn.append(tag);
+    }
+    btn.disabled = previewState.loading;
+    btn.addEventListener('click', () => selectBank(bank.idx, live));
+    li.append(btn);
+    list.append(li);
+  }
+  return list;
+}
+
+// Selecting a bank just shows its programs — EXCEPT the live Favorites bank,
+// which is re-fetched from the device first (its MRU list reorders on every
+// load, so the static snapshot is stale). The fetch locks the controls.
+function selectBank(bankIdx, live) {
+  if (previewState.loading) return;
+  selectedBankIdx = bankIdx;
+  searchQuery = '';
+  if (!live) {
+    renderBrowser();
+    return;
+  }
+  previewState.loading = true;
+  renderBrowser();
+  refreshFavoritesBank(() => {
+    previewState.loading = false;
+    onLoadComplete?.();
+    renderBrowser();
+  });
+}
+
+function renderPrograms(lib) {
+  const list = document.createElement('ul');
+  list.className = 'pb-programs';
+
+  if (searchQuery.trim()) {
+    // Search mode: flat hits across every bank (each row shows its bank).
+    if (!canSearch()) {
+      return emptyNote('Sync the library first to search.');
+    }
+    const hits = searchLibrary(searchQuery);
+    if (!hits.length) return emptyNote('No matching presets.');
+    for (const hit of hits) list.append(programRow(hit, hit.bankName));
+    return list;
+  }
+
+  const bank = lib.banks.find((b) => b.idx === selectedBankIdx);
+  if (!bank) return emptyNote('Select a bank to see its programs.');
+  for (const program of bank.programs) {
+    list.append(
+      programRow({ bankIdx: bank.idx, programIdx: program.idx, programName: program.name }, '')
+    );
+  }
+  return list;
+}
+
+function emptyNote(text) {
+  const d = document.createElement('div');
+  d.className = 'pb-empty';
+  d.textContent = text;
+  return d;
+}
+
+// The preview status bar: idle when nothing is auditioning, otherwise the
+// previewing program + Keep / Cancel. Cancel restores the slot's remembered
+// program; when there is no restore point we say so instead of offering it.
+function renderBanner() {
+  const bar = document.createElement('div');
+  bar.className = 'pb-banner';
+  const locked = previewState.loading;
+
+  if (previewState.loading && !previewState.previewing) {
+    bar.classList.add('pb-banner-busy');
+    bar.textContent = 'loading…';
+    return bar;
+  }
+  if (!previewState.previewing) {
+    bar.classList.add('pb-banner-idle');
+    bar.textContent = 'Preview auditions on the idle engine (DSP ' + previewSlot() + ').';
+    return bar;
+  }
+
+  bar.classList.add('pb-banner-live');
+  const msg = document.createElement('span');
+  msg.className = 'pb-banner-msg';
+  // Make the destructive reality legible: Keep leaves the preview in this
+  // slot (replacing what was there); Cancel puts the original back.
+  msg.append(
+    document.createTextNode('Previewing '),
+    bold(previewState.previewing.programName),
+    document.createTextNode(` on DSP ${previewState.dspSlot} — Keep replaces DSP ${previewState.dspSlot}.`)
+  );
+  bar.append(msg);
+
+  const actions = document.createElement('span');
+  actions.className = 'pb-banner-actions';
+  actions.append(makeButton('Keep', 'pb-btn pb-keep', keepPreview, locked));
+  if (previewState.restore) {
+    actions.append(makeButton('Cancel', 'pb-btn pb-cancel', cancelPreview, locked));
+  } else {
+    const note = document.createElement('span');
+    note.className = 'pb-banner-note';
+    note.textContent = `(no saved state for DSP ${previewState.dspSlot})`;
+    actions.append(note);
+  }
+  bar.append(actions);
+  return bar;
+}
+
+function bold(text) {
+  const b = document.createElement('b');
+  b.textContent = text;
+  return b;
+}
+
+export function renderBrowser() {
+  // No-op when closed: external callers (post-sync refresh) must not build the
+  // panel until it is actually open. Internal callers open it first.
+  if (!el || el.hidden) return;
+  const node = el;
+  node.innerHTML = '';
+  const lib = getLibrary();
+
+  const panel = document.createElement('div');
+  panel.className = 'pb-panel';
+
+  // Header: title, search, close.
+  const head = document.createElement('header');
+  head.className = 'pb-head';
+  const title = document.createElement('span');
+  title.className = 'pb-title';
+  title.textContent = 'PRESET BROWSER';
+  head.append(title);
+
+  if (lib) {
+    const search = document.createElement('input');
+    search.type = 'text';
+    search.className = 'pb-search';
+    search.value = searchQuery;
+    const enabled = canSearch();
+    search.disabled = !enabled;
+    search.placeholder = enabled
+      ? `Search ${libraryProgramCount()} presets`
+      : `Sync more to search (${libraryProgramCount()})`;
+    search.addEventListener('input', () => {
+      searchQuery = search.value;
+      renderPanelBody(panel, lib);
+    });
+    head.append(search);
+  }
+  head.append(makeButton('✕', 'pb-close', closePresetBrowser, false));
+  panel.append(head);
+
+  renderPanelBody(panel, lib);
+  node.append(panel);
+}
+
+// The body below the header — split out so a search keystroke can repaint the
+// lists + banner without rebuilding (and re-focusing) the search input.
+function renderPanelBody(panel, lib) {
+  panel.querySelector('.pb-banner')?.remove();
+  panel.querySelector('.pb-body')?.remove();
+
+  if (!lib) {
+    panel.append(
+      bannerless('Library not synced. Use Sync Library to browse every bank and program here.')
+    );
+    return;
+  }
+
+  panel.append(renderBanner());
+
+  const body = document.createElement('div');
+  body.className = 'pb-body';
+  // Default to the first STATIC bank so opening is instant — landing on the
+  // live Favorites bank would force a device round-trip on every open.
+  if (selectedBankIdx === null && lib.banks.length) {
+    const firstStatic = lib.banks.find((b) => !isFavoritesBank(b.idx)) || lib.banks[0];
+    selectedBankIdx = firstStatic.idx;
+  }
+  body.append(renderBanks(lib), renderPrograms(lib));
+  panel.append(body);
+}
+
+function bannerless(text) {
+  const d = document.createElement('div');
+  d.className = 'pb-body pb-unsynced';
+  d.append(emptyNote(text));
+  return d;
+}
+
+// --- actions (device-touching, all via library.js) -----------------------
+
+// Locks the controls, repaints (so buttons show disabled), runs the load,
+// then unlocks + repaints on the device-confirmed callback.
+function withLoadLock(run) {
+  previewState.loading = true;
+  renderBrowser();
+  run(() => {
+    previewState.loading = false;
+    onLoadComplete?.();
+    renderBrowser();
+  });
+}
+
+function loadToSlot(target, slot) {
+  if (previewState.loading) return;
+  withLoadLock((done) => loadProgramToDsp(target, slot, done));
+}
+
+/**
+ * Auditions a program on the idle engine (#135). Captures the slot's current
+ * program as the restore point BEFORE loading (and not again while a preview
+ * is already live on that slot, so the restore stays the pre-preview state).
+ *
+ * @param {{bankIdx: string, programIdx: string, programName: string}} target
+ * @param {'A'|'B'} slot
+ */
+export function previewProgram(target, slot) {
+  if (previewState.loading) return;
+  const startingFresh = !previewState.previewing || previewState.dspSlot !== slot;
+  const restore = startingFresh ? getRememberedProgram(slot) : previewState.restore;
+  if (startingFresh && !restore) {
+    log(`Preview: no saved program for DSP ${slot} — Cancel cannot restore`, 'general', 'general');
+  }
+  withLoadLock((done) =>
+    loadProgramToDsp(target, slot, () => {
+      previewState.dspSlot = slot;
+      previewState.previewing = target;
+      previewState.restore = restore;
+      done();
+    })
+  );
+}
+
+/** Keeps the previewed program (no device I/O) and clears the banner. */
+export function keepPreview() {
+  if (previewState.loading) return;
+  previewState = { dspSlot: null, previewing: null, restore: null, loading: false };
+  renderBrowser();
+}
+
+/** Restores the slot's pre-preview program (#135). */
+export function cancelPreview() {
+  if (previewState.loading || !previewState.restore) return;
+  const { restore, dspSlot } = previewState;
+  withLoadLock((done) =>
+    loadProgramToDsp(restore, dspSlot, () => {
+      previewState = { dspSlot: null, previewing: null, restore: null, loading: false };
+      done();
+    })
+  );
+}

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -14,7 +14,7 @@ import {
   GANG_MAX_DEPTH,
 } from './tree.js';
 import { log } from './logger.js';
-import { isSyncing, loadProgram } from './library.js';
+import { isSyncing, loadProgram, isFavoritesBank, refreshFavoritesBank } from './library.js';
 import {
   isLoadMenuActive,
   hasLibrary,
@@ -183,8 +183,24 @@ const handleSelectChange = (e) => {
   // every async repaint is idempotent. The device is touched only by the
   // explicit '<- load program in A/B' TRG (handleParamClick -> loadProgram).
   if (isLoadMenuActive() && hasLibrary() && isLoadMenuChooser({ key })) {
-    if (key === KEY.BANK_SELECT) selectBank(parseInt(selectedIndex, 10));
-    else selectProgram(parseInt(selectedIndex, 10));
+    if (key === KEY.BANK_SELECT) {
+      const bankIdx = parseInt(selectedIndex, 10);
+      selectBank(bankIdx);
+      renderScreen(appState.currentSubs, appState.lastAscii); // instant local paint
+      // EXCEPTION to the no-traffic rule: bank 0 is the device's live MRU
+      // "Favorites" bank, which reorders on every load — its library snapshot
+      // is always stale. Re-fetch it, then re-stage to its fresh first program
+      // and repaint. The 70 static banks stay pure local staging.
+      if (isFavoritesBank(bankIdx)) {
+        showLoading();
+        refreshFavoritesBank(() => {
+          selectBank(bankIdx);
+          renderScreen(appState.currentSubs, appState.lastAscii);
+        });
+      }
+      return;
+    }
+    selectProgram(parseInt(selectedIndex, 10));
     renderScreen(appState.currentSubs, appState.lastAscii);
     return;
   }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1372,3 +1372,229 @@ body {
     grid-template-columns: 1fr;
   }
 }
+
+/* Preset browser (#153) + preview (#135): a top-level modal over the
+   faceplate. Unlike the sync dialog (an LCD overlay inside the bezel), this is
+   a full interactive panel, so z-index IS wanted — it sits above everything.
+   Phosphor headers, a readable two-pane list, all on theme tokens. */
+.preset-browser[hidden] {
+  display: none;
+}
+.preset-browser {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, var(--btn-edge) 78%, transparent);
+  backdrop-filter: blur(3px);
+  font-family: var(--legend-font);
+}
+.pb-panel {
+  display: flex;
+  flex-direction: column;
+  width: min(880px, 92vw);
+  height: min(680px, 88vh);
+  background: linear-gradient(var(--btn-cap-hi), var(--btn-cap));
+  border: 1px solid var(--btn-edge);
+  border-radius: 6px;
+  box-shadow:
+    0 0 0 1px var(--panel-line),
+    0 24px 64px rgba(0, 0, 0, 0.6);
+  overflow: hidden;
+}
+.pb-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--panel-line);
+  background: var(--lcd-bg);
+}
+.pb-title {
+  font-family: 'OrvilleLCD', ui-monospace, Consolas, monospace;
+  font-size: 18px;
+  letter-spacing: 2px;
+  color: var(--lcd-px);
+  text-shadow:
+    0 0 2px var(--lcd-px),
+    0 0 8px var(--lcd-glow);
+  white-space: nowrap;
+}
+.pb-search {
+  flex: 1;
+  min-width: 0;
+  padding: 6px 10px;
+  font-family: var(--legend-font);
+  font-size: 13px;
+  color: var(--legend);
+  background: color-mix(in srgb, var(--lcd-bg) 70%, var(--btn-cap));
+  border: 1px solid var(--panel-line);
+  border-radius: 3px;
+}
+.pb-search:disabled {
+  color: var(--legend-dim);
+  cursor: not-allowed;
+}
+.pb-close {
+  padding: 4px 9px;
+  font-size: 14px;
+  line-height: 1;
+  color: var(--legend);
+  background: linear-gradient(var(--btn-cap-hi), var(--btn-cap));
+  border: 1px solid var(--btn-edge);
+  border-radius: 3px;
+  cursor: pointer;
+}
+.pb-close:hover {
+  color: var(--lcd-px);
+}
+/* Preview status bar: the destructive-preview legibility lives here. */
+.pb-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 16px;
+  min-height: 20px;
+  font-size: 12px;
+  border-bottom: 1px solid var(--panel-line);
+  color: var(--legend-dim);
+}
+.pb-banner-live {
+  color: var(--lcd-px);
+  background: color-mix(in srgb, var(--lcd-px) 8%, transparent);
+}
+.pb-banner-busy {
+  color: var(--legend);
+  font-style: italic;
+}
+.pb-banner-msg b {
+  color: var(--legend);
+}
+.pb-banner-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  white-space: nowrap;
+}
+.pb-banner-note {
+  color: var(--legend-dim);
+  font-style: italic;
+}
+.pb-body {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  min-height: 0;
+}
+.pb-unsynced {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+  text-align: center;
+  color: var(--legend-dim);
+}
+.pb-banks {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  overflow-y: auto;
+  border-right: 1px solid var(--panel-line);
+  background: color-mix(in srgb, var(--btn-edge) 30%, var(--btn-cap));
+}
+.pb-bank {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 7px 14px;
+  text-align: left;
+  font-family: var(--legend-font);
+  font-size: 12px;
+  color: var(--legend-dim);
+  background: none;
+  border: none;
+  border-bottom: 1px solid color-mix(in srgb, var(--panel-line) 50%, transparent);
+  cursor: pointer;
+}
+.pb-bank:hover {
+  color: var(--legend);
+  background: color-mix(in srgb, var(--lcd-px) 6%, transparent);
+}
+.pb-bank-sel {
+  color: var(--lcd-px);
+  background: color-mix(in srgb, var(--lcd-px) 12%, transparent);
+}
+.pb-bank-livetag {
+  font-size: 9px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  padding: 1px 5px;
+  border-radius: 2px;
+  color: var(--lcd-bg);
+  background: var(--lcd-px-dim);
+}
+.pb-programs {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  overflow-y: auto;
+}
+.pb-prog {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 16px;
+  border-bottom: 1px solid color-mix(in srgb, var(--panel-line) 50%, transparent);
+  font-size: 13px;
+  color: var(--legend);
+}
+.pb-prog:hover {
+  background: color-mix(in srgb, var(--lcd-px) 5%, transparent);
+}
+.pb-prog-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.pb-prog-bank {
+  color: var(--legend-dim);
+}
+.pb-prog-actions {
+  display: flex;
+  gap: 5px;
+  flex-shrink: 0;
+}
+.pb-btn {
+  padding: 3px 9px;
+  font-family: var(--legend-font);
+  font-size: 11px;
+  color: var(--legend);
+  background: linear-gradient(var(--btn-cap-hi), var(--btn-cap));
+  border: 1px solid var(--btn-edge);
+  border-radius: 3px;
+  cursor: pointer;
+}
+.pb-btn:hover:not(:disabled) {
+  color: var(--lcd-px);
+  border-color: var(--lcd-px-dim);
+}
+.pb-btn:disabled {
+  color: var(--legend-dim);
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.pb-preview {
+  color: var(--lcd-px);
+}
+.pb-empty {
+  padding: 24px 16px;
+  text-align: center;
+  color: var(--legend-dim);
+  font-size: 12px;
+}

--- a/tests/library.test.js
+++ b/tests/library.test.js
@@ -284,6 +284,17 @@ describe('loadProgramToDsp / preview slot targeting (#135)', () => {
     await loadProgramToDsp({ bankIdx: '0', programIdx: '1', programName: '1 X' }, 'A');
     expect(sendValueDump).toHaveBeenCalledWith('10020011');
   });
+
+  test('a load ignored mid-sync STILL fires onDone (review B1: no stuck UI lock)', async () => {
+    // Hold syncing=true: a sync with no bank list polls until it gives up.
+    getNode.mockReturnValue(undefined);
+    const syncPromise = syncLibrary(); // sets syncing=true synchronously
+    const done = jest.fn();
+    await loadProgramToDsp({ bankIdx: '5', programIdx: '0', programName: '0 X' }, 'A', done);
+    expect(done).toHaveBeenCalled(); // the lock-holder unlocks...
+    expect(sendValuePut).not.toHaveBeenCalledWith('1002001c', '1'); // ...but no load happened
+    await syncPromise;
+  });
 });
 
 describe('getRememberedProgram (preview restore, #135)', () => {

--- a/tests/library.test.js
+++ b/tests/library.test.js
@@ -24,7 +24,13 @@ jest.mock('../src/constants.js', () => {
   return {
     ...actual,
     // Millisecond-scale waits so the serialized scan runs in test time.
-    LIBRARY: { ...actual.LIBRARY, BANK_SETTLE_MS: 1, BANK_DUMP_TIMEOUT_MS: 50, LOAD_SETTLE_MS: 1 },
+    LIBRARY: {
+      ...actual.LIBRARY,
+      BANK_SETTLE_MS: 1,
+      BANK_DUMP_TIMEOUT_MS: 50,
+      LOAD_SETTLE_MS: 1,
+      FAVORITES_REFRESH_MS: 1,
+    },
   };
 });
 
@@ -35,12 +41,17 @@ import {
   syncLibrary,
   loadSearchHit,
   loadProgram,
+  loadProgramToDsp,
+  getRememberedProgram,
+  resetLibraryLoadMemory,
+  isFavoritesBank,
+  refreshFavoritesBank,
   libraryBankOptions,
   libraryProgramsForBank,
   canSearch,
   libraryProgramCount,
 } from '../src/library.js';
-import { sendValuePut, sendObjectInfoDump } from '../src/midi.js';
+import { sendValuePut, sendObjectInfoDump, sendValueDump } from '../src/midi.js';
 import { getNode, bankProgramsFor } from '../src/tree.js';
 import { appState } from '../src/state.js';
 
@@ -247,5 +258,82 @@ describe('loadProgram / loadSearchHit', () => {
       '10020011:12',
       '1002001c:1',
     ]);
+  });
+});
+
+describe('loadProgramToDsp / preview slot targeting (#135)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetLibraryLoadMemory();
+  });
+
+  test('targets the CHOSEN slot regardless of the active DSP', async () => {
+    appState.presetKey = '401000b'; // DSP A is active...
+    await loadProgramToDsp({ bankIdx: '5', programIdx: '0', programName: '0 Mono Delay' }, 'B');
+    // ...but the explicit slot B trigger fires, and B's name updates.
+    expect(appState.dspBName).toBe('Mono Delay');
+    expect(sendValuePut.mock.calls.map((c) => c.join(':'))).toEqual([
+      '10020012:5',
+      '10020011:0',
+      '1002001d:1', // LOAD_TRIGGER_B, not A
+    ]);
+  });
+
+  test('the program readback fires before the trigger (clamp-catch)', async () => {
+    appState.presetKey = '401000b';
+    await loadProgramToDsp({ bankIdx: '0', programIdx: '1', programName: '1 X' }, 'A');
+    expect(sendValueDump).toHaveBeenCalledWith('10020011');
+  });
+});
+
+describe('getRememberedProgram (preview restore, #135)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetLibraryLoadMemory();
+    setLibrary(sampleLibrary);
+  });
+
+  test('after an app load, returns the EXACT indices that slot now holds', async () => {
+    await loadProgramToDsp({ bankIdx: '50', programIdx: '12', programName: '12 Black Hole' }, 'A');
+    expect(getRememberedProgram('A')).toEqual({
+      bankIdx: '50',
+      programIdx: '12',
+      programName: '12 Black Hole',
+    });
+    expect(getRememberedProgram('B')).toBeNull(); // nothing loaded into B
+  });
+
+  test('cold start falls back to the running name resolved against the library', () => {
+    appState.dspAName = 'Techno Rumble'; // running, never loaded by the app
+    // Index-based, not the colliding "Black Hole" — exact program in bank 0.
+    expect(getRememberedProgram('A')).toEqual({
+      bankIdx: '0',
+      programIdx: '0',
+      programName: '0 Techno Rumble',
+    });
+  });
+
+  test('null when the slot was never app-loaded and the running name is unknown', () => {
+    appState.dspBName = 'Nonexistent Patch';
+    expect(getRememberedProgram('B')).toBeNull();
+  });
+});
+
+describe('Favorites bank is live (#138/#135 follow-up)', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('isFavoritesBank only matches bank 0', () => {
+    expect(isFavoritesBank(0)).toBe(true);
+    expect(isFavoritesBank('0')).toBe(true);
+    expect(isFavoritesBank(50)).toBe(false);
+  });
+
+  test('refreshFavoritesBank selects bank 0 and re-dumps the load menu', async () => {
+    const done = jest.fn();
+    await refreshFavoritesBank(done);
+    expect(sendValuePut).toHaveBeenCalledWith('10020012', '0'); // select bank 0
+    expect(sendObjectInfoDump).toHaveBeenCalledWith('10020010'); // re-fetch live
+    expect(sendValueDump).toHaveBeenCalledWith('10020010');
+    expect(done).toHaveBeenCalled();
   });
 });

--- a/tests/preset-browser.test.js
+++ b/tests/preset-browser.test.js
@@ -1,0 +1,209 @@
+// tests/preset-browser.test.js
+// The preset browser (#153) + preview (#135): render (browse/search/empty),
+// the remember-and-restore preview safety, no-auto-preview, the live
+// Favorites re-fetch, and reset. Device I/O is mocked at the library.js
+// boundary — this pins the panel's sequencing, not the wire.
+
+const mockLoadProgramToDsp = jest.fn((target, slot, onDone) => {
+  onDone?.();
+  return Promise.resolve();
+});
+const mockRefreshFavoritesBank = jest.fn((onDone) => {
+  onDone?.();
+  return Promise.resolve();
+});
+const mockGetRememberedProgram = jest.fn();
+let mockLibrary = null;
+let mockCanSearch = true;
+let mockHits = [];
+
+jest.mock('../src/library.js', () => ({
+  getLibrary: () => mockLibrary,
+  searchLibrary: () => mockHits,
+  canSearch: () => mockCanSearch,
+  libraryProgramCount: () => (mockLibrary ? 99 : 0),
+  loadProgramToDsp: (...a) => mockLoadProgramToDsp(...a),
+  getRememberedProgram: (...a) => mockGetRememberedProgram(...a),
+  isFavoritesBank: (idx) => parseInt(idx, 10) === 0,
+  refreshFavoritesBank: (...a) => mockRefreshFavoritesBank(...a),
+}));
+
+jest.mock('../src/logger.js', () => ({ log: jest.fn() }));
+
+import {
+  setupPresetBrowser,
+  openPresetBrowser,
+  resetPresetBrowser,
+  renderBrowser,
+} from '../src/preset-browser.js';
+import { appState } from '../src/state.js';
+
+const sampleLibrary = {
+  syncedAt: 'test',
+  banks: [
+    {
+      idx: '0',
+      name: '0 Favorites',
+      programs: [{ idx: '0', name: '0 Recently Used' }],
+    },
+    {
+      idx: '5',
+      name: '5 Delays',
+      programs: [
+        { idx: '0', name: '0 Mono Delay' },
+        { idx: '1', name: '1 PingPong' },
+      ],
+    },
+  ],
+};
+
+const q = (sel) => document.querySelector(sel);
+const qa = (sel) => [...document.querySelectorAll(sel)];
+const rowByName = (name) =>
+  qa('.pb-prog').find((li) => li.querySelector('.pb-prog-name').textContent.includes(name));
+
+describe('preset-browser', () => {
+  let onLoadComplete;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML = '';
+    resetPresetBrowser();
+    mockLibrary = sampleLibrary;
+    mockCanSearch = true;
+    mockHits = [];
+    appState.presetKey = '401000b'; // DSP A active -> preview auditions on B
+    appState.dspAName = '';
+    appState.dspBName = '';
+    onLoadComplete = jest.fn();
+    setupPresetBrowser({ onLoadComplete });
+  });
+
+  test('renders bank list + programs, defaulting to the first STATIC bank', () => {
+    openPresetBrowser();
+    // Both banks listed; Favorites flagged live.
+    expect(qa('.pb-bank').map((b) => b.textContent.replace('live', '').trim())).toEqual([
+      '0 Favorites',
+      '5 Delays',
+    ]);
+    expect(q('.pb-bank-live')).toBeTruthy();
+    // Default selection skipped Favorites (the live bank) -> bank 5's programs.
+    expect(qa('.pb-prog-name').map((n) => n.textContent)).toEqual(['0 Mono Delay', '1 PingPong']);
+  });
+
+  test('unsynced shows a sync prompt, no panes', () => {
+    mockLibrary = null;
+    openPresetBrowser();
+    expect(q('.pb-unsynced')).toBeTruthy();
+    expect(q('.pb-banks')).toBeNull();
+  });
+
+  test('search filters to hits across banks; gated when the corpus is small', () => {
+    openPresetBrowser();
+    mockHits = [{ bankIdx: '5', bankName: '5 Delays', programIdx: '1', programName: '1 PingPong' }];
+    const search = q('.pb-search');
+    search.value = 'ping';
+    search.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(qa('.pb-prog-name').map((n) => n.textContent)).toEqual(['5 Delays › 1 PingPong']);
+
+    // Below the search threshold: a sync-first note, no rows.
+    mockCanSearch = false;
+    search.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(q('.pb-empty').textContent).toMatch(/sync the library first/i);
+  });
+
+  test('selecting a bank or program never loads (no auto-preview)', () => {
+    openPresetBrowser();
+    q('.pb-bank').click(); // select Favorites
+    expect(mockLoadProgramToDsp).not.toHaveBeenCalled();
+  });
+
+  test('Preview captures the restore point, then auditions on the idle DSP (B)', () => {
+    mockGetRememberedProgram.mockReturnValue({
+      bankIdx: '5',
+      programIdx: '0',
+      programName: '0 Mono Delay',
+    });
+    openPresetBrowser();
+    rowByName('1 PingPong').querySelector('.pb-preview').click();
+
+    // Restore captured for the idle slot (B) BEFORE the load.
+    expect(mockGetRememberedProgram).toHaveBeenCalledWith('B');
+    // Loaded onto B (the non-active engine).
+    expect(mockLoadProgramToDsp).toHaveBeenCalledWith(
+      expect.objectContaining({ programIdx: '1', programName: '1 PingPong' }),
+      'B',
+      expect.any(Function)
+    );
+    // Banner reflects the live preview with Keep + Cancel.
+    expect(q('.pb-banner-live').textContent).toMatch(/Previewing.*1 PingPong.*DSP B/);
+    expect(q('.pb-keep')).toBeTruthy();
+    expect(q('.pb-cancel')).toBeTruthy();
+  });
+
+  test('Cancel restores the remembered program into the same slot', () => {
+    const restore = { bankIdx: '5', programIdx: '0', programName: '0 Mono Delay' };
+    mockGetRememberedProgram.mockReturnValue(restore);
+    openPresetBrowser();
+    rowByName('1 PingPong').querySelector('.pb-preview').click();
+    mockLoadProgramToDsp.mockClear();
+
+    q('.pb-cancel').click();
+    expect(mockLoadProgramToDsp).toHaveBeenCalledWith(restore, 'B', expect.any(Function));
+    // Banner cleared back to idle.
+    expect(q('.pb-banner-live')).toBeNull();
+  });
+
+  test('Keep leaves the preview in place — no further device load', () => {
+    mockGetRememberedProgram.mockReturnValue({ bankIdx: '5', programIdx: '0', programName: '0 X' });
+    openPresetBrowser();
+    rowByName('1 PingPong').querySelector('.pb-preview').click();
+    mockLoadProgramToDsp.mockClear();
+
+    q('.pb-keep').click();
+    expect(mockLoadProgramToDsp).not.toHaveBeenCalled();
+    expect(q('.pb-banner-live')).toBeNull();
+  });
+
+  test('with no restore point, Cancel is replaced by a note', () => {
+    mockGetRememberedProgram.mockReturnValue(null);
+    openPresetBrowser();
+    rowByName('1 PingPong').querySelector('.pb-preview').click();
+    expect(q('.pb-cancel')).toBeNull();
+    expect(q('.pb-banner-note').textContent).toMatch(/no saved state for DSP B/i);
+  });
+
+  test('selecting the live Favorites bank re-fetches it from the device', () => {
+    openPresetBrowser();
+    q('.pb-bank-live').click();
+    expect(mockRefreshFavoritesBank).toHaveBeenCalled();
+  });
+
+  test('load-to-A / load-to-B target the explicit slot', () => {
+    openPresetBrowser();
+    rowByName('0 Mono Delay').querySelector('.pb-load-b').click();
+    expect(mockLoadProgramToDsp).toHaveBeenCalledWith(
+      expect.objectContaining({ programIdx: '0' }),
+      'B',
+      expect.any(Function)
+    );
+  });
+
+  test('resetPresetBrowser hides the panel and clears preview state', () => {
+    mockGetRememberedProgram.mockReturnValue({ bankIdx: '5', programIdx: '0', programName: '0 X' });
+    openPresetBrowser();
+    rowByName('1 PingPong').querySelector('.pb-preview').click();
+    expect(q('.pb-banner-live')).toBeTruthy();
+
+    resetPresetBrowser();
+    expect(q('.preset-browser')).toBeNull(); // removed, not just hidden
+    // Reopening shows no stale preview banner.
+    openPresetBrowser();
+    expect(q('.pb-banner-live')).toBeNull();
+  });
+
+  test('renderBrowser is a no-op while the panel is closed', () => {
+    renderBrowser(); // never opened
+    expect(q('.preset-browser')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #153
Closes #135

## What

A **preset browser** with **program preview**, built on the #138 preset-loader foundation, plus a fix for the **live Favorites** staleness.

### Preset browser (#153)
A new top-level modal (`src/preset-browser.js`, themed via the token engine, modeled on the sync dialog) over the synced library: a bank list, the selected bank's programs, and a name search that reuses the existing `searchLibrary`/`canSearch` corpus. Each program offers **Preview**, **→A**, **→B**. Opened from a new **Browse** button in the connection strip.

### Program preview (#135)
Remember-and-restore. The Orville runs *both* DSP engines at once, so there is no idle engine — auditioning a program necessarily overwrites whatever sits in the slot. Preview captures the slot's **exact** current program (indices, since names repeat across banks) *before* loading the audition onto the **non-active** engine, then offers **Keep** (leave it) or **Cancel** (reload the remembered program). It is explicit-only (no auto-preview — every load is the device's ~2s DSP rebuild) and the controls lock while a load is in flight. The banner makes the destructive reality legible ("Keep replaces DSP B").

- `library.js`: `loadProgramToDsp(target, dspSlot, onDone)` generalizes `loadProgram` (slot-chosen trigger + optimistic name by slot); `loadProgram` is now a thin active-slot caller. `lastLoadedBySlot` + `getRememberedProgram` give the exact restore token (best-effort running-name fallback).

### Live Favorites (maintainer report: "favorites gets out of sync since that's a live menu")
Bank 0 is the device's auto-generated MRU, which **reorders on every load** — so its static library snapshot is always stale. `isFavoritesBank` + `refreshFavoritesBank` re-read it live whenever it's viewed (the load-menu bank-0 select **and** the browser's bank-0 select), while the 70 static banks keep the race-free library path. This is the one deliberate exception to #138's no-traffic-on-pick rule.

## Tests & review

**254/254**, lint clean. New `tests/preset-browser.test.js` (render, search, empty, preview remember/restore, Keep, no-auto-preview, live Favorites, reset) plus `library.js` coverage for the slot/restore/Favorites helpers.

Reviewed by correctness + docs agents. Fixes applied: a **blocker** — `loadProgramToDsp` now fires `onDone` on its sync-guard early-return so a browser load during a sync can't stick the control lock (regression-tested); and the CLAUDE.md architecture list now documents the new modules.

## Hardware gate

`logs/probe-preview-135.mjs` (preview round-trip) is written and ready, but the single-client WinMM port was held by the running app tab this session — run it with the tab closed to confirm the restore round-trip on hardware. The device-facing load mechanics are already hardware-proven via `probe-loadmenu` (same `loadProgramToDsp` path, explicit slot).
