### PR TITLE
feat: device-native MIDI mapping (#146, #152)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,8 @@ index.html
       ├─ sync-dialog.js     library-sync progress overlay drawn on the LCD (defrag-style bank map)
       ├─ preset-loader.js   DOM-free single source of truth for the load-menu dropdowns: local staging backed by the library (#138)
       ├─ preset-browser.js  top-level modal: browse/search the library, preview a program on the idle DSP (remember-and-restore), load to A/B (#153/#135)
+      ├─ midi-map.js        DOM-free device-native modulation engine: assign controllers, per-param source/range/type, bindParam (#146)
+      ├─ midi-map-ui.js     MIDI controllers panel + per-parameter mapping card modals (#146)
       ├─ navigation.js      toggleDspKey
       ├─ tree.js            persistent device object tree: recordDump, deriveKeyStack, labels (T1b/#105)
       ├─ eager-loader.js    background preset-subtree structure warm-up, one request in flight (#106)

--- a/docs/design/midi-mapping-146-plan.md
+++ b/docs/design/midi-mapping-146-plan.md
@@ -43,60 +43,67 @@ sources the unit can't use.
 - **Scale equation** (manual p.78): `(max - min) / full-range = scale` — replace
   the manual's trial-and-error with a calculator.
 
-## The two-layer model (Phase 0 spike — RESOLVED)
+## RESOLVED: fully object-addressable, no keypress automation
 
-The Orville's mapping is **two layers**, and the spike settled how each is
-configured:
+The whole modulation system is configured with the app's existing
+`OBJECTINFO` / `VALUE_PUT` machinery. (An earlier draft of this plan wrongly
+concluded the per-parameter page was not addressable — that was a key-guessing
+failure: the objects live in the `1003…` "remote control" region, **not**
+derivable from the parameter's `405…` key.)
 
-1. **Global assign controllers** (`10010100`) — the 8 reusable MIDI sources.
-   **Fully OBJECTINFO-addressable**: I dumped and edited their objects, and the
-   `Capture Midi` TRG (`…115`) learns a CC end-to-end over emulated MIDI. The
-   app configures these **directly by object** (fire Capture + emit/await a CC,
-   set channel via the `channel` SET).
-2. **Per-parameter modulation page** (SELECT-hold) — picks which assign drives
-   *this* parameter, plus `range` / `type`. **NOT cleanly object-addressable.**
+**The "remote control" menu** (`10030400`, manual: "Remote Controlling
+Parameters") holds a per-parameter **setup page** — e.g. `level setup` at
+`10030401` — whose fields are ordinary addressable objects:
 
-Resolution evidence (`logs/probe-midi-146c/d/e.mjs`, `logs/mod-activated.png`):
+| key | obj | meaning |
+|-----|-----|---------|
+| `10030402` | SET `mode` | the source: off / low / high / assign 1-8 / … (set by index) |
+| `10030403/404` | SET | sub-params (channel, controller #) — populate by mode |
+| `10030405` | CON `monitor` | live controller value (%) |
+| `10030406` | TRG `Capture Midi` | one-click learn |
+| `10030408` | NUM `range` (tag `scale`) | modulation depth |
+| `10030409` | SET `type` | absolute / relative (3 opts) |
 
-- `OBJECTINFO` is **context-free**: `OBJECTINFO(4050001)` returns the plain
-  `level` NUM before *and* after SELECT-hold — the page is not at the param key.
-- Every guessed mirror key (the hidden `14030400` under the preset; `1`-prefixed
-  and low-digit param keys) returns **type-8 EMPTY** — and the device returns
-  type-8 for *any* unallocated key, so a scan yields **no discovery signal**.
-- Activating a real mapping confirmed the model but populated **no** candidate
-  key: `parameter -> SELECT-hold -> INC` cycled `level`'s `mode`
-  `off -> assign 1 -> assign 2 -> assign 3`, and the level value moved
-  `-9 dB -> 0 dB` (modulation live, driving the parameter) — yet every candidate
-  stayed type-8. So the per-parameter page's key is not derivable/scannable.
+**Direct SysEx writes work with ZERO keypresses** (probe-midi-confirm.mjs):
+`VALUE_PUT(10030402, 3)` flipped the mode `low -> high` over SysEx alone, and the
+parameter value moved in response — verdict *"DIRECTLY ADDRESSABLE."* The 8
+**global assign controllers** (`10010100`) are likewise addressable, with a
+working `Capture Midi` learn.
 
-**Consequence (runtime unaffected):** per-parameter assignment is written by
-**driving the device UI** (position the cursor on the target param, SELECT-hold,
-set `mode = assign N` + `range`/`type`, `*done*`). The app is a configurator
-only; **at runtime the Orville does MIDI -> parameter entirely in its DSP — zero
-app latency, works after the app disconnects.** This is the explicit goal: no app
-middleman in the signal path.
+Two enablers (both from the internet research):
 
-**Needed primitive — a cursor-control layer** in `controls.js`: drive the device
-highlight to a chosen parameter (the dump's `position` field gives in-menu
-ordering), then SELECT-hold. This is the one genuinely new capability (the app
-currently navigates by key, not by driving the physical cursor). Add the `-hold`
-keys to `build_tools/hil-screenshot.cjs` as well.
+- **`sequence out = new`** (key `10010016`, options off/old/new): the unit
+  **emits the key of any field touched** — `F0 1C 70 <dev> 3C <ascii-hex key> 20
+  <ascii value> F7`. This is the discovery mechanism that located `10030402`
+  after blind key-guessing failed. The app can use it to map a parameter's
+  setup-page key by touching it once, or to mirror live changes.
+- **Degenerate `mode` options don't matter** — set the source by *index* via
+  `VALUE_PUT`; the device echoes the real name (`3 high`), so the app can
+  enumerate the index->source map once (PUT 0..N, read echoes).
+
+**Open detail (small):** map how each parameter's setup-page key is reached —
+`10030400` showed one child (`level setup`) for the *current* param, so confirm
+whether every param has a fixed setup key (fully direct) or the param must be
+selected first to populate `10030400` (a single OBJECTINFO navigate, still no
+keypress edit). Use sequence-out to enumerate the keys across a preset's params.
+
+**Runtime is pure device, zero app latency** — the app only writes config; the
+Orville does MIDI -> parameter in its DSP, persisted in the preset.
 
 ## Build phases
 
-0. **Cursor-control layer** in `controls.js`: drive the device highlight to a
-   parameter by its menu `position`, then SELECT-hold to open its modulation
-   page. The one new primitive everything else builds on.
-1. **Global controllers panel** (the addressable layer first — highest value,
-   lowest risk): a panel over the 8 assigns (`10010100`) showing each source +
-   live monitor, with a one-click **Learn** (fire `Capture Midi` TRG + emit/await
-   a CC) and clear. All object-addressable, proven end-to-end.
-2. **Per-parameter mapping** (the keypress-driven layer): a "MIDI Map" badge on
-   every editable NUM/SET that positions the cursor, SELECT-holds, and presents
-   the modulation page. Since the page is not object-addressable, drive its
-   fields by keypress (set `mode = assign N`, `range`, `type`) and mirror the
-   captured screen bitmap (we already decode/render it) for confirmation.
-   Read-back of the chosen assign closes the loop visually.
+0. **Map the remote-control region** (`10030400`): enumerate the per-parameter
+   setup-page keys for a preset (via sequence-out + OBJECTINFO walk) and the
+   `mode` index->source table. Record in `device-model.md`. No new control
+   primitive needed — it is all object access.
+1. **Global controllers panel** — a panel over the 8 assigns (`10010100`):
+   each source + live monitor, one-click **Learn** (fire `Capture Midi` +
+   emit/await a CC), clear. All object-addressable, proven end-to-end.
+2. **Per-parameter mapping** — a "MIDI Map" badge on every editable NUM/SET that
+   opens that parameter's setup page (`10030401`-style) as a focused card,
+   rendered from objects and edited by `VALUE_PUT`: pick `mode` (assign/source),
+   set `range`/`type`, fire `Capture Midi`. The live `monitor` CON shows it
+   working. No keypress automation.
 3. **Scale calculator** — user types desired min/max parameter range -> apply
    the manual's equation -> write `scale`.
 4. **Mappings overview** — list every mapped parameter (`mode != off`), with
@@ -114,18 +121,18 @@ modulation page). Unit tests mock the SysEx boundary like the rest of the suite.
 
 ## Risks
 
-- **Cursor-drive correctness** — per-parameter config is keypress-driven, so the
-  app must reliably land the device cursor on the intended parameter before
-  SELECT-hold. Mitigated by the dump `position` field for ordering + a
-  screen-capture read-back after each step to confirm the right page/field.
-  Keypress sequences proved reliable in the `hil-screenshot` captures.
-- **Source enumeration** — the `mode` SET options are degenerate placeholders;
-  set the source via Capture (proven), not a 127-entry CC dropdown. The
-  per-parameter `mode` enumerates the 8 assigns (off / assign 1-8) — a clean,
-  short list.
-- **Leaving the device modified** — driving config changes device state; the app
-  must read-back and let the user confirm/undo, and never leave a half-written
-  mapping.
+- **Per-parameter setup-key reachability** (the one open detail above) — confirm
+  every parameter's setup page has a directly addressable key vs. needing a
+  one-time OBJECTINFO navigate to populate `10030400`. Either way it is object
+  access, not keypress automation; resolved by a short sequence-out enumeration
+  in Phase 0.
+- **Source enumeration** — the `mode` SET options are degenerate placeholders, so
+  set by index and read the echo for the real name; enumerate the index->source
+  table once. (Not a 127-entry dropdown.)
+- **Leaving the device modified** — writes change preset state; the app should
+  read-back, let the user confirm/undo, and never leave a half-written mapping.
+  Note: enabling `sequence out = new` is itself a device setting the app turns
+  on (and should restore) when it wants live-change mirroring.
 
 ## Out of scope
 

--- a/docs/design/midi-mapping-146-plan.md
+++ b/docs/design/midi-mapping-146-plan.md
@@ -1,0 +1,113 @@
+# MIDI Mapping (#146) — Implementation Plan
+
+Device-native MIDI mapping: an app UI over the Orville's own modulation system,
+so mappings live in the preset and keep working after the app disconnects.
+Grounded in live hardware probing (June 2026; harnesses in `logs/probe-midi-146*.mjs`,
+screenshots `logs/mod-before.png` / `logs/mod-after.png`).
+
+## Architecture decision: device-native
+
+The Orville already maps any MIDI source to any parameter, stored in the preset.
+A browser-side `CC -> VALUE_PUT` bridge would only work while the tab is open and
+would duplicate hardware capability. So the feature is a modern UI over the
+native system, with an optional app-layer bridge later for app-only actions /
+sources the unit can't use.
+
+## Confirmed live (hardware)
+
+- **Per-parameter modulation page.** Holding **SELECT** on a highlighted
+  parameter opens its modulation page — screenshotted as `level setup` with:
+  `mode` (source SET), `Capture Midi` (learn TRG), `range` (depth NUM),
+  `type: absolute` (SET), the live parameter value, and a controller monitor
+  bar. `select-hold` mask already exists in `controls.js`
+  (`[0xff,0xff,0xfe,0xfe]`).
+- **Global external controllers** (`10010100`): 8 `assign` slots + 2 `trig`
+  slots, each fully OBJECTINFO-addressable with children `mode` / `channel` /
+  two sub-params / `monitor` CON / `Capture Midi` TRG. Keys: assign 1 =
+  `10010110` (mode `…111`, channel `…112`, sub `…113`, monitor `…114`,
+  capture `…115`); assigns 2-8 at `…120/130/140/170/180/190/1a0`.
+- **Capture-learn works over emulated MIDI.** Armed `Capture Midi` on assign 1,
+  sent CC#7 -> the device captured it as `mode='1e volume'`, revealed a
+  `channel: base+N` sub-param (17 options base+0..base+15), and the monitor
+  tracked the live value (62.5% for value 0x50). The mode SET's 52 "options"
+  are degenerate placeholders (all `off`, then all the captured name) — the
+  source is set by **Capture**, not by picking from a list.
+- **Inbound MIDI works.** CC#0=5 changed the bank to `5 Delays`; Program Change
+  #2 loaded slot 2 into DSP A (`MonoDelay` -> `1x4 Delay`). This also delivers
+  **#152** (Program-Change loads).
+- **The app can emit raw CC / PC** from its output port — a "test this mapping"
+  button and an app-driven learn sweep need no physical hardware.
+- **MIDI configuration** (`10010010`): `global configure` (`1001001c`),
+  `MIDI setup` (`1001001b`, channels/omni), `serial setup` (`10010070`),
+  `MIDI group setup` (`10010076`).
+- **Scale equation** (manual p.78): `(max - min) / full-range = scale` — replace
+  the manual's trial-and-error with a calculator.
+
+## The decisive open question (Phase 0 spike)
+
+`OBJECTINFO` stays **context-free**: `OBJECTINFO(4050001)` returned the plain
+`level` NUM both before and after SELECT-hold. The modulation page is therefore
+**not** at the param key. Guessed mirror keys — the hidden type-8 node
+`14030400` under the preset, and `1`-prefixed param keys (`14050001`, …) — all
+returned **type-8 EMPTY placeholders** (`8 0 <key> … '' ''`). All params are
+currently `mode: off`, so those slots may simply be empty until a mapping is
+active.
+
+**Spike to resolve (first implementation step):** activate a mapping on one
+parameter (drive cursor onto it, SELECT-hold, fire `Capture Midi`, emit a CC),
+then re-scan the candidate keys.
+
+- If a `<param> setup` COL **materializes** at a discoverable key -> **render
+  the page as ordinary objects** (the clean path; the rest of this plan).
+- If nothing materializes -> the page is a **transient UI overlay**, and the
+  feature becomes a **remote-control** model: drive the device cursor by
+  keypress and mirror its screen bitmap (we already capture + render the
+  bitmap). More limited, more fragile — fall back only if forced.
+
+Either way the app needs a small **cursor-control layer** (cursor up/down/
+left/right + the `-hold` keys) to drive SELECT-hold onto a chosen parameter,
+since SELECT-hold is cursor-position dependent. (Add the `-hold` keys to
+`build_tools/hil-screenshot.cjs` too — they were used for the screenshots and
+are generally useful.)
+
+## Build phases
+
+0. **Addressing spike** (above) + the cursor-control layer in `controls.js`
+   (drive the device highlight to a parameter by position; the dump's
+   `position` field gives ordering).
+1. **Modulation card** — a "MIDI Map" badge on every editable NUM/SET; clicking
+   it positions the cursor, SELECT-holds, and opens the modulation page as a
+   focused card (render-as-objects path) — `mode` / `channel` / `con` /
+   `range` / `type` / live monitor, all existing renderers.
+2. **One-click Learn** — a button that fires the on-screen `Capture Midi` TRG,
+   then waits for the user's controller OR emits an app CC sweep, and shows the
+   captured source. (Proven end-to-end on the global assigns.)
+3. **Scale calculator** — user types desired min/max parameter range -> apply
+   the manual's equation -> write `scale`.
+4. **Mappings overview** — list every mapped parameter (`mode != off`), with
+   quick clear/edit; optionally surface the 8 global assigns as a "controllers"
+   panel.
+5. **(bonus, nearly free) #152** — a Program-Change / CC sender, since inbound
+   MIDI is proven.
+
+## Testing
+
+Every layer is emulatable without hardware: the app emits CC / Program-Change
+from its output port, drives Capture, and reads back the captured mode/monitor.
+`hil-screenshot.cjs` gives device-side visual regression (used to confirm the
+modulation page). Unit tests mock the SysEx boundary like the rest of the suite.
+
+## Risks
+
+- **Page addressability** (the Phase 0 spike) — the whole "render-as-objects"
+  shape depends on it; the remote-control fallback exists but is weaker.
+- **Cursor-drive fragility** — SELECT-hold is position-dependent; mitigated by
+  the dump `position` field + screen-capture verification.
+- **Source enumeration** — the `mode` SET options are degenerate; set the source
+  via Capture (proven) or by index once the index->source map is derived. Do not
+  build a 127-entry CC dropdown.
+
+## Out of scope
+
+The modular **Patch Editor** (separate Programmer's Manual) — enormous surface,
+a separate initiative if ever. Relay/serial/Orville-to-Orville control — niche.

--- a/docs/design/midi-mapping-146-plan.md
+++ b/docs/design/midi-mapping-146-plan.md
@@ -43,45 +43,60 @@ sources the unit can't use.
 - **Scale equation** (manual p.78): `(max - min) / full-range = scale` — replace
   the manual's trial-and-error with a calculator.
 
-## The decisive open question (Phase 0 spike)
+## The two-layer model (Phase 0 spike — RESOLVED)
 
-`OBJECTINFO` stays **context-free**: `OBJECTINFO(4050001)` returned the plain
-`level` NUM both before and after SELECT-hold. The modulation page is therefore
-**not** at the param key. Guessed mirror keys — the hidden type-8 node
-`14030400` under the preset, and `1`-prefixed param keys (`14050001`, …) — all
-returned **type-8 EMPTY placeholders** (`8 0 <key> … '' ''`). All params are
-currently `mode: off`, so those slots may simply be empty until a mapping is
-active.
+The Orville's mapping is **two layers**, and the spike settled how each is
+configured:
 
-**Spike to resolve (first implementation step):** activate a mapping on one
-parameter (drive cursor onto it, SELECT-hold, fire `Capture Midi`, emit a CC),
-then re-scan the candidate keys.
+1. **Global assign controllers** (`10010100`) — the 8 reusable MIDI sources.
+   **Fully OBJECTINFO-addressable**: I dumped and edited their objects, and the
+   `Capture Midi` TRG (`…115`) learns a CC end-to-end over emulated MIDI. The
+   app configures these **directly by object** (fire Capture + emit/await a CC,
+   set channel via the `channel` SET).
+2. **Per-parameter modulation page** (SELECT-hold) — picks which assign drives
+   *this* parameter, plus `range` / `type`. **NOT cleanly object-addressable.**
 
-- If a `<param> setup` COL **materializes** at a discoverable key -> **render
-  the page as ordinary objects** (the clean path; the rest of this plan).
-- If nothing materializes -> the page is a **transient UI overlay**, and the
-  feature becomes a **remote-control** model: drive the device cursor by
-  keypress and mirror its screen bitmap (we already capture + render the
-  bitmap). More limited, more fragile — fall back only if forced.
+Resolution evidence (`logs/probe-midi-146c/d/e.mjs`, `logs/mod-activated.png`):
 
-Either way the app needs a small **cursor-control layer** (cursor up/down/
-left/right + the `-hold` keys) to drive SELECT-hold onto a chosen parameter,
-since SELECT-hold is cursor-position dependent. (Add the `-hold` keys to
-`build_tools/hil-screenshot.cjs` too — they were used for the screenshots and
-are generally useful.)
+- `OBJECTINFO` is **context-free**: `OBJECTINFO(4050001)` returns the plain
+  `level` NUM before *and* after SELECT-hold — the page is not at the param key.
+- Every guessed mirror key (the hidden `14030400` under the preset; `1`-prefixed
+  and low-digit param keys) returns **type-8 EMPTY** — and the device returns
+  type-8 for *any* unallocated key, so a scan yields **no discovery signal**.
+- Activating a real mapping confirmed the model but populated **no** candidate
+  key: `parameter -> SELECT-hold -> INC` cycled `level`'s `mode`
+  `off -> assign 1 -> assign 2 -> assign 3`, and the level value moved
+  `-9 dB -> 0 dB` (modulation live, driving the parameter) — yet every candidate
+  stayed type-8. So the per-parameter page's key is not derivable/scannable.
+
+**Consequence (runtime unaffected):** per-parameter assignment is written by
+**driving the device UI** (position the cursor on the target param, SELECT-hold,
+set `mode = assign N` + `range`/`type`, `*done*`). The app is a configurator
+only; **at runtime the Orville does MIDI -> parameter entirely in its DSP — zero
+app latency, works after the app disconnects.** This is the explicit goal: no app
+middleman in the signal path.
+
+**Needed primitive — a cursor-control layer** in `controls.js`: drive the device
+highlight to a chosen parameter (the dump's `position` field gives in-menu
+ordering), then SELECT-hold. This is the one genuinely new capability (the app
+currently navigates by key, not by driving the physical cursor). Add the `-hold`
+keys to `build_tools/hil-screenshot.cjs` as well.
 
 ## Build phases
 
-0. **Addressing spike** (above) + the cursor-control layer in `controls.js`
-   (drive the device highlight to a parameter by position; the dump's
-   `position` field gives ordering).
-1. **Modulation card** — a "MIDI Map" badge on every editable NUM/SET; clicking
-   it positions the cursor, SELECT-holds, and opens the modulation page as a
-   focused card (render-as-objects path) — `mode` / `channel` / `con` /
-   `range` / `type` / live monitor, all existing renderers.
-2. **One-click Learn** — a button that fires the on-screen `Capture Midi` TRG,
-   then waits for the user's controller OR emits an app CC sweep, and shows the
-   captured source. (Proven end-to-end on the global assigns.)
+0. **Cursor-control layer** in `controls.js`: drive the device highlight to a
+   parameter by its menu `position`, then SELECT-hold to open its modulation
+   page. The one new primitive everything else builds on.
+1. **Global controllers panel** (the addressable layer first — highest value,
+   lowest risk): a panel over the 8 assigns (`10010100`) showing each source +
+   live monitor, with a one-click **Learn** (fire `Capture Midi` TRG + emit/await
+   a CC) and clear. All object-addressable, proven end-to-end.
+2. **Per-parameter mapping** (the keypress-driven layer): a "MIDI Map" badge on
+   every editable NUM/SET that positions the cursor, SELECT-holds, and presents
+   the modulation page. Since the page is not object-addressable, drive its
+   fields by keypress (set `mode = assign N`, `range`, `type`) and mirror the
+   captured screen bitmap (we already decode/render it) for confirmation.
+   Read-back of the chosen assign closes the loop visually.
 3. **Scale calculator** — user types desired min/max parameter range -> apply
    the manual's equation -> write `scale`.
 4. **Mappings overview** — list every mapped parameter (`mode != off`), with
@@ -99,13 +114,18 @@ modulation page). Unit tests mock the SysEx boundary like the rest of the suite.
 
 ## Risks
 
-- **Page addressability** (the Phase 0 spike) — the whole "render-as-objects"
-  shape depends on it; the remote-control fallback exists but is weaker.
-- **Cursor-drive fragility** — SELECT-hold is position-dependent; mitigated by
-  the dump `position` field + screen-capture verification.
-- **Source enumeration** — the `mode` SET options are degenerate; set the source
-  via Capture (proven) or by index once the index->source map is derived. Do not
-  build a 127-entry CC dropdown.
+- **Cursor-drive correctness** — per-parameter config is keypress-driven, so the
+  app must reliably land the device cursor on the intended parameter before
+  SELECT-hold. Mitigated by the dump `position` field for ordering + a
+  screen-capture read-back after each step to confirm the right page/field.
+  Keypress sequences proved reliable in the `hil-screenshot` captures.
+- **Source enumeration** — the `mode` SET options are degenerate placeholders;
+  set the source via Capture (proven), not a 127-entry CC dropdown. The
+  per-parameter `mode` enumerates the 8 assigns (off / assign 1-8) — a clean,
+  short list.
+- **Leaving the device modified** — driving config changes device state; the app
+  must read-back and let the user confirm/undo, and never leave a half-written
+  mapping.
 
 ## Out of scope
 

--- a/docs/design/midi-mapping-146-plan.md
+++ b/docs/design/midi-mapping-146-plan.md
@@ -81,11 +81,15 @@ Two enablers (both from the internet research):
   `VALUE_PUT`; the device echoes the real name (`3 high`), so the app can
   enumerate the index->source map once (PUT 0..N, read echoes).
 
-**Open detail (small):** map how each parameter's setup-page key is reached —
-`10030400` showed one child (`level setup`) for the *current* param, so confirm
-whether every param has a fixed setup key (fully direct) or the param must be
-selected first to populate `10030400` (a single OBJECTINFO navigate, still no
-keypress edit). Use sequence-out to enumerate the keys across a preset's params.
+**Binding model (RESOLVED, 2026-06-12):** `10030401` is a SINGLE context-bound
+editing surface, not per-param keys (`10030400` has one child). SELECT-hold on a
+parameter binds it — confirmed it rebinds `level setup` -> `t_delay setup` with
+the same field keys. So mapping a parameter is: **bind** (drive the device cursor
+to the param — `program`->`parameter`->`CURSOR-DOWN`×n then SELECT-hold, verified
+by the screen title `<param> setup`) then **configure** by clean `VALUE_PUT` to
+the fixed keys (`10030402` mode, `10030408` range, `10030409` type, `10030406`
+Capture). Bind is one short verified keypress sequence; config is pure object
+writes. Full `mode` index->source table + field keys: `device-model.md` §8b.
 
 **Runtime is pure device, zero app latency** — the app only writes config; the
 Orville does MIDI -> parameter in its DSP, persisted in the preset.

--- a/docs/design/midi-mapping-146-plan.md
+++ b/docs/design/midi-mapping-146-plan.md
@@ -62,7 +62,7 @@ Parameters") holds a per-parameter **setup page** — e.g. `level setup` at
 | `10030405` | CON `monitor` | live controller value (%) |
 | `10030406` | TRG `Capture Midi` | one-click learn |
 | `10030408` | NUM `range` (tag `scale`) | modulation depth |
-| `10030409` | SET `type` | absolute / relative (3 opts) |
+| `10030409` | SET `type` | absolute / unipolar / bipolar (3 opts) |
 
 **Direct SysEx writes work with ZERO keypresses** (probe-midi-confirm.mjs):
 `VALUE_PUT(10030402, 3)` flipped the mode `low -> high` over SysEx alone, and the

--- a/docs/device-model.md
+++ b/docs/device-model.md
@@ -384,6 +384,71 @@ observe), and otherwise tracks it as app-side view state.
 The factory default **device ID is 1** `[D]`; multiple units share a chain via
 distinct ids; id 0 = broadcast (§1).
 
+## 8b. Remote control of parameters (MIDI modulation) `[V]`
+
+Probed live 2026-06-12 (`logs/probe-midi-*.mjs`, screenshots `logs/mod-*.png`).
+The Orville natively maps any source (MIDI CC, pedal, internal) to any parameter;
+mappings live in the preset and run in the DSP. The whole system is reachable as
+ordinary userobjects — no special command, no keypress automation for the config.
+
+**Two layers.**
+
+1. **Global external controllers** (`10010100`, SETUP -> ext controllers): 8
+   reusable `assign` slots + 2 `trig` slots. Each (e.g. assign 1 = `10010110`) has
+   children `mode` (`…111`), `channel` (`…112`), a sub (`…113`), `monitor` CON
+   (`…114`), `Capture Midi` TRG (`…115`). These define named sources used by the
+   per-parameter `assign 1-8` modes.
+
+2. **Per-parameter modulation** — a SINGLE context-bound editing surface under
+   `remote control` (`10030400`), child `10030401` = `<param> setup`. SELECT-hold
+   on a highlighted parameter **binds** the surface to it (confirmed: the same
+   keys read `level setup` then `t_delay setup` after binding each). Fields (fixed
+   keys, regardless of bound param):
+
+   | key | obj | meaning |
+   |-----|-----|---------|
+   | `10030402` | SET `mode` | the source (set by index; see table) |
+   | `10030403` | SET | sub: `channel` (base+0..15) for a MIDI source; the assign's state for an `assign N` mode; empty for off/low/mid/high |
+   | `10030404` | SET | second sub (controller #, for sources that need it) |
+   | `10030405` | CON `monitor` | live source value (%) |
+   | `10030406` | TRG `Capture Midi` | one-click learn |
+   | `10030408` | NUM `range` (tag `scale`) | modulation depth (±32767) |
+   | `10030409` | SET `type` | `absolute` / `unipolar` / `bipolar` |
+   | `50001` | NUM | the bound parameter's value mirror |
+
+**`mode` index -> source** (decimal index via `VALUE_PUT`; device echoes hex idx
++ name; the SET's own option list is DEGENERATE — it repeats the current value, so
+set by index, do not read options):
+
+```
+0 off · 1 low · 2 mid · 3 high · 4-11 assign 1-8 · 12-13 trig 1-2 ·
+14-15 pedal 1-2 · 16-21 tip 1/ring 1/tip&ring 1/tip 2/ring 2/tip&ring 2 ·
+22 mod wheel · 23 breath con · 24 foot con · 25 damper · 26 portamento ·
+27 sostenuto · 28 soft · 29 hold 2 · 30 volume · 31 balance · 32 pan ·
+33 expression · 34-40 general 1-7 · … (52 total; named MIDI CCs continue)
+```
+
+The named MIDI sources are the standard CCs (mod wheel = CC1, breath = CC2,
+foot = CC4, volume = CC7, pan = CC10, expression = CC11, general 1-8 = CC16-23).
+
+**Writing a mapping is clean and deterministic** (`probe-midi-confirm.mjs`):
+`VALUE_PUT(10030402, 3)` over SysEx flipped the mode `low -> high` and the bound
+parameter moved in response — no keypress needed for the config. The one
+UI-driven step is **binding**: drive the device cursor onto the target parameter
+(`program`->`parameter`->`CURSOR-DOWN`×n, masks in `system_commands.txt`) then
+SELECT-hold, verified by the screen title `<param> setup`. After binding, all
+config is `VALUE_PUT` to the fixed keys above.
+
+**`sequence out`** (`10010016`, options off/old/new): set to `new`, the unit
+EMITS the key of any field changed — `F0 1C 70 <dev> 3C <ascii-hex key> 20
+<ascii value> F7`. This is how the `1003…` keys were discovered (they are not
+derivable from the parameter's `4…` key) and is usable for key discovery + live
+mirroring.
+
+**Inbound MIDI** (live-confirmed): a CC#0 sets the bank; a Program Change loads
+that slot from the current bank of the target DSP (`MonoDelay` -> `1x4 Delay` on
+PC #2). The app can also emit CC/PC from its output to drive/test mappings.
+
 ## 9. Behavioral contract & quirks
 
 - **PUTs are echoed** `[V]` (corrected) — a `VALUE_PUT` triggers a `VALUE_DUMP`

--- a/docs/device-model.md
+++ b/docs/device-model.md
@@ -425,9 +425,10 @@ set by index, do not read options):
 14-15 pedal 1-2 · 16-21 tip 1/ring 1/tip&ring 1/tip 2/ring 2/tip&ring 2 ·
 22 mod wheel · 23 breath con · 24 foot con · 25 damper · 26 portamento ·
 27 sostenuto · 28 soft · 29 hold 2 · 30 volume · 31 balance · 32 pan ·
-33 expression · 34-40 general 1-7 · … (indices 0-40 enumerated; the device
-reports 52 sources total — higher indices continue the named MIDI CC set, not
-yet enumerated)
+33 expression · 34-41 general 1-8 · 42 MIDI single · 43 MIDI double (raw CC by
+number — the con sub carries the CC) · 44 chan pressure · 45 pitch wheel ·
+46 note on · 47 note switch · 48 MIDI program · 49 MIDI clock · 50 MIDI start ·
+51 MIDI stop (all 52 enumerated live)
 ```
 
 The named MIDI sources are the standard CCs (mod wheel = CC1, breath = CC2,

--- a/docs/device-model.md
+++ b/docs/device-model.md
@@ -414,7 +414,7 @@ ordinary userobjects — no special command, no keypress automation for the conf
    | `10030406` | TRG `Capture Midi` | one-click learn |
    | `10030408` | NUM `range` (tag `scale`) | modulation depth (±32767) |
    | `10030409` | SET `type` | `absolute` / `unipolar` / `bipolar` |
-   | `50001` | NUM | the bound parameter's value mirror |
+   | `50001` | NUM | the bound parameter's value mirror (observed in the bound `10030401` dump; key is the param's short form) |
 
 **`mode` index -> source** (decimal index via `VALUE_PUT`; device echoes hex idx
 + name; the SET's own option list is DEGENERATE — it repeats the current value, so
@@ -425,7 +425,9 @@ set by index, do not read options):
 14-15 pedal 1-2 · 16-21 tip 1/ring 1/tip&ring 1/tip 2/ring 2/tip&ring 2 ·
 22 mod wheel · 23 breath con · 24 foot con · 25 damper · 26 portamento ·
 27 sostenuto · 28 soft · 29 hold 2 · 30 volume · 31 balance · 32 pan ·
-33 expression · 34-40 general 1-7 · … (52 total; named MIDI CCs continue)
+33 expression · 34-40 general 1-7 · … (indices 0-40 enumerated; the device
+reports 52 sources total — higher indices continue the named MIDI CC set, not
+yet enumerated)
 ```
 
 The named MIDI sources are the standard CCs (mod wheel = CC1, breath = CC2,

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -863,6 +863,30 @@ restored -> idle name back to '10 Delaytaps' (RESTORE-ROUND-TRIP PASS). Reviewed
 fixed one blocker (loadProgramToDsp now fires onDone on its sync-guard early-return so a browser load
 during a sync cannot stick the control lock — regression-tested).
 
+2026-06-12 — MIDI MAPPING, device-native (#146, branch feat/midi-mapping-146 stacked on the browser
+branch, PR open). The flagship: map any MIDI source to any parameter, run IN THE DEVICE DSP (zero app
+latency, persists in the preset; the app is only a configurator). Phase 0 mapped the whole system
+live (device-model.md §8b): the per-parameter modulation surface is fully OBJECTINFO/VALUE-addressable
+under "remote control" (10030400 -> <param> setup 10030401; mode 10030402, range 10030408, type
+10030409, Capture 10030406) — an earlier draft wrongly thought it un-addressable; key discovery via
+`sequence out = new` (10010016) and the internet research (Eventide Programming Manual + userobj.pdf +
+forums) corrected it. The mode index->source table (off/low/mid/high, assign 1-8, trig 1-2, pedals,
+named MIDI CCs) is set by index; the device echoes the name. NEW src/midi-map.js (DOM-free engine:
+assign read/Capture/clear, per-param set source/range/type + Capture, bindParam = the one keypress
+step [program->parameter->DOWN x row->select-hold], OBJECTINFO-verified by surface title). NEW
+src/midi-map-ui.js (two themed modals: a CONTROLLERS panel over the 8 global assigns with one-click
+Learn, and a per-parameter CARD opened from a "MIDI" badge the renderer adds to DSP-preset NUM/SET
+rows). renderer.js: the badge (DSP-keys only) + handleLcdClick branch. main.js: MIDI Map button,
+setupMidiMapUI, resetMidiMapUI at both reset seams. sysex-commands.js: MOD keys + MOD_SOURCES;
+constants.js: MIDI_MAP timings. Tests 280/280 (+27: midi-map ops/sources/bind, midi-map-ui modals,
+renderer badge), lint+format clean. VALIDATED LIVE end-to-end through the shipped module
+(logs/probe-midimap-e2e.mjs): bindParam('level') -> "level setup", set source=volume(CC7) via the
+module, then CC#7 drove level -100->0 dB with the app out of the runtime path. NEEDS browser smoke:
+the full UI click-through (badge -> card -> device) against the unit; the engine + bind are
+hardware-proven, the UI is jsdom-tested. Pre-merge reviewer pass pending. Foundation note: bindParam
+reaches params on a preset's MAIN param page; deeply-nested sub-page params need extra navigation (a
+follow-up). Also delivers #152 (inbound Program Change loads) — confirmed live.
+
 ## Done (verified merged — do not redo)
 - A1  main.js debug-upload slice bounds — PR #24
 - 8-step decoupling refactor — PR #23

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -886,6 +886,10 @@ the full UI click-through (badge -> card -> device) against the unit; the engine
 hardware-proven, the UI is jsdom-tested. Pre-merge reviewer pass pending. Foundation note: bindParam
 reaches params on a preset's MAIN param page; deeply-nested sub-page params need extra navigation (a
 follow-up). Also delivers #152 (inbound Program Change loads) — confirmed live.
+CONFIRMED LIVE BY MAINTAINER: bound a real controller and saw modulation on hardware. Polish batch
+(A/B sync, CC/con display, mapped badge, DSP-B/embedded params, range hint) + the completed 52-entry
+mode source table all hardware-verified (logs/probe-verify-batch.mjs): MIDI double surfaces the con
+(CC number); the A/B keypress toggles the DSP so a bind lands on the right engine; DSP-B params bind.
 
 ## Done (verified merged — do not redo)
 - A1  main.js debug-upload slice bounds — PR #24

--- a/src/config.js
+++ b/src/config.js
@@ -124,6 +124,26 @@ export function saveLibraryConfig(library) {
   log(`Preset library saved (${library.banks.length} banks)`, 'info', 'general');
 }
 
+/**
+ * Persists the per-program MIDI mapping badges (#146) into midiConfig without
+ * touching the rest. The device holds the real mapping in the preset; this is
+ * the app's render hint (which params are mapped) so the badges survive a page
+ * reload — the dev server's HMR reload included — instead of vanishing until
+ * each param is re-read.
+ *
+ * @param {Object} mappings - { [programId]: { [paramKey]: sourceName } }
+ */
+export function saveMidiMappings(mappings) {
+  const existing = readStoredConfig();
+  existing.midiMappings = mappings;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(existing));
+}
+
+/** Reads the persisted MIDI mapping badges (#146), or {} if none stored. */
+export function loadMidiMappings() {
+  return readStoredConfig().midiMappings || {};
+}
+
 // Stored config, tolerating corruption (review): the read-modify-write
 // savers must remain the self-healing path — a corrupt midiConfig string
 // becomes an empty object and the next save overwrites it, instead of

--- a/src/constants.js
+++ b/src/constants.js
@@ -129,8 +129,10 @@ export const MIDI_MAP = {
   //                         sends the CC to be learned: the device needs to be
   //                         listening; 800ms is comfortably past the ~100ms
   //                         echo seen on the assign Capture probes, still snappy
-  WRITE_SETTLE_MS: 250, // wait after a modulation VALUE_PUT before reading back
-  //                       the echoed result (PUTs are self-confirming, §9)
+  UI_REFRESH_MS: 600, // the MIDI modals wait this long after a write/refresh
+  //                     before re-reading the device and repainting — long
+  //                     enough for the assign/surface OBJECTINFO + VALUE echoes
+  //                     to land (PUTs are self-confirming, §9)
   BIND_STEP_MS: 300, // pace between cursor keypresses while binding a parameter
   //                    (driving the device highlight to the target row)
   BIND_SETTLE_MS: 600, // wait after parameter/select-hold before reading the

--- a/src/constants.js
+++ b/src/constants.js
@@ -123,6 +123,16 @@ export const LIBRARY = {
   //                             objectinfo:received listener to re-record it
 };
 
+// MIDI mapping (#146, src/midi-map.js): device-native modulation config.
+export const MIDI_MAP = {
+  CAPTURE_SETTLE_MS: 800, // wait after arming Capture Midi before the user/app
+  //                         sends the CC to be learned: the device needs to be
+  //                         listening; 800ms is comfortably past the ~100ms
+  //                         echo seen on the assign Capture probes, still snappy
+  WRITE_SETTLE_MS: 250, // wait after a modulation VALUE_PUT before reading back
+  //                       the echoed result (PUTs are self-confirming, §9)
+};
+
 // Demo mode (src/demo.js): the canned device built from a live capture.
 export const DEMO = {
   REPLY_LATENCY_MS: 25, // per-reply delay so the dump-wave lifecycle (BUSY

--- a/src/constants.js
+++ b/src/constants.js
@@ -131,6 +131,11 @@ export const MIDI_MAP = {
   //                         echo seen on the assign Capture probes, still snappy
   WRITE_SETTLE_MS: 250, // wait after a modulation VALUE_PUT before reading back
   //                       the echoed result (PUTs are self-confirming, §9)
+  BIND_STEP_MS: 300, // pace between cursor keypresses while binding a parameter
+  //                    (driving the device highlight to the target row)
+  BIND_SETTLE_MS: 600, // wait after parameter/select-hold before reading the
+  //                      bound surface back (the page swap is near-instant but
+  //                      the OBJECTINFO round-trip needs room)
 };
 
 // Demo mode (src/demo.js): the canned device built from a live capture.

--- a/src/constants.js
+++ b/src/constants.js
@@ -138,6 +138,11 @@ export const MIDI_MAP = {
   BIND_SETTLE_MS: 600, // wait after parameter/select-hold before reading the
   //                      bound surface back (the page swap is near-instant but
   //                      the OBJECTINFO round-trip needs room)
+  BIND_READ_TRIES: 4, // re-request the bound surface up to this many times if its
+  //                     OBJECTINFO hasn't landed yet (a single read sometimes
+  //                     came back blank and falsely reported "could not bind")
+  LEARN_POLL_TRIES: 20, // how many times the Learn flow polls for a captured
+  //                       controller before giving up (x UI_REFRESH_MS ~= 12s)
 };
 
 // Demo mode (src/demo.js): the canned device built from a live capture.

--- a/src/index.html
+++ b/src/index.html
@@ -58,6 +58,13 @@
         >
           Browse
         </button>
+        <button
+          id="open-midi-map"
+          class="util-btn"
+          title="Map MIDI controllers to parameters (device-native modulation)"
+        >
+          MIDI Map
+        </button>
         <span id="sync-status" class="sync-status">not synced</span>
         <span class="conn-spacer"></span>
         <button id="save-config" class="util-btn">Save Config</button>

--- a/src/library.js
+++ b/src/library.js
@@ -17,7 +17,7 @@ import { sendValuePut, sendObjectInfoDump, sendValueDump, isOutputConnected } fr
 import { KEY, KEY_PREFIX } from './sysex-commands.js';
 import { LIBRARY } from './constants.js';
 import { getNode, bankProgramsFor } from './tree.js';
-import { on } from './events.js';
+import { on, emit } from './events.js';
 import { log } from './logger.js';
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
@@ -280,6 +280,10 @@ export async function loadProgramToDsp(target, dspSlot, onDone) {
     onDone?.();
     return;
   }
+  // A program load replaces a DSP's parameters, so any observed MIDI-map badge
+  // state is now stale. Announce it on the bus (kept decoupled — importing
+  // midi-map here would drag controls->renderer->main into library; review).
+  emit('program:loaded', { dspSlot });
   const isA = dspSlot === 'A';
   log(
     `Load: '${target.programName}' (bank ${target.bankIdx}) -> DSP ${dspSlot}`,

--- a/src/main.js
+++ b/src/main.js
@@ -30,6 +30,7 @@ import {
   renderBrowser,
   resetPresetBrowser,
 } from './preset-browser.js';
+import { setupMidiMapUI, openControllers, resetMidiMapUI } from './midi-map-ui.js';
 import { setupKeypressControls, setupDataKnob, testKeypress, meterPollTick } from './controls.js';
 import {
   setMidiPorts,
@@ -186,6 +187,7 @@ function resetAndLand() {
   // one-shot seed from the new dump (#138), not the previous session's pick.
   resetPresetLoader();
   resetPresetBrowser(); // also drop any open browser + in-flight preview state
+  resetMidiMapUI(); // close MIDI modals; the new device re-reads on demand
   setState(
     {
       currentKey: KEY.ROOT,
@@ -289,6 +291,7 @@ syncBtn.addEventListener('click', () => {
   // it re-seeds from the device's current bank/program (#138).
   resetPresetLoader();
   resetPresetBrowser();
+  resetMidiMapUI();
   setState({ currentKey: KEY.ROOT, keyStack: [] }, 'main:sync-root');
   updateScreen(log);
   log('Synced to root', 'info', 'general');
@@ -506,6 +509,12 @@ function setupLibraryUI() {
   setupPresetBrowser({ onLoadComplete: afterLoad });
   const browseBtn = document.getElementById('open-browser');
   if (browseBtn) browseBtn.addEventListener('click', openPresetBrowser);
+
+  // MIDI mapping (#146): device-native modulation config. afterLoad re-reads
+  // the device after a write (refreshes DSP names / screen).
+  setupMidiMapUI({ onChange: afterLoad });
+  const midiBtn = document.getElementById('open-midi-map');
+  if (midiBtn) midiBtn.addEventListener('click', openControllers);
 
   // "12m ago" style relative time from an ISO stamp.
   const timeAgo = (iso) => {

--- a/src/midi-map-ui.js
+++ b/src/midi-map-ui.js
@@ -27,7 +27,9 @@ import {
   sourceOptions,
 } from './midi-map.js';
 import { MOD } from './sysex-commands.js';
+import { MIDI_MAP } from './constants.js';
 
+const REFRESH = MIDI_MAP.UI_REFRESH_MS; // device-echo settle before re-read/repaint
 const ASSIGN_COUNT = 8; // global assign slots (device-model §8b)
 const TYPE_OPTIONS = ['absolute', 'unipolar', 'bipolar']; // MOD.TYPE indices 0-2
 
@@ -89,7 +91,7 @@ export function openControllers() {
   panelEl.hidden = false;
   // The assign dumps land async; repaint shortly after.
   renderControllers();
-  setTimeout(renderControllers, 600);
+  setTimeout(renderControllers, REFRESH);
 }
 
 export function closeControllers() {
@@ -143,10 +145,7 @@ function renderControllers() {
         'mm-btn',
         () => {
           clearAssign(i);
-          setTimeout(() => {
-            refreshAssign(i);
-            setTimeout(renderControllers, 400);
-          }, 300);
+          refreshAssignThenRender(i);
         },
         false
       )
@@ -158,13 +157,18 @@ function renderControllers() {
   panelEl.append(panel);
 }
 
+// Re-fetch an assign slot, then repaint once its echo has had time to land.
+function refreshAssignThenRender(i) {
+  refreshAssign(i);
+  setTimeout(renderControllers, REFRESH);
+}
+
 // Learn: arm Capture, prompt the user to move a controller, refresh on Done.
 function learnAssign(i) {
   captureAssign(i, () => {
-    showLearnPrompt(panelEl, `Move a controller for assign ${i + 1}, then Done.`, () => {
-      refreshAssign(i);
-      setTimeout(renderControllers, 500);
-    });
+    showLearnPrompt(panelEl, `Move a controller for assign ${i + 1}, then Done.`, () =>
+      refreshAssignThenRender(i)
+    );
   });
 }
 
@@ -207,9 +211,12 @@ export function openParamMapping(param) {
   renderCard();
   bindParam(param.rowIndex, (setup) => {
     card.loading = false;
-    // The surface title is the binding proof; require it to name our param so
-    // a page mismatch can never write the mapping to the wrong target.
-    card.bound = setup && setup.title && setup.title.startsWith(strip(param.name)) ? setup : null;
+    // The surface title ("<param> setup") is the binding proof. Match the WHOLE
+    // first token + a trailing space, not just a prefix — a short name like
+    // "in" must NOT match "input gain setup" (review), or a wrong-row bind
+    // could write the mapping to the wrong parameter.
+    const want = strip(param.name) + ' ';
+    card.bound = setup && setup.title && setup.title.startsWith(want) ? setup : null;
     if (!card.bound) card.error = `Could not bind "${param.name}" (got "${setup?.title || '?'}")`;
     renderCard();
   });
@@ -342,7 +349,7 @@ function afterWrite() {
   setTimeout(() => {
     card && (card.bound = readParamSetup());
     renderCard();
-  }, 500);
+  }, REFRESH);
 }
 
 function field(label, control) {

--- a/src/midi-map-ui.js
+++ b/src/midi-map-ui.js
@@ -51,6 +51,7 @@ export function setupMidiMapUI(cfg) {
 /** Closes both modals + clears card state (disconnect / Sync). */
 export function resetMidiMapUI() {
   card = null;
+  document.querySelector('.mm-learn-overlay')?.remove();
   if (panelEl) {
     panelEl.remove();
     panelEl = null;
@@ -163,35 +164,67 @@ function refreshAssignThenRender(i) {
   setTimeout(renderControllers, REFRESH);
 }
 
-// Learn: arm Capture, prompt the user to move a controller, refresh on Done.
+// Learn: arm Capture, then POLL the device until it reports a captured source,
+// showing it live (the device gives no "done" signal, so we watch its readback).
 function learnAssign(i) {
-  captureAssign(i, () => {
-    showLearnPrompt(panelEl, `Move a controller for assign ${i + 1}, then Done.`, () =>
-      refreshAssignThenRender(i)
-    );
-  });
+  captureAssign(i, () =>
+    startLearnPoll(
+      () => refreshAssign(i),
+      () => readAssign(i).source,
+      () => renderControllers(),
+      `assign ${i + 1}`
+    )
+  );
 }
 
-// A small overlay prompt shared by both Learn flows.
-function showLearnPrompt(host, message, onDone) {
+// True once the slot/surface reports a real source (not off, not the "CAPTURE"
+// armed-but-waiting placeholder).
+function isCaptured(src) {
+  return !!src && src !== 'off' && src.toUpperCase() !== 'CAPTURE';
+}
+
+// A live Learn overlay: prompt to move a controller, poll `read` (after each
+// `refresh`) until it returns a captured source, show it, then `onClose`
+// re-reads + repaints behind the dismissed overlay. Appended to <body> (not the
+// panel/card) so a deferred repaint of the modal cannot wipe it mid-Learn.
+function startLearnPoll(refresh, read, onClose, label) {
+  document.querySelector('.mm-learn-overlay')?.remove(); // never stack two
   const ov = document.createElement('div');
   ov.className = 'mm-learn-overlay';
   const msg = document.createElement('div');
   msg.className = 'mm-learn-msg';
-  msg.textContent = message;
-  ov.append(
-    msg,
-    makeButton(
-      'Done',
-      'mm-btn mm-learn',
-      () => {
-        ov.remove();
-        onDone();
-      },
-      false
-    )
-  );
-  host.append(ov);
+  msg.textContent = `Move your controller for ${label}…`;
+  let stopped = false;
+  const finish = () => {
+    stopped = true;
+    ov.remove();
+    onClose();
+  };
+  const btn = makeButton('Cancel', 'mm-btn mm-learn', finish, false);
+  ov.append(msg, btn);
+  document.body.append(ov);
+
+  let tries = 0;
+  const poll = () => {
+    if (stopped) return;
+    refresh();
+    setTimeout(() => {
+      if (stopped) return;
+      const src = read();
+      if (isCaptured(src)) {
+        msg.textContent = `Captured: ${src}`;
+        btn.textContent = 'Done';
+        return; // stop polling; Done dismisses + repaints with the result
+      }
+      if (++tries >= MIDI_MAP.LEARN_POLL_TRIES) {
+        msg.textContent = 'No controller heard. Move it and retry (check the MIDI channel / omni).';
+        btn.textContent = 'Close';
+        return;
+      }
+      poll();
+    }, REFRESH);
+  };
+  poll();
 }
 
 // --- 2. Per-parameter mapping card ---------------------------------------
@@ -337,9 +370,18 @@ function typeSelect(currentValue) {
 }
 
 function learnParam() {
-  captureParam(() => {
-    showLearnPrompt(cardEl, 'Move a controller, then Done.', afterWrite);
-  });
+  captureParam(() =>
+    startLearnPoll(
+      () => refreshParamSetup(),
+      () => readParamSetup().source,
+      () => {
+        if (card) card.bound = readParamSetup();
+        renderCard();
+        onChange?.();
+      },
+      strip(card?.paramName || 'this parameter')
+    )
+  );
 }
 
 // Re-read the bound surface + let the rest of the app refresh, then repaint.

--- a/src/midi-map-ui.js
+++ b/src/midi-map-ui.js
@@ -25,6 +25,8 @@ import {
   setParamType,
   captureParam,
   sourceOptions,
+  recordParamMapping,
+  resetParamMappings,
 } from './midi-map.js';
 import { MOD } from './sysex-commands.js';
 import { MIDI_MAP } from './constants.js';
@@ -51,6 +53,7 @@ export function setupMidiMapUI(cfg) {
 /** Closes both modals + clears card state (disconnect / Sync). */
 export function resetMidiMapUI() {
   card = null;
+  resetParamMappings(); // the badge state is per-program; clear on reconnect/Sync
   document.querySelector('.mm-learn-overlay')?.remove();
   if (panelEl) {
     panelEl.remove();
@@ -80,6 +83,14 @@ function modalShell(className) {
   el.hidden = true;
   document.body.appendChild(el);
   return el;
+}
+
+// "midi double · con 42" — appends the con# (the actual CC number) when the
+// source reveals one (MIDI single/double); otherwise just the source name.
+function sourceLabel(state) {
+  const con = (state.details || []).find((d) => /con/i.test(d.label));
+  const base = state.source || 'off';
+  return con ? `${base} · ${con.label} ${con.value}` : base;
 }
 
 // --- 1. Controllers panel -------------------------------------------------
@@ -132,7 +143,7 @@ function renderControllers() {
     label.textContent = `assign ${i + 1}`;
     const src = document.createElement('span');
     src.className = 'mm-row-src';
-    src.textContent = a.source || 'off';
+    src.textContent = sourceLabel(a);
     const mon = document.createElement('span');
     mon.className = 'mm-row-mon';
     mon.textContent = a.monitor ? `${Math.round(parseFloat(a.monitor))}%` : '';
@@ -239,7 +250,13 @@ function startLearnPoll(refresh, read, onClose, label) {
 export function openParamMapping(param) {
   if (!cardEl) cardEl = modalShell('mm-modal');
   enableSequenceOut();
-  card = { paramName: param.name, rowIndex: param.rowIndex, bound: null, loading: true };
+  card = {
+    key: param.key,
+    paramName: param.name,
+    rowIndex: param.rowIndex,
+    bound: null,
+    loading: true,
+  };
   cardEl.hidden = false;
   renderCard();
   bindParam(param.rowIndex, (setup) => {
@@ -251,6 +268,8 @@ export function openParamMapping(param) {
     const want = strip(param.name) + ' ';
     card.bound = setup && setup.title && setup.title.startsWith(want) ? setup : null;
     if (!card.bound) card.error = `Could not bind "${param.name}" (got "${setup?.title || '?'}")`;
+    // Record what the bind read so the LCD badge reflects the real state.
+    if (card.bound) recordParamMapping(card.key, card.bound.source);
     renderCard();
   });
 }
@@ -297,6 +316,14 @@ function renderCard() {
 
   // Source picker (set by index; degenerate device options, so we own the list).
   body.append(field('source', sourceSelect(s.source)));
+  // Sub-fields the source reveals: channel, and the con# for MIDI single/double
+  // (this is where the actual CC number shows). Read-only info for now.
+  for (const d of s.details || []) {
+    const v = document.createElement('span');
+    v.className = 'mm-mon';
+    v.textContent = d.value;
+    body.append(field(d.label, v));
+  }
   // Range (depth) — the parameter's display units.
   const range = document.createElement('input');
   range.type = 'number';
@@ -307,6 +334,11 @@ function renderCard() {
     afterWrite();
   });
   body.append(field('range', range));
+  const hint = document.createElement('div');
+  hint.className = 'mm-note';
+  hint.textContent =
+    'range = how far the parameter moves across the full controller sweep, in its own units (e.g. dB / ms / %). Negative inverts.';
+  body.append(hint);
   // Type.
   body.append(field('type', typeSelect(s.type)));
   // Live monitor.
@@ -389,7 +421,10 @@ function afterWrite() {
   refreshParamSetup();
   onChange?.();
   setTimeout(() => {
-    card && (card.bound = readParamSetup());
+    if (card) {
+      card.bound = readParamSetup();
+      recordParamMapping(card.key, card.bound.source); // keep the LCD badge in sync
+    }
     renderCard();
   }, REFRESH);
 }

--- a/src/midi-map-ui.js
+++ b/src/midi-map-ui.js
@@ -1,0 +1,366 @@
+// midi-map-ui.js
+// The MIDI-mapping UI (#146): two themed modals over the device-native engine
+// in midi-map.js. Device I/O goes through that module; this file only renders
+// and sequences, and injects a post-change refresh (onChange) so the rest of
+// the app re-reads the device — the modules never send SysEx themselves beyond
+// midi-map's calls.
+//
+//   1. CONTROLLERS panel — the 8 global assign sources (read / Learn / clear).
+//      Pure object access, no parameter binding.
+//   2. Per-parameter CARD — opened from a parameter's MIDI badge: binds the
+//      modulation surface to that parameter (the one keypress step) then edits
+//      source / range / type / Learn as plain object writes.
+
+import {
+  enableSequenceOut,
+  readAssign,
+  refreshAssign,
+  captureAssign,
+  clearAssign,
+  bindParam,
+  readParamSetup,
+  refreshParamSetup,
+  setParamSource,
+  setParamRange,
+  setParamType,
+  captureParam,
+  sourceOptions,
+} from './midi-map.js';
+import { MOD } from './sysex-commands.js';
+
+const ASSIGN_COUNT = 8; // global assign slots (device-model §8b)
+const TYPE_OPTIONS = ['absolute', 'unipolar', 'bipolar']; // MOD.TYPE indices 0-2
+
+let onChange = null; // injected: re-read device + repaint after a write
+let panelEl = null; // controllers modal
+let cardEl = null; // per-parameter modal
+let card = null; // { paramName, rowIndex, bound, loading, learning }
+
+/**
+ * Wires the post-change refresh once at boot (kept out of this module so it
+ * never sends SysEx). Also turns on sequence-out so live monitors update.
+ *
+ * @param {{onChange: () => void}} cfg
+ */
+export function setupMidiMapUI(cfg) {
+  onChange = cfg?.onChange || null;
+}
+
+/** Closes both modals + clears card state (disconnect / Sync). */
+export function resetMidiMapUI() {
+  card = null;
+  if (panelEl) {
+    panelEl.remove();
+    panelEl = null;
+  }
+  if (cardEl) {
+    cardEl.remove();
+    cardEl = null;
+  }
+}
+
+// --- shared helpers -------------------------------------------------------
+
+function makeButton(label, className, onClick, disabled) {
+  const b = document.createElement('button');
+  b.type = 'button';
+  b.className = className;
+  b.textContent = label;
+  if (disabled) b.disabled = true;
+  else b.addEventListener('click', onClick);
+  return b;
+}
+
+function modalShell(className) {
+  const el = document.createElement('div');
+  el.className = className;
+  el.hidden = true;
+  document.body.appendChild(el);
+  return el;
+}
+
+// --- 1. Controllers panel -------------------------------------------------
+
+/** Opens the global MIDI controllers panel. */
+export function openControllers() {
+  if (!panelEl) panelEl = modalShell('mm-modal');
+  enableSequenceOut(); // live monitors
+  for (let i = 0; i < ASSIGN_COUNT; i++) refreshAssign(i);
+  panelEl.hidden = false;
+  // The assign dumps land async; repaint shortly after.
+  renderControllers();
+  setTimeout(renderControllers, 600);
+}
+
+export function closeControllers() {
+  if (panelEl) panelEl.hidden = true;
+}
+
+function renderControllers() {
+  if (!panelEl || panelEl.hidden) return;
+  panelEl.innerHTML = '';
+  const panel = document.createElement('div');
+  panel.className = 'mm-panel';
+
+  const head = document.createElement('header');
+  head.className = 'mm-head';
+  const title = document.createElement('span');
+  title.className = 'mm-title';
+  title.textContent = 'MIDI CONTROLLERS';
+  head.append(title, makeButton('refresh', 'mm-btn', openControllers, false));
+  head.append(makeButton('✕', 'mm-close', closeControllers, false));
+  panel.append(head);
+
+  const note = document.createElement('div');
+  note.className = 'mm-note';
+  note.textContent =
+    '8 reusable sources. Learn, then move your controller. Used by params as "assign N".';
+  panel.append(note);
+
+  const list = document.createElement('ul');
+  list.className = 'mm-list';
+  for (let i = 0; i < ASSIGN_COUNT; i++) {
+    const a = readAssign(i);
+    const li = document.createElement('li');
+    li.className = 'mm-row';
+
+    const label = document.createElement('span');
+    label.className = 'mm-row-label';
+    label.textContent = `assign ${i + 1}`;
+    const src = document.createElement('span');
+    src.className = 'mm-row-src';
+    src.textContent = a.source || 'off';
+    const mon = document.createElement('span');
+    mon.className = 'mm-row-mon';
+    mon.textContent = a.monitor ? `${Math.round(parseFloat(a.monitor))}%` : '';
+
+    const actions = document.createElement('span');
+    actions.className = 'mm-row-actions';
+    actions.append(
+      makeButton('Learn', 'mm-btn mm-learn', () => learnAssign(i), false),
+      makeButton(
+        'clear',
+        'mm-btn',
+        () => {
+          clearAssign(i);
+          setTimeout(() => {
+            refreshAssign(i);
+            setTimeout(renderControllers, 400);
+          }, 300);
+        },
+        false
+      )
+    );
+    li.append(label, src, mon, actions);
+    list.append(li);
+  }
+  panel.append(list);
+  panelEl.append(panel);
+}
+
+// Learn: arm Capture, prompt the user to move a controller, refresh on Done.
+function learnAssign(i) {
+  captureAssign(i, () => {
+    showLearnPrompt(panelEl, `Move a controller for assign ${i + 1}, then Done.`, () => {
+      refreshAssign(i);
+      setTimeout(renderControllers, 500);
+    });
+  });
+}
+
+// A small overlay prompt shared by both Learn flows.
+function showLearnPrompt(host, message, onDone) {
+  const ov = document.createElement('div');
+  ov.className = 'mm-learn-overlay';
+  const msg = document.createElement('div');
+  msg.className = 'mm-learn-msg';
+  msg.textContent = message;
+  ov.append(
+    msg,
+    makeButton(
+      'Done',
+      'mm-btn mm-learn',
+      () => {
+        ov.remove();
+        onDone();
+      },
+      false
+    )
+  );
+  host.append(ov);
+}
+
+// --- 2. Per-parameter mapping card ---------------------------------------
+
+/**
+ * Opens the mapping card for a parameter and BINDS the modulation surface to
+ * it (the one keypress step). rowIndex is the parameter's 0-based row on the
+ * active DSP's main parameter page; paramName is its label for the bind check.
+ *
+ * @param {{name: string, rowIndex: number}} param
+ */
+export function openParamMapping(param) {
+  if (!cardEl) cardEl = modalShell('mm-modal');
+  enableSequenceOut();
+  card = { paramName: param.name, rowIndex: param.rowIndex, bound: null, loading: true };
+  cardEl.hidden = false;
+  renderCard();
+  bindParam(param.rowIndex, (setup) => {
+    card.loading = false;
+    // The surface title is the binding proof; require it to name our param so
+    // a page mismatch can never write the mapping to the wrong target.
+    card.bound = setup && setup.title && setup.title.startsWith(strip(param.name)) ? setup : null;
+    if (!card.bound) card.error = `Could not bind "${param.name}" (got "${setup?.title || '?'}")`;
+    renderCard();
+  });
+}
+
+export function closeParamMapping() {
+  card = null;
+  if (cardEl) cardEl.hidden = true;
+}
+
+// "level  : %4.0f dB" -> "level"
+function strip(label) {
+  return String(label).split(/[: ]/)[0];
+}
+
+function renderCard() {
+  if (!cardEl || cardEl.hidden) return;
+  cardEl.innerHTML = '';
+  const panel = document.createElement('div');
+  panel.className = 'mm-panel mm-card';
+
+  const head = document.createElement('header');
+  head.className = 'mm-head';
+  const title = document.createElement('span');
+  title.className = 'mm-title';
+  title.textContent = `MAP ${strip(card?.paramName || '')}`.toUpperCase();
+  head.append(title, makeButton('✕', 'mm-close', closeParamMapping, false));
+  panel.append(head);
+
+  if (card?.loading) {
+    panel.append(note('binding to the parameter…'));
+    cardEl.append(panel);
+    return;
+  }
+  if (!card?.bound) {
+    panel.append(note(card?.error || 'not bound'));
+    panel.append(makeButton('Close', 'mm-btn', closeParamMapping, false));
+    cardEl.append(panel);
+    return;
+  }
+
+  const s = readParamSetup();
+  const body = document.createElement('div');
+  body.className = 'mm-card-body';
+
+  // Source picker (set by index; degenerate device options, so we own the list).
+  body.append(field('source', sourceSelect(s.source)));
+  // Range (depth) — the parameter's display units.
+  const range = document.createElement('input');
+  range.type = 'number';
+  range.className = 'mm-input';
+  range.value = parseFloat(s.range) || 0;
+  range.addEventListener('change', () => {
+    setParamRange(range.value);
+    afterWrite();
+  });
+  body.append(field('range', range));
+  // Type.
+  body.append(field('type', typeSelect(s.type)));
+  // Live monitor.
+  const mon = document.createElement('span');
+  mon.className = 'mm-mon';
+  mon.textContent = s.monitor ? `${Math.round(parseFloat(s.monitor))}%` : '—';
+  body.append(field('monitor', mon));
+  panel.append(body);
+
+  const foot = document.createElement('div');
+  foot.className = 'mm-card-foot';
+  foot.append(
+    makeButton('Learn', 'mm-btn mm-learn', learnParam, false),
+    makeButton(
+      'clear',
+      'mm-btn',
+      () => {
+        setParamSource(0);
+        afterWrite();
+      },
+      false
+    ),
+    makeButton('Done', 'mm-btn', closeParamMapping, false)
+  );
+  panel.append(foot);
+  cardEl.append(panel);
+}
+
+function sourceSelect(currentName) {
+  const sel = document.createElement('select');
+  sel.className = 'mm-input';
+  for (const { index, name } of sourceOptions()) {
+    const o = document.createElement('option');
+    o.value = String(index);
+    o.textContent = name;
+    if (name === currentName) o.selected = true;
+    sel.append(o);
+  }
+  sel.addEventListener('change', () => {
+    setParamSource(parseInt(sel.value, 10));
+    afterWrite();
+  });
+  return sel;
+}
+
+function typeSelect(currentValue) {
+  const sel = document.createElement('select');
+  sel.className = 'mm-input';
+  TYPE_OPTIONS.forEach((name, index) => {
+    const o = document.createElement('option');
+    o.value = String(index);
+    o.textContent = name;
+    if (currentValue.includes(name)) o.selected = true;
+    sel.append(o);
+  });
+  sel.addEventListener('change', () => {
+    setParamType(parseInt(sel.value, 10));
+    afterWrite();
+  });
+  return sel;
+}
+
+function learnParam() {
+  captureParam(() => {
+    showLearnPrompt(cardEl, 'Move a controller, then Done.', afterWrite);
+  });
+}
+
+// Re-read the bound surface + let the rest of the app refresh, then repaint.
+function afterWrite() {
+  refreshParamSetup();
+  onChange?.();
+  setTimeout(() => {
+    card && (card.bound = readParamSetup());
+    renderCard();
+  }, 500);
+}
+
+function field(label, control) {
+  const row = document.createElement('label');
+  row.className = 'mm-field';
+  const l = document.createElement('span');
+  l.className = 'mm-field-label';
+  l.textContent = label;
+  row.append(l, control);
+  return row;
+}
+
+function note(text) {
+  const d = document.createElement('div');
+  d.className = 'mm-note';
+  d.textContent = text;
+  return d;
+}
+
+// Re-export the surface key for callers that need it (e.g. tests).
+export const PARAM_SURFACE_KEY = MOD.PARAM_SETUP;

--- a/src/midi-map-ui.js
+++ b/src/midi-map-ui.js
@@ -406,27 +406,29 @@ function learnParam() {
     startLearnPoll(
       () => refreshParamSetup(),
       () => readParamSetup().source,
-      () => {
-        if (card) card.bound = readParamSetup();
-        renderCard();
-        onChange?.();
-      },
+      syncBoundMapping, // record + repaint so the LCD badge lights after Learn
       strip(card?.paramName || 'this parameter')
     )
   );
 }
 
-// Re-read the bound surface + let the rest of the app refresh, then repaint.
+// Re-read the bound surface, RECORD the mapping for the LCD badge, then repaint
+// the card AND the LCD behind it. Order matters: onChange (the LCD re-render)
+// runs LAST, after recordParamMapping — re-rendering before recording left the
+// badge unlit even though the mapping had been applied (maintainer report).
+function syncBoundMapping() {
+  if (card) {
+    card.bound = readParamSetup();
+    recordParamMapping(card.key, card.bound.source);
+  }
+  renderCard();
+  onChange?.();
+}
+
+// A write to the bound surface settles, then we re-read + record + repaint.
 function afterWrite() {
   refreshParamSetup();
-  onChange?.();
-  setTimeout(() => {
-    if (card) {
-      card.bound = readParamSetup();
-      recordParamMapping(card.key, card.bound.source); // keep the LCD badge in sync
-    }
-    renderCard();
-  }, REFRESH);
+  setTimeout(syncBoundMapping, REFRESH);
 }
 
 function field(label, control) {

--- a/src/midi-map-ui.js
+++ b/src/midi-map-ui.js
@@ -25,8 +25,8 @@ import {
   setParamType,
   captureParam,
   sourceOptions,
+  rangeForSpan,
   recordParamMapping,
-  resetParamMappings,
 } from './midi-map.js';
 import { MOD } from './sysex-commands.js';
 import { MIDI_MAP } from './constants.js';
@@ -53,7 +53,10 @@ export function setupMidiMapUI(cfg) {
 /** Closes both modals + clears card state (disconnect / Sync). */
 export function resetMidiMapUI() {
   card = null;
-  resetParamMappings(); // the badge state is per-program; clear on reconnect/Sync
+  // Badge state is intentionally NOT cleared here: it is program-scoped and
+  // persisted (midi-map.js), so it survives a reconnect/reload and a reconnect
+  // to a different program simply shows that program's badges. Clearing it here
+  // wiped the persisted store on every reconnect (the page-reload path).
   document.querySelector('.mm-learn-overlay')?.remove();
   if (panelEl) {
     panelEl.remove();
@@ -324,7 +327,11 @@ function renderCard() {
     v.textContent = d.value;
     body.append(field(d.label, v));
   }
-  // Range (depth) — the parameter's display units.
+  // Range (depth) — in the bound parameter's OWN display units, shown with the
+  // parameter's span as the reference (a bare "200" means nothing without it).
+  const unit = s.param?.unit || '';
+  const rangeWrap = document.createElement('div');
+  rangeWrap.className = 'mm-range-row';
   const range = document.createElement('input');
   range.type = 'number';
   range.className = 'mm-input';
@@ -333,11 +340,43 @@ function renderCard() {
     setParamRange(range.value);
     afterWrite();
   });
-  body.append(field('range', range));
+  rangeWrap.append(range);
+  if (unit) {
+    const u = document.createElement('span');
+    u.className = 'mm-unit';
+    u.textContent = unit;
+    rangeWrap.append(u);
+  }
+  if (s.param) {
+    // One click to the natural value: a full controller sweep = the parameter's
+    // full span (the device's `range` NUM is already in the parameter's units).
+    rangeWrap.append(
+      makeButton(
+        'full span',
+        'mm-btn mm-mini',
+        () => {
+          setParamRange(rangeForSpan(s.param.span));
+          afterWrite();
+        },
+        false
+      )
+    );
+  }
+  body.append(field('range', rangeWrap));
   const hint = document.createElement('div');
   hint.className = 'mm-note';
-  hint.textContent =
-    'range = how far the parameter moves across the full controller sweep, in its own units (e.g. dB / ms / %). Negative inverts.';
+  if (s.param) {
+    const span = Math.abs(Math.round(s.param.span));
+    const u = unit ? ` ${unit}` : '';
+    hint.textContent =
+      `${strip(card?.paramName || 'this parameter')} runs ${Math.round(s.param.min)}…${Math.round(s.param.max)}${u} ` +
+      `(${span}${u} wide). range = how much it moves across a full controller sweep: ` +
+      `${span} covers its whole span, ${span * 2} is twice as sensitive (hits both ends at mid-travel), ` +
+      `half that is gentler. Negative inverts.`;
+  } else {
+    hint.textContent =
+      'range = how far the parameter moves across the full controller sweep, in its own units (e.g. dB / ms / %). Negative inverts.';
+  }
   body.append(hint);
   // Type.
   body.append(field('type', typeSelect(s.type)));

--- a/src/midi-map.js
+++ b/src/midi-map.js
@@ -12,7 +12,8 @@
 //
 // DOM-free like library.js: it reads the tree + sends SysEx, nothing else.
 
-import { sendValuePut, sendObjectInfoDump, sendValueDump } from './midi.js';
+import { sendValuePut, sendObjectInfoDump, sendValueDump, sendKeypress } from './midi.js';
+import { keypressMasks } from './controls.js';
 import { MOD, MOD_SOURCES } from './sysex-commands.js';
 import { MIDI_MAP } from './constants.js';
 import { getNode } from './tree.js';
@@ -97,10 +98,39 @@ export function clearAssign(i) {
   sendValuePut(assignSlot(i).mode, '0');
 }
 
-// --- Per-parameter modulation (surface must be BOUND first) ---------------
-// Binding is a SELECT-hold on the target parameter (the one keypress step); the
-// caller owns that + the screen-title verification. Once bound, these are pure
-// VALUE_PUT/OBJECTINFO on the fixed surface keys.
+// --- Per-parameter modulation ---------------------------------------------
+// Binding is the one keypress step: drive the device highlight to the target
+// parameter and SELECT-hold. After that, config is pure VALUE_PUT/OBJECTINFO on
+// the fixed surface keys, and the bind is verified by the surface's OBJECTINFO
+// title (no bitmap scraping).
+
+/**
+ * Binds the per-parameter modulation surface to the parameter at `rowIndex` on
+ * the active DSP's main parameter page (0-based, in dump order). Drives the
+ * device cursor there (program -> parameter resets to the top row, then DOWN x
+ * rowIndex) and SELECT-holds, then reads the bound surface back. The returned
+ * setup's `title` is the binding proof ("<param> setup") — the caller compares
+ * it to the expected parameter and aborts on mismatch rather than writing to
+ * the wrong target.
+ *
+ * @param {number} rowIndex
+ * @param {(setup: object) => void} [onDone] - called with readParamSetup()
+ */
+export async function bindParam(rowIndex, onDone) {
+  sendKeypress(keypressMasks.program); // reset to a known page...
+  await sleep(MIDI_MAP.BIND_STEP_MS);
+  sendKeypress(keypressMasks.parameter); // ...then the param page (cursor at top)
+  await sleep(MIDI_MAP.BIND_SETTLE_MS);
+  for (let i = 0; i < rowIndex; i++) {
+    sendKeypress(keypressMasks.down);
+    await sleep(MIDI_MAP.BIND_STEP_MS);
+  }
+  sendKeypress(keypressMasks['select-hold']);
+  await sleep(MIDI_MAP.BIND_SETTLE_MS);
+  refreshParamSetup();
+  await sleep(MIDI_MAP.BIND_SETTLE_MS);
+  onDone?.(readParamSetup());
+}
 
 /** Sets the bound parameter's modulation source by index (MOD_SOURCES). */
 export function setParamSource(index) {

--- a/src/midi-map.js
+++ b/src/midi-map.js
@@ -20,6 +20,29 @@ import { getNode } from './tree.js';
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
+// Observed per-parameter mapping state (param key -> source name), so the
+// renderer can flag mapped knobs WITHOUT re-binding each one. The device stores
+// the truth in the preset; this records what the app has set or read so far.
+// Cleared on disconnect/Sync (the mappings change with the loaded program).
+let mappedParams = {};
+
+/** Records (or clears, when source is off/empty) a param's mapping for the badge. */
+export function recordParamMapping(key, source) {
+  if (!key) return;
+  if (!source || source === 'off') delete mappedParams[key];
+  else mappedParams[key] = source;
+}
+
+/** The source name a param is mapped to (for the lit badge), or null. */
+export function paramMappingOf(key) {
+  return mappedParams[key] || null;
+}
+
+/** Clears all observed mappings (disconnect / Sync / program change). */
+export function resetParamMappings() {
+  mappedParams = {};
+}
+
 /** The child key at `offset` within a slot/surface base key (hex math). */
 export function childKey(base, offset) {
   return (parseInt(base, 16) + offset).toString(16);
@@ -62,6 +85,21 @@ export function assignSlot(i) {
   };
 }
 
+// A modulation sub-field (channel / con#) made presentable, or null when it is
+// the blank "-----" placeholder. For "MIDI single"/"MIDI double" sources the
+// device reveals a `con` (controller-number) sub here — this is how the actual
+// CC number surfaces. Strips the format spec from the label and the leading
+// index token from a SET value: { label: 'con', value: '42' }.
+function subDetail(o) {
+  if (!o || o.tag === '-----') return null;
+  const label = String(o.statement || '')
+    .replace(/\s*:?\s*%[-0-9.]*[a-z%].*$/i, '')
+    .trim();
+  if (!label || /^[-\s]+$/.test(label)) return null;
+  const raw = String(o.value ?? '');
+  return { label, value: raw.replace(/^[0-9a-f]+\s/i, '') || raw };
+}
+
 /** Reads assign slot `i`'s current state from the tree (after a refresh). */
 export function readAssign(i) {
   const s = assignSlot(i);
@@ -72,6 +110,10 @@ export function readAssign(i) {
     source: (find(s.mode)?.value || '').replace(/^\w+\s/, '') || 'off',
     channel: find(s.channel)?.value || '',
     monitor: find(s.monitor)?.value || '',
+    // channel + the con# (for MIDI single/double) as presentable detail.
+    details: [subDetail(find(s.channel)), subDetail(find(childKey(s.base, MOD.OFF_SUB)))].filter(
+      Boolean
+    ),
   };
 }
 
@@ -179,6 +221,8 @@ export function readParamSetup() {
     range: find(MOD.RANGE)?.value || '',
     type: find(MOD.TYPE)?.value || '',
     monitor: find(MOD.MONITOR)?.value || '',
+    // channel + the con# (for MIDI single/double, this is the actual CC number).
+    details: [subDetail(find(MOD.CHANNEL)), subDetail(find(MOD.SUB2))].filter(Boolean),
   };
 }
 

--- a/src/midi-map.js
+++ b/src/midi-map.js
@@ -239,9 +239,11 @@ export function refreshParamSetup() {
 
 // The display unit trailing a printf statement, e.g. 'level : %4.0f dB' -> 'dB',
 // 'con: %2.0f' -> ''. Used to give the bare `range` number its parameter units.
+// The device escapes a literal percent as '%%' (printf), e.g. 'size/decay: %3.0f
+// %%' — collapse it back to a single '%' so percent params don't read "%%".
 function unitOf(statement) {
   const m = String(statement || '').match(/%[-+ 0-9.]*[a-zA-Z](.*)$/);
-  return m ? m[1].trim() : '';
+  return m ? m[1].replace(/%%/g, '%').trim() : '';
 }
 
 /** Reads the bound modulation surface from the tree (title proves the binding). */

--- a/src/midi-map.js
+++ b/src/midi-map.js
@@ -1,0 +1,159 @@
+// midi-map.js
+// Device-native MIDI mapping (#146): configures the Orville's own modulation
+// system so a MIDI source drives a parameter IN THE DSP — the app is only a
+// configurator, never in the runtime signal path (zero latency, persists in the
+// preset). See docs/device-model.md §8b for the full model.
+//
+// Two layers, both ordinary userobjects edited with VALUE_PUT/OBJECTINFO:
+//   - 8 global "assign" controllers (reusable MIDI sources) under ext
+//     controllers; each has a Capture-Midi learn.
+//   - a per-parameter modulation surface (mode/range/type/capture) bound to a
+//     parameter by SELECT-hold (the one keypress step, handled by the caller).
+//
+// DOM-free like library.js: it reads the tree + sends SysEx, nothing else.
+
+import { sendValuePut, sendObjectInfoDump, sendValueDump } from './midi.js';
+import { MOD, MOD_SOURCES } from './sysex-commands.js';
+import { MIDI_MAP } from './constants.js';
+import { getNode } from './tree.js';
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** The child key at `offset` within a slot/surface base key (hex math). */
+export function childKey(base, offset) {
+  return (parseInt(base, 16) + offset).toString(16);
+}
+
+/** Display name for a `mode` source index (device-model §8b). */
+export function sourceName(index) {
+  return MOD_SOURCES[index] ?? `source ${index}`;
+}
+
+/** The index for a source name, or -1. The names are unique in MOD_SOURCES. */
+export function sourceIndex(name) {
+  return MOD_SOURCES.indexOf(name);
+}
+
+/** The full source list as { index, name } for a picker. */
+export function sourceOptions() {
+  return MOD_SOURCES.map((name, index) => ({ index, name }));
+}
+
+/**
+ * Enables `sequence out = new` so the unit echoes the key of any changed field
+ * (live monitors + change mirroring; also the key-discovery channel). One-time.
+ */
+export function enableSequenceOut() {
+  sendValuePut(MOD.SEQ_OUT, String(MOD.SEQ_OUT_NEW));
+}
+
+// --- Global assign controllers (the 8 reusable MIDI sources) --------------
+
+/** The child keys for global assign slot `i` (0-7). */
+export function assignSlot(i) {
+  const base = MOD.ASSIGN_BASES[i];
+  return {
+    base,
+    mode: childKey(base, MOD.OFF_MODE),
+    channel: childKey(base, MOD.OFF_CHANNEL),
+    monitor: childKey(base, MOD.OFF_MONITOR),
+    capture: childKey(base, MOD.OFF_CAPTURE),
+  };
+}
+
+/** Reads assign slot `i`'s current state from the tree (after a refresh). */
+export function readAssign(i) {
+  const s = assignSlot(i);
+  const node = getNode(s.base);
+  const find = (k) => node?.find((o) => o.key === k);
+  return {
+    index: i,
+    source: (find(s.mode)?.value || '').replace(/^\w+\s/, '') || 'off',
+    channel: find(s.channel)?.value || '',
+    monitor: find(s.monitor)?.value || '',
+  };
+}
+
+/** Re-fetches assign slot `i` (structure + values) into the tree. */
+export function refreshAssign(i) {
+  const s = assignSlot(i);
+  sendObjectInfoDump(s.base);
+  sendValueDump(s.base);
+}
+
+/**
+ * Arms Capture-Midi on assign slot `i`; the caller then has the user move a
+ * controller (or emits a CC) and the unit captures it. Calls onDone after the
+ * arm settles so a UI can prompt "move your controller now".
+ */
+export async function captureAssign(i, onDone) {
+  sendValuePut(assignSlot(i).capture, '1');
+  await sleep(MIDI_MAP.CAPTURE_SETTLE_MS);
+  onDone?.();
+}
+
+/** Clears assign slot `i` (source -> off). */
+export function clearAssign(i) {
+  sendValuePut(assignSlot(i).mode, '0');
+}
+
+// --- Per-parameter modulation (surface must be BOUND first) ---------------
+// Binding is a SELECT-hold on the target parameter (the one keypress step); the
+// caller owns that + the screen-title verification. Once bound, these are pure
+// VALUE_PUT/OBJECTINFO on the fixed surface keys.
+
+/** Sets the bound parameter's modulation source by index (MOD_SOURCES). */
+export function setParamSource(index) {
+  sendValuePut(MOD.MODE, String(index));
+}
+
+/** Sets the bound parameter's modulation depth/range. */
+export function setParamRange(value) {
+  sendValuePut(MOD.RANGE, String(value));
+}
+
+/** Sets the bound parameter's response type (0 absolute / 1 unipolar / 2 bipolar). */
+export function setParamType(index) {
+  sendValuePut(MOD.TYPE, String(index));
+}
+
+/** Arms Capture-Midi on the bound parameter's surface. */
+export async function captureParam(onDone) {
+  sendValuePut(MOD.CAPTURE, '1');
+  await sleep(MIDI_MAP.CAPTURE_SETTLE_MS);
+  onDone?.();
+}
+
+/** Re-fetches the bound modulation surface (structure + values). */
+export function refreshParamSetup() {
+  sendObjectInfoDump(MOD.PARAM_SETUP);
+  sendValueDump(MOD.PARAM_SETUP);
+}
+
+/** Reads the bound modulation surface from the tree (title proves the binding). */
+export function readParamSetup() {
+  const node = getNode(MOD.PARAM_SETUP);
+  const find = (k) => node?.find((o) => o.key === k);
+  return {
+    title: node?.[0]?.statement || '',
+    source: (find(MOD.MODE)?.value || '').replace(/^\w+\s/, '') || 'off',
+    channel: find(MOD.CHANNEL)?.value || '',
+    range: find(MOD.RANGE)?.value || '',
+    type: find(MOD.TYPE)?.value || '',
+    monitor: find(MOD.MONITOR)?.value || '',
+  };
+}
+
+/**
+ * The manual's scale equation (p.78): the `range` value that maps a controller's
+ * full sweep onto a desired parameter span. `(spanMax - spanMin)` over the
+ * parameter's full range, times the device's full-scale range unit. We expose
+ * the simple linear case: the desired parameter delta IS the range value (the
+ * device's `range` NUM is already in the parameter's display units, e.g. dB).
+ *
+ * @param {number} desiredDelta - parameter change across the controller's sweep
+ * @returns {number} the value to write to MOD.RANGE
+ */
+export function rangeForSpan(desiredDelta) {
+  return Math.round(desiredDelta);
+}

--- a/src/midi-map.js
+++ b/src/midi-map.js
@@ -17,6 +17,7 @@ import { keypressMasks } from './controls.js';
 import { MOD, MOD_SOURCES } from './sysex-commands.js';
 import { MIDI_MAP } from './constants.js';
 import { getNode } from './tree.js';
+import { on } from './events.js';
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
@@ -42,6 +43,9 @@ export function paramMappingOf(key) {
 export function resetParamMappings() {
   mappedParams = {};
 }
+
+// A program load (library.js) replaces a DSP's params, staling the badge state.
+on('program:loaded', resetParamMappings);
 
 /** The child key at `offset` within a slot/surface base key (hex math). */
 export function childKey(base, offset) {
@@ -97,7 +101,9 @@ function subDetail(o) {
     .trim();
   if (!label || /^[-\s]+$/.test(label)) return null;
   const raw = String(o.value ?? '');
-  return { label, value: raw.replace(/^[0-9a-f]+\s/i, '') || raw };
+  const value = raw.replace(/^[0-9a-f]+\s/i, '') || raw;
+  if (/^[-\s]*$/.test(value)) return null; // an unset value placeholder ("-----")
+  return { label, value };
 }
 
 /** Reads assign slot `i`'s current state from the tree (after a refresh). */

--- a/src/midi-map.js
+++ b/src/midi-map.js
@@ -127,9 +127,17 @@ export async function bindParam(rowIndex, onDone) {
   }
   sendKeypress(keypressMasks['select-hold']);
   await sleep(MIDI_MAP.BIND_SETTLE_MS);
-  refreshParamSetup();
-  await sleep(MIDI_MAP.BIND_SETTLE_MS);
-  onDone?.(readParamSetup());
+  // The bound surface OBJECTINFO can lag the page swap — poll it a few times
+  // rather than reading once (a single short wait reported a blank title and
+  // "could not bind" even when the bind had landed; review).
+  let setup = { title: '' };
+  for (let i = 0; i < MIDI_MAP.BIND_READ_TRIES; i++) {
+    refreshParamSetup();
+    await sleep(MIDI_MAP.BIND_SETTLE_MS);
+    setup = readParamSetup();
+    if (setup.title) break;
+  }
+  onDone?.(setup);
 }
 
 /** Sets the bound parameter's modulation source by index (MOD_SOURCES). */

--- a/src/midi-map.js
+++ b/src/midi-map.js
@@ -14,38 +14,59 @@
 
 import { sendValuePut, sendObjectInfoDump, sendValueDump, sendKeypress } from './midi.js';
 import { keypressMasks } from './controls.js';
-import { MOD, MOD_SOURCES } from './sysex-commands.js';
+import { MOD, MOD_SOURCES, KEY_PREFIX } from './sysex-commands.js';
 import { MIDI_MAP } from './constants.js';
 import { getNode } from './tree.js';
-import { on } from './events.js';
+import { saveMidiMappings, loadMidiMappings } from './config.js';
+import { appState } from './state.js';
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
-// Observed per-parameter mapping state (param key -> source name), so the
-// renderer can flag mapped knobs WITHOUT re-binding each one. The device stores
-// the truth in the preset; this records what the app has set or read so far.
-// Cleared on disconnect/Sync (the mappings change with the loaded program).
-let mappedParams = {};
+// Observed per-parameter mapping state, so the renderer can flag mapped knobs
+// WITHOUT re-binding each one. The device stores the truth in the preset; this
+// records what the app has set or read so far, and persists it to midiConfig so
+// the badges survive a page reload (the dev server's HMR reload included).
+//
+// Keyed by PROGRAM: { [programId]: { [paramKey]: sourceName } }. A param key
+// lives in one DSP slot, and that slot's loaded program name identifies which
+// preset it is — so loading a different program naturally shows ITS badges and
+// never the previous program's stale ones (no blunt clear-on-load needed; the
+// lookup is self-correcting). Cleared wholesale only on an explicit reset.
+let mappedParams = loadMidiMappings();
+
+// The program a param key belongs to: its DSP slot's loaded program name. The
+// key prefix names the slot (A/B); appState holds each slot's program name. When
+// a slot's name is not yet known, fall back to the slot letter so a mapping set
+// before the name resolves is still recoverable. Null for non-preset keys (the
+// load menu / setup / gangs — never badged).
+function progIdOf(key) {
+  if (key?.startsWith(KEY_PREFIX.DSP_A)) return appState.dspAName || KEY_PREFIX.DSP_A;
+  if (key?.startsWith(KEY_PREFIX.DSP_B)) return appState.dspBName || KEY_PREFIX.DSP_B;
+  return null;
+}
 
 /** Records (or clears, when source is off/empty) a param's mapping for the badge. */
 export function recordParamMapping(key, source) {
-  if (!key) return;
-  if (!source || source === 'off') delete mappedParams[key];
-  else mappedParams[key] = source;
+  const prog = progIdOf(key);
+  if (!prog) return;
+  const forProg = mappedParams[prog] || (mappedParams[prog] = {});
+  if (!source || source === 'off') delete forProg[key];
+  else forProg[key] = source;
+  if (!Object.keys(forProg).length) delete mappedParams[prog]; // don't leave empty buckets
+  saveMidiMappings(mappedParams);
 }
 
 /** The source name a param is mapped to (for the lit badge), or null. */
 export function paramMappingOf(key) {
-  return mappedParams[key] || null;
+  const prog = progIdOf(key);
+  return (prog && mappedParams[prog]?.[key]) || null;
 }
 
-/** Clears all observed mappings (disconnect / Sync / program change). */
+/** Clears ALL observed mappings (explicit reset only — tests, hard reset). */
 export function resetParamMappings() {
   mappedParams = {};
+  saveMidiMappings(mappedParams);
 }
-
-// A program load (library.js) replaces a DSP's params, staling the badge state.
-on('program:loaded', resetParamMappings);
 
 /** The child key at `offset` within a slot/surface base key (hex math). */
 export function childKey(base, offset) {
@@ -216,10 +237,31 @@ export function refreshParamSetup() {
   sendValueDump(MOD.PARAM_SETUP);
 }
 
+// The display unit trailing a printf statement, e.g. 'level : %4.0f dB' -> 'dB',
+// 'con: %2.0f' -> ''. Used to give the bare `range` number its parameter units.
+function unitOf(statement) {
+  const m = String(statement || '').match(/%[-+ 0-9.]*[a-zA-Z](.*)$/);
+  return m ? m[1].trim() : '';
+}
+
 /** Reads the bound modulation surface from the tree (title proves the binding). */
 export function readParamSetup() {
   const node = getNode(MOD.PARAM_SETUP);
   const find = (k) => node?.find((o) => o.key === k);
+  // The bound parameter's own value mirror (device-model §8b): the surface's NUM
+  // that ISN'T the `range` NUM. It carries the parameter's display unit + its
+  // full span (min..max) — the reference that makes a `range` value meaningful
+  // (e.g. range 200 on a 100 dB-span parameter = twice its span).
+  const mirror = node?.find((o) => o.type === 'NUM' && o.key !== MOD.RANGE);
+  const param =
+    mirror && mirror.min !== '' && mirror.max !== ''
+      ? {
+          unit: unitOf(mirror.statement),
+          min: Number(mirror.min),
+          max: Number(mirror.max),
+          span: Number(mirror.max) - Number(mirror.min),
+        }
+      : null;
   return {
     title: node?.[0]?.statement || '',
     source: (find(MOD.MODE)?.value || '').replace(/^\w+\s/, '') || 'off',
@@ -227,6 +269,7 @@ export function readParamSetup() {
     range: find(MOD.RANGE)?.value || '',
     type: find(MOD.TYPE)?.value || '',
     monitor: find(MOD.MONITOR)?.value || '',
+    param,
     // channel + the con# (for MIDI single/double, this is the actual CC number).
     details: [subDetail(find(MOD.CHANNEL)), subDetail(find(MOD.SUB2))].filter(Boolean),
   };

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,6 +1,6 @@
 // renderer.js
 import { appState } from './state.js';
-import { CMD, KEY, KEY_PREFIX, ROOT_SOFTKEYS, TYPE_EMPTY } from './sysex-commands.js';
+import { CMD, KEY, KEY_PREFIX, ROOT_SOFTKEYS, TYPE_EMPTY, PARAM_TYPES } from './sysex-commands.js';
 import { TIMING, LAYOUT, RENDER } from './constants.js';
 import { setState } from './store.js';
 import { sendObjectInfoDump, sendValueDump, sendValuePut, sendSysEx } from './midi.js';
@@ -15,6 +15,7 @@ import {
 } from './tree.js';
 import { log } from './logger.js';
 import { isSyncing, loadProgram, isFavoritesBank, refreshFavoritesBank } from './library.js';
+import { openParamMapping } from './midi-map-ui.js';
 import {
   isLoadMenuActive,
   hasLibrary,
@@ -61,6 +62,17 @@ export function updateScreen(logParam = null) {
  * @param {Event} e - The click event.
  */
 const handleLcdClick = (e) => {
+  if (e.target.classList.contains('lcd-midi-badge')) {
+    // #146: map a MIDI controller to this parameter. Opens the mapping card,
+    // which binds the device modulation surface to the param (row index) and
+    // verifies by title before writing — see midi-map-ui.openParamMapping.
+    e.stopPropagation();
+    openParamMapping({
+      name: e.target.dataset.midiName || '',
+      rowIndex: parseInt(e.target.dataset.midiRow, 10) || 0,
+    });
+    return;
+  }
   if (e.target.classList.contains('dsp-clickable')) {
     const newPresetKey = e.target.dataset.key;
     const patch = {
@@ -900,6 +912,28 @@ export function renderScreen(subs, ascii, logParam) {
       paramLines.push(graphicEqLine);
       paramHtmlLines.push(graphicEqHtml);
     }
+    // #146 MIDI-map: the modulatable params in device cursor order (how many
+    // DOWN presses from the top of the parameter page reach each one). NUM/SET
+    // get a "MIDI" badge whose data-midi-row drives the bind. The bind verifies
+    // by surface title, so a mismatch (wrong page) aborts rather than mis-writes.
+    const midiRowByKey = new Map(
+      subs
+        .slice(1)
+        .filter((s) => PARAM_TYPES.includes(s.type) && s.position !== 'a')
+        .map((s, i) => [s.key, i])
+    );
+    const midiBadge = (s) => {
+      if (prePainting) return '';
+      // Only preset parameters are modulatable (keys under DSP A/B). The load
+      // menu / setup / gang SETs are not, and the bind's "parameter" keypress
+      // navigates to the active preset's page — so a badge only makes sense on
+      // a DSP preset param.
+      if (!s.key.startsWith(KEY_PREFIX.DSP_A) && !s.key.startsWith(KEY_PREFIX.DSP_B)) return '';
+      const row = midiRowByKey.get(s.key);
+      if (row === undefined) return '';
+      const name = escapeHtml(s.statement || s.tag || '');
+      return ` <span class="lcd-midi-badge" data-midi-row="${row}" data-midi-name="${name}" title="Map a MIDI controller to this parameter">MIDI</span>`;
+    };
     subs.slice(1).forEach((s) => {
       if (prePainting) {
         // R3: one inert placeholder line per param — no clickable spans,
@@ -924,7 +958,7 @@ export function renderScreen(subs, ascii, logParam) {
         if (appState.currentValues[s.key] === undefined && !s.value) sendValueDump(s.key);
         const formatStr = s.statement || s.tag || '';
         fullText = formatValue(formatStr, value);
-        fullHtml = formatValue(formatStr, value, true, s.key);
+        fullHtml = formatValue(formatStr, value, true, s.key) + midiBadge(s);
       } else if (s.type === 'INF') {
         let value = appState.currentValues[s.key] || s.value || '';
         if (appState.currentValues[s.key] === undefined && !s.value) sendValueDump(s.key, logParam);
@@ -954,7 +988,7 @@ export function renderScreen(subs, ascii, logParam) {
           selectHtml += `<option value="${option.index}" ${isSelected ? 'selected' : ''}>${escapeHtml(option.desc)}</option>`;
         });
         selectHtml += `</select>`;
-        fullHtml = escapeHtml(s.statement || '').replace(/%(-)?(\d*)s/g, selectHtml);
+        fullHtml = escapeHtml(s.statement || '').replace(/%(-)?(\d*)s/g, selectHtml) + midiBadge(s);
       } else if (s.type === 'CON') {
         let meterValue = parseFloat(appState.currentValues[s.key] || s.value) || 0;
         if (isNaN(meterValue)) {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -3,7 +3,14 @@ import { appState } from './state.js';
 import { CMD, KEY, KEY_PREFIX, ROOT_SOFTKEYS, TYPE_EMPTY, PARAM_TYPES } from './sysex-commands.js';
 import { TIMING, LAYOUT, RENDER } from './constants.js';
 import { setState } from './store.js';
-import { sendObjectInfoDump, sendValueDump, sendValuePut, sendSysEx } from './midi.js';
+import {
+  sendObjectInfoDump,
+  sendValueDump,
+  sendValuePut,
+  sendSysEx,
+  sendKeypress,
+} from './midi.js';
+import { keypressMasks } from './controls.js';
 import { showLoading } from './main.js';
 import {
   getNode,
@@ -16,6 +23,7 @@ import {
 import { log } from './logger.js';
 import { isSyncing, loadProgram, isFavoritesBank, refreshFavoritesBank } from './library.js';
 import { openParamMapping } from './midi-map-ui.js';
+import { paramMappingOf } from './midi-map.js';
 import {
   isLoadMenuActive,
   hasLibrary,
@@ -68,6 +76,7 @@ const handleLcdClick = (e) => {
     // verifies by title before writing — see midi-map-ui.openParamMapping.
     e.stopPropagation();
     openParamMapping({
+      key: e.target.dataset.midiKey || '',
       name: e.target.dataset.midiName || '',
       rowIndex: parseInt(e.target.dataset.midiRow, 10) || 0,
     });
@@ -75,6 +84,13 @@ const handleLcdClick = (e) => {
   }
   if (e.target.classList.contains('dsp-clickable')) {
     const newPresetKey = e.target.dataset.key;
+    // Keep the DEVICE on the same DSP as the glass view: a MIDI-map bind drives
+    // the device's "parameter" page, which follows the unit's current DSP — so
+    // a view-only A/B toggle used to bind the WRONG DSP (maintainer). Press the
+    // unit's A/B when the view actually switches so they stay in lockstep (#146).
+    if (newPresetKey !== appState.presetKey) {
+      sendKeypress(keypressMasks.ab);
+    }
     const patch = {
       presetKey: newPresetKey,
       currentKey: newPresetKey,
@@ -922,17 +938,26 @@ export function renderScreen(subs, ascii, logParam) {
         .filter((s) => PARAM_TYPES.includes(s.type) && s.position !== 'a')
         .map((s, i) => [s.key, i])
     );
-    const midiBadge = (s) => {
+    const midiBadge = (s, rowMap) => {
       if (prePainting) return '';
       // Only preset parameters are modulatable (keys under DSP A/B). The load
       // menu / setup / gang SETs are not, and the bind's "parameter" keypress
       // navigates to the active preset's page — so a badge only makes sense on
       // a DSP preset param.
       if (!s.key.startsWith(KEY_PREFIX.DSP_A) && !s.key.startsWith(KEY_PREFIX.DSP_B)) return '';
-      const row = midiRowByKey.get(s.key);
+      const row = rowMap.get(s.key);
       if (row === undefined) return '';
       const name = escapeHtml(s.statement || s.tag || '');
-      return ` <span class="lcd-midi-badge" data-midi-row="${row}" data-midi-name="${name}" title="Map a MIDI controller to this parameter">MIDI</span>`;
+      // A mapped param shows its source lit (e.g. "pan"); an unmapped one shows
+      // a dim "MIDI" affordance (#146). Mapping state is what the app has set or
+      // read — see midi-map.paramMappingOf.
+      const mapped = paramMappingOf(s.key);
+      const cls = mapped ? 'lcd-midi-badge lcd-midi-mapped' : 'lcd-midi-badge';
+      const label = mapped ? escapeHtml(mapped) : 'MIDI';
+      const title = mapped
+        ? `Mapped to ${escapeHtml(mapped)} — click to edit`
+        : 'Map a MIDI controller to this parameter';
+      return ` <span class="${cls}" data-midi-key="${s.key}" data-midi-row="${row}" data-midi-name="${name}" title="${title}">${label}</span>`;
     };
     subs.slice(1).forEach((s) => {
       if (prePainting) {
@@ -958,7 +983,7 @@ export function renderScreen(subs, ascii, logParam) {
         if (appState.currentValues[s.key] === undefined && !s.value) sendValueDump(s.key);
         const formatStr = s.statement || s.tag || '';
         fullText = formatValue(formatStr, value);
-        fullHtml = formatValue(formatStr, value, true, s.key) + midiBadge(s);
+        fullHtml = formatValue(formatStr, value, true, s.key) + midiBadge(s, midiRowByKey);
       } else if (s.type === 'INF') {
         let value = appState.currentValues[s.key] || s.value || '';
         if (appState.currentValues[s.key] === undefined && !s.value) sendValueDump(s.key, logParam);
@@ -988,7 +1013,9 @@ export function renderScreen(subs, ascii, logParam) {
           selectHtml += `<option value="${option.index}" ${isSelected ? 'selected' : ''}>${escapeHtml(option.desc)}</option>`;
         });
         selectHtml += `</select>`;
-        fullHtml = escapeHtml(s.statement || '').replace(/%(-)?(\d*)s/g, selectHtml) + midiBadge(s);
+        fullHtml =
+          escapeHtml(s.statement || '').replace(/%(-)?(\d*)s/g, selectHtml) +
+          midiBadge(s, midiRowByKey);
       } else if (s.type === 'CON') {
         let meterValue = parseFloat(appState.currentValues[s.key] || s.value) || 0;
         if (isNaN(meterValue)) {
@@ -1086,6 +1113,15 @@ export function renderScreen(subs, ascii, logParam) {
     // existed for label-filtered children) is retired.
     for (let local of potentialEmbedSubs) {
       const childSubs = getNode(local.key) || [];
+      // #146: the embedded child IS the preset's main param page (what the
+      // device's "parameter" key shows), so its params get badges too — DSP B's
+      // params render here when the view sits on the preset root.
+      const embedRowByKey = new Map(
+        childSubs
+          .slice(1)
+          .filter((s) => PARAM_TYPES.includes(s.type) && s.position !== 'a')
+          .map((s, i) => [s.key, i])
+      );
       if (childSubs.length > 0 && !embeddedKey) {
         embeddedKey = local.key; // Only embed the first local COL
         paramLines.push(''); // Blank line separator
@@ -1106,7 +1142,8 @@ export function renderScreen(subs, ascii, logParam) {
             if (appState.currentValues[cs.key] === undefined) sendValueDump(cs.key); // empty string = confirmed-absent, do not refetch (C1 review)
             const formatStr = cs.statement || cs.tag || '';
             childFullText = formatValue(formatStr, value);
-            childFullHtml = formatValue(formatStr, value, true, cs.key);
+            childFullHtml =
+              formatValue(formatStr, value, true, cs.key) + midiBadge(cs, embedRowByKey);
           } else if (cs.type === 'INF') {
             let value = appState.currentValues[cs.key] || cs.value || '';
             if (appState.currentValues[cs.key] === undefined && !cs.value)
@@ -1143,7 +1180,9 @@ export function renderScreen(subs, ascii, logParam) {
               selectHtml += `<option value="${option.index}" ${isSelected ? 'selected' : ''}>${escapeHtml(option.desc)}</option>`;
             });
             selectHtml += `</select>`;
-            childFullHtml = escapeHtml(cs.statement || '').replace(/%(-)?(\d*)s/g, selectHtml);
+            childFullHtml =
+              escapeHtml(cs.statement || '').replace(/%(-)?(\d*)s/g, selectHtml) +
+              midiBadge(cs, embedRowByKey);
           } else if (cs.type === 'CON') {
             let meterValue = parseFloat(appState.currentValues[cs.key] || cs.value) || 0;
             if (isNaN(meterValue)) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1749,6 +1749,26 @@ body {
   color: var(--lcd-px);
   font-variant-numeric: tabular-nums;
 }
+/* Range row: the number input, its parameter-unit suffix, and a "full span"
+   shortcut, kept on one line so the unit reads as part of the value. */
+.mm-range-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.mm-range-row .mm-input {
+  width: 6em;
+}
+.mm-unit {
+  font-family: var(--legend-font);
+  font-size: 12px;
+  color: var(--legend);
+  opacity: 0.85;
+}
+.mm-btn.mm-mini {
+  padding: 3px 8px;
+  font-size: 11px;
+}
 .mm-card-foot {
   display: flex;
   gap: 8px;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1758,10 +1758,12 @@ body {
 .mm-card-foot .mm-btn:last-child {
   margin-left: auto;
 }
-/* The Learn "move your controller" prompt overlay. */
+/* The Learn "move your controller" prompt overlay. Top-level (on <body>) so a
+   modal repaint can't wipe it mid-Learn; sits above the modals (z 56). */
 .mm-learn-overlay {
-  position: absolute;
+  position: fixed;
   inset: 0;
+  z-index: 56;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1598,3 +1598,193 @@ body {
   color: var(--legend-dim);
   font-size: 12px;
 }
+
+/* MIDI mapping (#146): controllers panel + per-parameter card. Top-level
+   modals on theme tokens, same family as the preset browser. */
+.mm-modal[hidden] {
+  display: none;
+}
+.mm-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 55;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, var(--btn-edge) 78%, transparent);
+  backdrop-filter: blur(3px);
+  font-family: var(--legend-font);
+}
+.mm-panel {
+  display: flex;
+  flex-direction: column;
+  width: min(560px, 92vw);
+  max-height: 86vh;
+  background: linear-gradient(var(--btn-cap-hi), var(--btn-cap));
+  border: 1px solid var(--btn-edge);
+  border-radius: 6px;
+  box-shadow:
+    0 0 0 1px var(--panel-line),
+    0 24px 64px rgba(0, 0, 0, 0.6);
+  overflow: hidden;
+}
+.mm-card {
+  width: min(420px, 92vw);
+}
+.mm-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--panel-line);
+  background: var(--lcd-bg);
+}
+.mm-title {
+  flex: 1;
+  font-family: 'OrvilleLCD', ui-monospace, Consolas, monospace;
+  font-size: 16px;
+  letter-spacing: 2px;
+  color: var(--lcd-px);
+  text-shadow:
+    0 0 2px var(--lcd-px),
+    0 0 8px var(--lcd-glow);
+}
+.mm-close {
+  padding: 4px 9px;
+  font-size: 14px;
+  line-height: 1;
+  color: var(--legend);
+  background: linear-gradient(var(--btn-cap-hi), var(--btn-cap));
+  border: 1px solid var(--btn-edge);
+  border-radius: 3px;
+  cursor: pointer;
+}
+.mm-close:hover {
+  color: var(--lcd-px);
+}
+.mm-note {
+  padding: 8px 16px;
+  font-size: 11px;
+  color: var(--legend-dim);
+  border-bottom: 1px solid color-mix(in srgb, var(--panel-line) 50%, transparent);
+}
+.mm-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  overflow-y: auto;
+}
+.mm-row {
+  display: grid;
+  grid-template-columns: 64px 1fr auto auto;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 16px;
+  border-bottom: 1px solid color-mix(in srgb, var(--panel-line) 50%, transparent);
+  font-size: 13px;
+  color: var(--legend);
+}
+.mm-row-label {
+  color: var(--legend-dim);
+}
+.mm-row-src {
+  color: var(--lcd-px);
+}
+.mm-row-mon {
+  color: var(--legend-dim);
+  font-variant-numeric: tabular-nums;
+}
+.mm-row-actions {
+  display: flex;
+  gap: 6px;
+}
+.mm-btn {
+  padding: 4px 10px;
+  font-family: var(--legend-font);
+  font-size: 11px;
+  color: var(--legend);
+  background: linear-gradient(var(--btn-cap-hi), var(--btn-cap));
+  border: 1px solid var(--btn-edge);
+  border-radius: 3px;
+  cursor: pointer;
+}
+.mm-btn:hover:not(:disabled) {
+  color: var(--lcd-px);
+  border-color: var(--lcd-px-dim);
+}
+.mm-btn:disabled {
+  color: var(--legend-dim);
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.mm-learn {
+  color: var(--lcd-px);
+}
+.mm-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px;
+}
+.mm-field {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  align-items: center;
+  gap: 12px;
+}
+.mm-field-label {
+  color: var(--legend-dim);
+  font-size: 12px;
+}
+.mm-input {
+  padding: 5px 9px;
+  font-family: var(--legend-font);
+  font-size: 13px;
+  color: var(--legend);
+  background: color-mix(in srgb, var(--lcd-bg) 70%, var(--btn-cap));
+  border: 1px solid var(--panel-line);
+  border-radius: 3px;
+}
+.mm-mon {
+  color: var(--lcd-px);
+  font-variant-numeric: tabular-nums;
+}
+.mm-card-foot {
+  display: flex;
+  gap: 8px;
+  padding: 12px 16px;
+  border-top: 1px solid var(--panel-line);
+}
+.mm-card-foot .mm-btn:last-child {
+  margin-left: auto;
+}
+/* The Learn "move your controller" prompt overlay. */
+.mm-learn-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  padding: 24px;
+  text-align: center;
+  background: color-mix(in srgb, var(--lcd-bg) 92%, transparent);
+  color: var(--lcd-px);
+  text-shadow: 0 0 6px var(--lcd-glow);
+}
+/* The per-parameter MIDI badge the renderer adds to editable params. */
+.lcd-midi-badge {
+  margin-left: 6px;
+  padding: 0 4px;
+  font-size: 9px;
+  letter-spacing: 1px;
+  color: var(--lcd-bg);
+  background: var(--lcd-px-dim);
+  border-radius: 2px;
+  cursor: pointer;
+  vertical-align: middle;
+}
+.lcd-midi-badge:hover {
+  background: var(--lcd-px);
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1790,3 +1790,11 @@ body {
 .lcd-midi-badge:hover {
   background: var(--lcd-px);
 }
+/* A mapped parameter: the badge shows its source, lit, so mapped knobs read at
+   a glance vs the dim "MIDI" affordance on unmapped ones (#146). */
+.lcd-midi-mapped {
+  color: var(--lcd-bg);
+  background: var(--lcd-px);
+  box-shadow: 0 0 5px var(--lcd-glow);
+  text-transform: none;
+}

--- a/src/sysex-commands.js
+++ b/src/sysex-commands.js
@@ -104,12 +104,9 @@ export const MOD = {
 // The per-parameter `mode` SET source list, by DECIMAL index (device-model
 // §8b). The SET's own option list is degenerate (it repeats the current value),
 // so sources MUST be set by index, not picked from the dump. Indices 4-13
-// reference the global assign/trig slots above. INDICES 0-40 ARE ENUMERATED
-// HERE (probed live 2026-06-12, logs/probe-midi-phase0.mjs); the device reports
-// 52 sources total — the higher indices (more general/CC controllers) continue
-// the standard MIDI set and are not enumerated yet (a param can still select
-// them by index once captured). Setting an out-of-list index falls back to the
-// device's name, which the echo reports.
+// reference the global assign/trig slots above; "MIDI single"/"MIDI double" are
+// a raw CC by number (the con sub-field carries the CC). All 52 indices probed
+// live (logs/probe-midi-phase0.mjs + probe-verify-batch.mjs, 2026-06-12).
 export const MOD_SOURCES = [
   'off',
   'low',
@@ -152,6 +149,17 @@ export const MOD_SOURCES = [
   'general 5',
   'general 6',
   'general 7',
+  'general 8',
+  'MIDI single', // a raw 7-bit CC by number (con sub-field = the CC number)
+  'MIDI double', // a 14-bit CC pair by number (con sub-field = the CC number)
+  'chan pressure',
+  'pitch wheel',
+  'note on',
+  'note switch',
+  'MIDI program',
+  'MIDI clock',
+  'MIDI start',
+  'MIDI stop',
 ];
 
 // First-char prefix and suffix tests on dynamically-discovered keys.

--- a/src/sysex-commands.js
+++ b/src/sysex-commands.js
@@ -103,9 +103,13 @@ export const MOD = {
 
 // The per-parameter `mode` SET source list, by DECIMAL index (device-model
 // §8b). The SET's own option list is degenerate (it repeats the current value),
-// so sources MUST be set by index, not picked from the dump. Names past 40
-// continue the standard MIDI CC set; indices 4-13 reference the global assign/
-// trig slots above. Verified live 2026-06-12 (logs/probe-midi-phase0.mjs).
+// so sources MUST be set by index, not picked from the dump. Indices 4-13
+// reference the global assign/trig slots above. INDICES 0-40 ARE ENUMERATED
+// HERE (probed live 2026-06-12, logs/probe-midi-phase0.mjs); the device reports
+// 52 sources total — the higher indices (more general/CC controllers) continue
+// the standard MIDI set and are not enumerated yet (a param can still select
+// them by index once captured). Setting an out-of-list index falls back to the
+// device's name, which the echo reports.
 export const MOD_SOURCES = [
   'off',
   'low',

--- a/src/sysex-commands.js
+++ b/src/sysex-commands.js
@@ -60,6 +60,96 @@ export const KEY = {
   LOAD_TRIGGER_B: '1002001d', // TRG that loads the selected program into DSP B
 };
 
+// MIDI modulation / remote control (#146, device-model.md §8b). The whole
+// system is ordinary userobjects — the app reads/writes them with the normal
+// OBJECTINFO/VALUE machinery (no special command, no keypress for the config).
+export const MOD = {
+  // Per-parameter modulation: a SINGLE context-bound editing surface. SELECT-
+  // hold a parameter to bind it; then these FIXED keys edit it (verified live —
+  // the same keys read 'level setup' then 't_delay setup' after each bind).
+  REMOTE_CONTROL: '10030400', // the "remote control" COL (holds the bound setup)
+  PARAM_SETUP: '10030401', // the bound "<param> setup" surface
+  MODE: '10030402', // SET: the source (set by index; see MOD_SOURCES)
+  CHANNEL: '10030403', // SET: MIDI channel (base+0..15) for a MIDI source
+  SUB2: '10030404', // SET: second sub-param (controller #, when needed)
+  MONITOR: '10030405', // CON: live source value (%)
+  CAPTURE: '10030406', // TRG: one-click MIDI learn
+  RANGE: '10030408', // NUM: modulation depth (tag 'scale')
+  TYPE: '10030409', // SET: absolute / unipolar / bipolar
+  // SETUP -> ext controllers (10010100): 8 reusable 'assign' source slots + 2
+  // 'trig' slots. Bases are NON-CONTIGUOUS (probed). Each slot's children are
+  // base + OFF_* below.
+  ASSIGN_BASES: [
+    '10010110',
+    '10010120',
+    '10010130',
+    '10010140',
+    '10010170',
+    '10010180',
+    '10010190',
+    '100101a0',
+  ],
+  TRIG_BASES: ['10010150', '10010160'],
+  OFF_MODE: 1, // base+1: mode SET (the captured source)
+  OFF_CHANNEL: 2, // base+2: channel SET
+  OFF_SUB: 3, // base+3: sub SET
+  OFF_MONITOR: 4, // base+4: monitor CON
+  OFF_CAPTURE: 5, // base+5: Capture Midi TRG
+  SEQ_OUT: '10010016', // sequence-out setting SET (0 off / 1 old / 2 new): when
+  //                      'new' the unit emits the key of any changed field
+  //                      (F0 1C 70 dev 3C <ascii key> 20 <ascii value> F7).
+  SEQ_OUT_NEW: 2, // the 'new' option index
+};
+
+// The per-parameter `mode` SET source list, by DECIMAL index (device-model
+// §8b). The SET's own option list is degenerate (it repeats the current value),
+// so sources MUST be set by index, not picked from the dump. Names past 40
+// continue the standard MIDI CC set; indices 4-13 reference the global assign/
+// trig slots above. Verified live 2026-06-12 (logs/probe-midi-phase0.mjs).
+export const MOD_SOURCES = [
+  'off',
+  'low',
+  'mid',
+  'high',
+  'assign 1',
+  'assign 2',
+  'assign 3',
+  'assign 4',
+  'assign 5',
+  'assign 6',
+  'assign 7',
+  'assign 8',
+  'trig 1',
+  'trig 2',
+  'pedal 1',
+  'pedal 2',
+  'tip 1',
+  'ring 1',
+  'tip & ring 1',
+  'tip 2',
+  'ring 2',
+  'tip & ring 2',
+  'mod wheel',
+  'breath con',
+  'foot con',
+  'damper',
+  'portamento',
+  'sostenuto',
+  'soft',
+  'hold 2',
+  'volume',
+  'balance',
+  'pan',
+  'expression',
+  'general 1',
+  'general 2',
+  'general 3',
+  'general 4',
+  'general 5',
+  'general 6',
+  'general 7',
+];
+
 // First-char prefix and suffix tests on dynamically-discovered keys.
 export const KEY_PREFIX = {
   DSP_A: '4', // keys under DSP A start with '4'

--- a/tests/midi-map-ui.test.js
+++ b/tests/midi-map-ui.test.js
@@ -54,15 +54,23 @@ import {
   captureParam,
 } from '../src/midi-map.js';
 
+import { MIDI_MAP } from '../src/constants.js';
+
 const q = (sel) => document.querySelector(sel);
 const qa = (sel) => [...document.querySelectorAll(sel)];
 
 describe('midi-map-ui', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.useFakeTimers(); // the Learn poll + repaint use setTimeout
     document.body.innerHTML = '';
     resetMidiMapUI();
     setupMidiMapUI({ onChange: jest.fn() });
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
   });
 
   describe('controllers panel', () => {
@@ -79,9 +87,21 @@ describe('midi-map-ui', () => {
       q('.mm-row .mm-learn').click();
       expect(captureAssign).toHaveBeenCalledWith(0, expect.any(Function));
       expect(q('.mm-learn-overlay')).toBeTruthy();
-      // Done dismisses the prompt.
+      expect(q('.mm-learn-msg').textContent).toMatch(/move your controller/i);
+      // Cancel dismisses the prompt.
       q('.mm-learn-overlay .mm-learn').click();
       expect(q('.mm-learn-overlay')).toBeNull();
+    });
+
+    test('Learn polls the device and shows the captured source (live feedback)', () => {
+      openControllers(); // mock readAssign(0).source === 'volume'
+      q('.mm-row .mm-learn').click();
+      expect(q('.mm-learn-msg').textContent).toMatch(/move your controller/i);
+      // One poll cycle later, the device reports a captured source.
+      jest.advanceTimersByTime(MIDI_MAP.UI_REFRESH_MS + 20);
+      expect(q('.mm-learn-msg').textContent).toMatch(/captured: volume/i);
+      // and the button becomes Done.
+      expect(q('.mm-learn-overlay .mm-learn').textContent).toBe('Done');
     });
 
     test('clear clears the assign source', () => {

--- a/tests/midi-map-ui.test.js
+++ b/tests/midi-map-ui.test.js
@@ -1,0 +1,149 @@
+// tests/midi-map-ui.test.js
+// The MIDI-mapping UI (#146): the controllers panel + per-parameter card.
+// Device I/O is mocked at the midi-map.js boundary — this pins the modal
+// rendering and that edits route to clean object writes (no keypress beyond
+// the bind).
+
+jest.mock('../src/midi-map.js', () => ({
+  enableSequenceOut: jest.fn(),
+  readAssign: jest.fn((i) => ({ index: i, source: i === 0 ? 'volume' : 'off', monitor: '50' })),
+  refreshAssign: jest.fn(),
+  captureAssign: jest.fn((i, onDone) => onDone?.()),
+  clearAssign: jest.fn(),
+  bindParam: jest.fn((row, onDone) =>
+    onDone?.({
+      title: 'level setup',
+      source: 'off',
+      range: '100',
+      type: '0 absolute',
+      monitor: '0',
+    })
+  ),
+  readParamSetup: jest.fn(() => ({
+    title: 'level setup',
+    source: 'off',
+    range: '100',
+    type: '0 absolute',
+    monitor: '0',
+  })),
+  refreshParamSetup: jest.fn(),
+  setParamSource: jest.fn(),
+  setParamRange: jest.fn(),
+  setParamType: jest.fn(),
+  captureParam: jest.fn((onDone) => onDone?.()),
+  sourceOptions: jest.fn(() => [
+    { index: 0, name: 'off' },
+    { index: 30, name: 'volume' },
+  ]),
+}));
+
+import {
+  setupMidiMapUI,
+  openControllers,
+  closeControllers,
+  openParamMapping,
+  resetMidiMapUI,
+} from '../src/midi-map-ui.js';
+import {
+  enableSequenceOut,
+  captureAssign,
+  clearAssign,
+  bindParam,
+  setParamSource,
+  setParamRange,
+  captureParam,
+} from '../src/midi-map.js';
+
+const q = (sel) => document.querySelector(sel);
+const qa = (sel) => [...document.querySelectorAll(sel)];
+
+describe('midi-map-ui', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML = '';
+    resetMidiMapUI();
+    setupMidiMapUI({ onChange: jest.fn() });
+  });
+
+  describe('controllers panel', () => {
+    test('renders 8 assign rows and turns on sequence-out', () => {
+      openControllers();
+      expect(enableSequenceOut).toHaveBeenCalled();
+      expect(qa('.mm-row')).toHaveLength(8);
+      // assign 1 shows its captured source.
+      expect(q('.mm-row .mm-row-src').textContent).toBe('volume');
+    });
+
+    test('Learn arms Capture and shows the "move your controller" prompt', () => {
+      openControllers();
+      q('.mm-row .mm-learn').click();
+      expect(captureAssign).toHaveBeenCalledWith(0, expect.any(Function));
+      expect(q('.mm-learn-overlay')).toBeTruthy();
+      // Done dismisses the prompt.
+      q('.mm-learn-overlay .mm-learn').click();
+      expect(q('.mm-learn-overlay')).toBeNull();
+    });
+
+    test('clear clears the assign source', () => {
+      openControllers();
+      const clearBtn = qa('.mm-row .mm-btn').find((b) => b.textContent === 'clear');
+      clearBtn.click();
+      expect(clearAssign).toHaveBeenCalledWith(0);
+    });
+
+    test('close hides the panel', () => {
+      openControllers();
+      closeControllers();
+      expect(q('.mm-modal').hidden).toBe(true);
+    });
+  });
+
+  describe('per-parameter card', () => {
+    test('binds the surface then renders source / range / type from the bound setup', () => {
+      openParamMapping({ name: 'level  : %4.0f dB', rowIndex: 0 });
+      expect(bindParam).toHaveBeenCalledWith(0, expect.any(Function));
+      // The card shows the editable fields (bind succeeded — title matched).
+      expect(q('.mm-card')).toBeTruthy();
+      expect(qa('.mm-field')).toHaveLength(4); // source, range, type, monitor
+      expect(q('.mm-title').textContent).toContain('LEVEL');
+    });
+
+    test('changing the source writes it by index (clean object PUT)', () => {
+      openParamMapping({ name: 'level  : %4.0f dB', rowIndex: 0 });
+      const sourceSel = q('.mm-card-body select');
+      sourceSel.value = '30'; // volume / CC7
+      sourceSel.dispatchEvent(new Event('change', { bubbles: true }));
+      expect(setParamSource).toHaveBeenCalledWith(30);
+    });
+
+    test('changing the range writes it', () => {
+      openParamMapping({ name: 'level  : %4.0f dB', rowIndex: 0 });
+      const range = q('.mm-card-body input[type="number"]');
+      range.value = '50';
+      range.dispatchEvent(new Event('change', { bubbles: true }));
+      expect(setParamRange).toHaveBeenCalledWith('50');
+    });
+
+    test('Learn on the card arms Capture for the bound param', () => {
+      openParamMapping({ name: 'level  : %4.0f dB', rowIndex: 0 });
+      q('.mm-card-foot .mm-learn').click();
+      expect(captureParam).toHaveBeenCalled();
+    });
+
+    test('a bind whose title does NOT match the param aborts with an error (no mis-write)', () => {
+      bindParam.mockImplementationOnce((row, onDone) => onDone({ title: 'something else' }));
+      openParamMapping({ name: 'level  : %4.0f dB', rowIndex: 0 });
+      // No editable fields; an error + Close instead.
+      expect(qa('.mm-field')).toHaveLength(0);
+      expect(q('.mm-card .mm-note').textContent).toMatch(/could not bind/i);
+    });
+  });
+
+  test('resetMidiMapUI removes both modals', () => {
+    openControllers();
+    openParamMapping({ name: 'level  : %4.0f dB', rowIndex: 0 });
+    expect(qa('.mm-modal').length).toBeGreaterThan(0);
+    resetMidiMapUI();
+    expect(qa('.mm-modal')).toHaveLength(0);
+  });
+});

--- a/tests/midi-map-ui.test.js
+++ b/tests/midi-map-ui.test.js
@@ -35,6 +35,7 @@ jest.mock('../src/midi-map.js', () => ({
     { index: 0, name: 'off' },
     { index: 30, name: 'volume' },
   ]),
+  rangeForSpan: jest.fn((d) => Math.round(d)),
   recordParamMapping: jest.fn(),
   resetParamMappings: jest.fn(),
 }));

--- a/tests/midi-map-ui.test.js
+++ b/tests/midi-map-ui.test.js
@@ -35,6 +35,8 @@ jest.mock('../src/midi-map.js', () => ({
     { index: 0, name: 'off' },
     { index: 30, name: 'volume' },
   ]),
+  recordParamMapping: jest.fn(),
+  resetParamMappings: jest.fn(),
 }));
 
 import {

--- a/tests/midi-map.test.js
+++ b/tests/midi-map.test.js
@@ -62,6 +62,7 @@ import {
 import { sendValuePut, sendObjectInfoDump, sendValueDump, sendKeypress } from '../src/midi.js';
 import { getNode } from '../src/tree.js';
 import { bindParam } from '../src/midi-map.js';
+import { emit } from '../src/events.js';
 
 beforeEach(() => jest.clearAllMocks());
 
@@ -186,6 +187,12 @@ describe('param mapping state (the LCD "mapped" badge, #146)', () => {
     recordParamMapping('4060001', 'volume');
     resetParamMappings();
     expect(paramMappingOf('4060001')).toBeNull();
+  });
+
+  test('a program:loaded event clears the badges (stale after a load, review)', () => {
+    recordParamMapping('4050001', 'pan');
+    emit('program:loaded', { dspSlot: 'A' });
+    expect(paramMappingOf('4050001')).toBeNull();
   });
 });
 

--- a/tests/midi-map.test.js
+++ b/tests/midi-map.test.js
@@ -1,0 +1,151 @@
+// tests/midi-map.test.js
+// Device-native MIDI mapping (#146): the clean VALUE_PUT/OBJECTINFO operations
+// on the global assigns and the per-parameter modulation surface. Pins the key
+// math, the source table, and that config is plain object writes (no keypress).
+
+jest.mock('../src/midi.js', () => ({
+  sendValuePut: jest.fn(),
+  sendObjectInfoDump: jest.fn(),
+  sendValueDump: jest.fn(),
+}));
+
+jest.mock('../src/tree.js', () => ({
+  getNode: jest.fn(),
+}));
+
+jest.mock('../src/constants.js', () => {
+  const actual = jest.requireActual('../src/constants.js');
+  return { ...actual, MIDI_MAP: { CAPTURE_SETTLE_MS: 1, WRITE_SETTLE_MS: 1 } };
+});
+
+import {
+  childKey,
+  sourceName,
+  sourceIndex,
+  sourceOptions,
+  enableSequenceOut,
+  assignSlot,
+  readAssign,
+  refreshAssign,
+  captureAssign,
+  clearAssign,
+  setParamSource,
+  setParamRange,
+  setParamType,
+  captureParam,
+  readParamSetup,
+  rangeForSpan,
+} from '../src/midi-map.js';
+import { sendValuePut, sendObjectInfoDump, sendValueDump } from '../src/midi.js';
+import { getNode } from '../src/tree.js';
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('source table + key math', () => {
+  test('childKey does hex addition on the base', () => {
+    expect(childKey('10010110', 1)).toBe('10010111');
+    expect(childKey('10010110', 5)).toBe('10010115');
+    expect(childKey('100101a0', 5)).toBe('100101a5'); // carries within the nibble
+  });
+
+  test('sourceName / sourceIndex map the documented list', () => {
+    expect(sourceName(0)).toBe('off');
+    expect(sourceName(4)).toBe('assign 1');
+    expect(sourceName(30)).toBe('volume'); // CC7
+    expect(sourceIndex('volume')).toBe(30);
+    expect(sourceIndex('assign 3')).toBe(6);
+  });
+
+  test('sourceOptions yields { index, name } pairs', () => {
+    const opts = sourceOptions();
+    expect(opts[0]).toEqual({ index: 0, name: 'off' });
+    expect(opts.find((o) => o.name === 'pan')).toEqual({ index: 32, name: 'pan' });
+  });
+
+  test('rangeForSpan rounds the desired delta', () => {
+    expect(rangeForSpan(12.4)).toBe(12);
+  });
+});
+
+describe('global assign controllers', () => {
+  test('assignSlot computes the non-contiguous slot keys', () => {
+    expect(assignSlot(0)).toMatchObject({
+      base: '10010110',
+      mode: '10010111',
+      channel: '10010112',
+      monitor: '10010114',
+      capture: '10010115',
+    });
+    // slot 5 base is 10010180 (the bases are not contiguous)
+    expect(assignSlot(5).base).toBe('10010180');
+    expect(assignSlot(5).capture).toBe('10010185');
+  });
+
+  test('readAssign pulls source/channel/monitor from the tree', () => {
+    getNode.mockReturnValue([
+      { key: '10010110', type: 'COL', statement: 'assign 1 setup' },
+      { key: '10010111', value: '1e volume' },
+      { key: '10010112', value: '0 base + 0' },
+      { key: '10010114', value: '62.5' },
+    ]);
+    expect(readAssign(0)).toEqual({
+      index: 0,
+      source: 'volume',
+      channel: '0 base + 0',
+      monitor: '62.5',
+    });
+  });
+
+  test('captureAssign arms the slot Capture TRG; clearAssign sets mode off', async () => {
+    await captureAssign(2, () => {});
+    expect(sendValuePut).toHaveBeenCalledWith('10010135', '1'); // assign 3 capture
+    clearAssign(2);
+    expect(sendValuePut).toHaveBeenCalledWith('10010131', '0'); // assign 3 mode off
+  });
+
+  test('refreshAssign re-fetches the slot subtree', () => {
+    refreshAssign(0);
+    expect(sendObjectInfoDump).toHaveBeenCalledWith('10010110');
+    expect(sendValueDump).toHaveBeenCalledWith('10010110');
+  });
+});
+
+describe('per-parameter modulation (bound surface)', () => {
+  test('source/range/type are plain VALUE_PUTs to the fixed surface keys', () => {
+    setParamSource(30); // volume / CC7
+    setParamRange(100);
+    setParamType(2); // bipolar
+    expect(sendValuePut.mock.calls).toEqual([
+      ['10030402', '30'],
+      ['10030408', '100'],
+      ['10030409', '2'],
+    ]);
+  });
+
+  test('captureParam arms the surface Capture TRG', async () => {
+    await captureParam(() => {});
+    expect(sendValuePut).toHaveBeenCalledWith('10030406', '1');
+  });
+
+  test('readParamSetup reflects the bound param (title proves the binding)', () => {
+    getNode.mockReturnValue([
+      { key: '10030401', type: 'COL', statement: 't_delay setup' },
+      { key: '10030402', value: '4 assign 1' },
+      { key: '10030408', value: '100' },
+      { key: '10030409', value: '0 absolute' },
+      { key: '10030405', value: '50.0' },
+    ]);
+    expect(readParamSetup()).toMatchObject({
+      title: 't_delay setup',
+      source: 'assign 1',
+      range: '100',
+      type: '0 absolute',
+      monitor: '50.0',
+    });
+  });
+});
+
+test('enableSequenceOut sets the setup toggle to new', () => {
+  enableSequenceOut();
+  expect(sendValuePut).toHaveBeenCalledWith('10010016', '2');
+});

--- a/tests/midi-map.test.js
+++ b/tests/midi-map.test.js
@@ -27,7 +27,14 @@ jest.mock('../src/constants.js', () => {
   const actual = jest.requireActual('../src/constants.js');
   return {
     ...actual,
-    MIDI_MAP: { CAPTURE_SETTLE_MS: 1, WRITE_SETTLE_MS: 1, BIND_STEP_MS: 1, BIND_SETTLE_MS: 1 },
+    MIDI_MAP: {
+      CAPTURE_SETTLE_MS: 1,
+      UI_REFRESH_MS: 1,
+      BIND_STEP_MS: 1,
+      BIND_SETTLE_MS: 1,
+      BIND_READ_TRIES: 4,
+      LEARN_POLL_TRIES: 3,
+    },
   };
 });
 

--- a/tests/midi-map.test.js
+++ b/tests/midi-map.test.js
@@ -63,6 +63,7 @@ import { sendValuePut, sendObjectInfoDump, sendValueDump, sendKeypress } from '.
 import { getNode } from '../src/tree.js';
 import { bindParam } from '../src/midi-map.js';
 import { emit } from '../src/events.js';
+import { appState } from '../src/state.js';
 
 beforeEach(() => jest.clearAllMocks());
 
@@ -168,6 +169,32 @@ describe('per-parameter modulation (bound surface)', () => {
       monitor: '50.0',
     });
   });
+
+  test('readParamSetup surfaces the bound parameter span + unit (range context)', () => {
+    getNode.mockReturnValue([
+      { key: '10030401', type: 'COL', statement: 'level setup' },
+      { key: '10030402', value: '0 off' },
+      // the range NUM itself — must NOT be mistaken for the value mirror
+      {
+        key: '10030408',
+        type: 'NUM',
+        statement: 'range: +%4.0f dB',
+        value: '200',
+        min: '-32767',
+        max: '32767',
+      },
+      // the bound parameter's value mirror: its unit + full span live here
+      {
+        key: '50001',
+        type: 'NUM',
+        statement: 'level : %4.0f dB',
+        value: '-12',
+        min: '-100',
+        max: '0',
+      },
+    ]);
+    expect(readParamSetup().param).toEqual({ unit: 'dB', min: -100, max: 0, span: 100 });
+  });
 });
 
 test('enableSequenceOut sets the setup toggle to new', () => {
@@ -176,7 +203,11 @@ test('enableSequenceOut sets the setup toggle to new', () => {
 });
 
 describe('param mapping state (the LCD "mapped" badge, #146)', () => {
-  beforeEach(() => resetParamMappings());
+  beforeEach(() => {
+    appState.dspAName = '';
+    appState.dspBName = '';
+    resetParamMappings();
+  });
 
   test('record / read / off-clears / reset', () => {
     expect(paramMappingOf('4050001')).toBeNull();
@@ -189,10 +220,28 @@ describe('param mapping state (the LCD "mapped" badge, #146)', () => {
     expect(paramMappingOf('4060001')).toBeNull();
   });
 
-  test('a program:loaded event clears the badges (stale after a load, review)', () => {
+  test('scoped by program: a slot program change hides the old badge, each sticks', () => {
+    appState.dspAName = 'MonoDelay';
+    recordParamMapping('4050001', 'pan');
+    expect(paramMappingOf('4050001')).toBe('pan');
+    // a different program in the same slot -> its own set; no stale 'pan'
+    appState.dspAName = '1x4 Delay';
+    expect(paramMappingOf('4050001')).toBeNull();
+    // back to the mapped program -> the badge returns (stuck through the switch)
+    appState.dspAName = 'MonoDelay';
+    expect(paramMappingOf('4050001')).toBe('pan');
+  });
+
+  test('persists to midiConfig so a reload restores it', () => {
+    recordParamMapping('4050001', 'pan'); // dspAName '' -> slot fallback '4'
+    const stored = JSON.parse(localStorage.getItem('midiConfig')).midiMappings;
+    expect(stored['4']['4050001']).toBe('pan');
+  });
+
+  test('a program:loaded event no longer clears the badges (program-scoped + persisted)', () => {
     recordParamMapping('4050001', 'pan');
     emit('program:loaded', { dspSlot: 'A' });
-    expect(paramMappingOf('4050001')).toBeNull();
+    expect(paramMappingOf('4050001')).toBe('pan'); // sticks through the load
   });
 });
 

--- a/tests/midi-map.test.js
+++ b/tests/midi-map.test.js
@@ -55,6 +55,9 @@ import {
   captureParam,
   readParamSetup,
   rangeForSpan,
+  recordParamMapping,
+  paramMappingOf,
+  resetParamMappings,
 } from '../src/midi-map.js';
 import { sendValuePut, sendObjectInfoDump, sendValueDump, sendKeypress } from '../src/midi.js';
 import { getNode } from '../src/tree.js';
@@ -109,7 +112,7 @@ describe('global assign controllers', () => {
       { key: '10010112', value: '0 base + 0' },
       { key: '10010114', value: '62.5' },
     ]);
-    expect(readAssign(0)).toEqual({
+    expect(readAssign(0)).toMatchObject({
       index: 0,
       source: 'volume',
       channel: '0 base + 0',
@@ -169,6 +172,37 @@ describe('per-parameter modulation (bound surface)', () => {
 test('enableSequenceOut sets the setup toggle to new', () => {
   enableSequenceOut();
   expect(sendValuePut).toHaveBeenCalledWith('10010016', '2');
+});
+
+describe('param mapping state (the LCD "mapped" badge, #146)', () => {
+  beforeEach(() => resetParamMappings());
+
+  test('record / read / off-clears / reset', () => {
+    expect(paramMappingOf('4050001')).toBeNull();
+    recordParamMapping('4050001', 'pan');
+    expect(paramMappingOf('4050001')).toBe('pan');
+    recordParamMapping('4050001', 'off'); // off (or empty) un-marks it
+    expect(paramMappingOf('4050001')).toBeNull();
+    recordParamMapping('4060001', 'volume');
+    resetParamMappings();
+    expect(paramMappingOf('4060001')).toBeNull();
+  });
+});
+
+test('readParamSetup surfaces the con# (CC number) for MIDI single/double', () => {
+  getNode.mockReturnValue([
+    { key: '10030401', type: 'COL', statement: 'level setup' },
+    { key: '10030402', value: '1f midi double' },
+    { key: '10030403', statement: 'channel: %-11s', tag: 'channel', value: '0 base + 0' },
+    { key: '10030404', statement: 'con: %2.0f', tag: 'con', value: '42' },
+  ]);
+  const s = readParamSetup();
+  expect(s.source).toBe('midi double');
+  // the channel + the actual CC number, presentable.
+  expect(s.details).toEqual([
+    { label: 'channel', value: 'base + 0' },
+    { label: 'con', value: '42' },
+  ]);
 });
 
 describe('bindParam (the one keypress step)', () => {

--- a/tests/midi-map.test.js
+++ b/tests/midi-map.test.js
@@ -195,6 +195,29 @@ describe('per-parameter modulation (bound surface)', () => {
     ]);
     expect(readParamSetup().param).toEqual({ unit: 'dB', min: -100, max: 0, span: 100 });
   });
+
+  test('readParamSetup collapses the printf %% escape to a single % unit', () => {
+    getNode.mockReturnValue([
+      { key: '10030401', type: 'COL', statement: 'size setup' },
+      {
+        key: '10030408',
+        type: 'NUM',
+        statement: 'range: +%4.0f %%',
+        value: '50',
+        min: '-100',
+        max: '100',
+      },
+      {
+        key: '50001',
+        type: 'NUM',
+        statement: 'size/decay: %3.0f %%',
+        value: '70',
+        min: '0',
+        max: '100',
+      },
+    ]);
+    expect(readParamSetup().param).toEqual({ unit: '%', min: 0, max: 100, span: 100 });
+  });
 });
 
 test('enableSequenceOut sets the setup toggle to new', () => {

--- a/tests/midi-map.test.js
+++ b/tests/midi-map.test.js
@@ -7,6 +7,16 @@ jest.mock('../src/midi.js', () => ({
   sendValuePut: jest.fn(),
   sendObjectInfoDump: jest.fn(),
   sendValueDump: jest.fn(),
+  sendKeypress: jest.fn(),
+}));
+
+jest.mock('../src/controls.js', () => ({
+  keypressMasks: {
+    program: ['program'],
+    parameter: ['parameter'],
+    down: ['down'],
+    'select-hold': ['select-hold'],
+  },
 }));
 
 jest.mock('../src/tree.js', () => ({
@@ -15,7 +25,10 @@ jest.mock('../src/tree.js', () => ({
 
 jest.mock('../src/constants.js', () => {
   const actual = jest.requireActual('../src/constants.js');
-  return { ...actual, MIDI_MAP: { CAPTURE_SETTLE_MS: 1, WRITE_SETTLE_MS: 1 } };
+  return {
+    ...actual,
+    MIDI_MAP: { CAPTURE_SETTLE_MS: 1, WRITE_SETTLE_MS: 1, BIND_STEP_MS: 1, BIND_SETTLE_MS: 1 },
+  };
 });
 
 import {
@@ -36,8 +49,9 @@ import {
   readParamSetup,
   rangeForSpan,
 } from '../src/midi-map.js';
-import { sendValuePut, sendObjectInfoDump, sendValueDump } from '../src/midi.js';
+import { sendValuePut, sendObjectInfoDump, sendValueDump, sendKeypress } from '../src/midi.js';
 import { getNode } from '../src/tree.js';
+import { bindParam } from '../src/midi-map.js';
 
 beforeEach(() => jest.clearAllMocks());
 
@@ -148,4 +162,34 @@ describe('per-parameter modulation (bound surface)', () => {
 test('enableSequenceOut sets the setup toggle to new', () => {
   enableSequenceOut();
   expect(sendValuePut).toHaveBeenCalledWith('10010016', '2');
+});
+
+describe('bindParam (the one keypress step)', () => {
+  test('drives program->parameter->DOWN x row->select-hold, then reads the surface', async () => {
+    getNode.mockReturnValue([
+      { key: '10030401', type: 'COL', statement: 't_delay setup' },
+      { key: '10030402', value: '0 off' },
+    ]);
+    let result;
+    await bindParam(1, (s) => (result = s)); // row 1 = second param
+    expect(sendKeypress.mock.calls.map((c) => c[0])).toEqual([
+      ['program'],
+      ['parameter'],
+      ['down'], // one DOWN for row index 1
+      ['select-hold'],
+    ]);
+    // The surface is read back; its title is the binding proof.
+    expect(result.title).toBe('t_delay setup');
+    expect(sendObjectInfoDump).toHaveBeenCalledWith('10030401');
+  });
+
+  test('row 0 binds with no DOWN presses', async () => {
+    getNode.mockReturnValue([{ key: '10030401', type: 'COL', statement: 'level setup' }]);
+    await bindParam(0);
+    expect(sendKeypress.mock.calls.map((c) => c[0])).toEqual([
+      ['program'],
+      ['parameter'],
+      ['select-hold'],
+    ]);
+  });
 });

--- a/tests/renderer.test.js
+++ b/tests/renderer.test.js
@@ -1,6 +1,13 @@
 import { renderScreen } from '../src/renderer.js';
 import { appState } from '../src/state.js';
-import { sendObjectInfoDump, sendValueDump, sendValuePut, sendSysEx } from '../src/midi.js';
+import {
+  sendObjectInfoDump,
+  sendValueDump,
+  sendValuePut,
+  sendSysEx,
+  sendKeypress,
+} from '../src/midi.js';
+import { recordParamMapping, resetParamMappings } from '../src/midi-map.js';
 import { showLoading } from '../src/main.js';
 import { log as mockLog } from '../src/logger.js';
 import { recordDump, reset as treeReset } from '../src/tree.js';
@@ -12,10 +19,11 @@ jest.mock('../src/midi.js', () => ({
   sendValueDump: jest.fn(),
   sendValuePut: jest.fn(),
   sendSysEx: jest.fn(),
+  sendKeypress: jest.fn(),
 }));
 
 jest.mock('../src/controls.js', () => ({
-  keypressMasks: { enter: [0xff, 0xff, 0xff, 0xef] },
+  keypressMasks: { enter: [0xff, 0xff, 0xff, 0xef], ab: [0xfd, 0xff, 0xfd, 0xff] },
 }));
 
 jest.mock('../src/main.js', () => ({
@@ -1850,5 +1858,38 @@ describe('renderer.js', () => {
     // T1b: ancestry derived from the tree — root is the preset's parent.
     expect(appState.keyStack.map((e) => e.key)).toEqual(['0']);
     expect(sendObjectInfoDump).toHaveBeenCalledWith('801000b', null);
+    // #146: the view switch also presses the device A/B so the unit follows,
+    // keeping a MIDI-map bind on the right DSP.
+    expect(sendKeypress).toHaveBeenCalledWith([0xfd, 0xff, 0xfd, 0xff]); // keypressMasks.ab
+  });
+
+  test('a mapped DSP param shows its source lit on the badge (#146)', () => {
+    resetParamMappings();
+    recordParamMapping('4070001', 'pan'); // app has mapped this knob
+    appState.currentKey = '401000b';
+    const subs = [
+      {
+        type: 'COL',
+        position: '0',
+        key: '401000b',
+        parent: '401000b',
+        statement: 'Black Hole',
+        tag: '',
+      },
+      {
+        type: 'NUM',
+        position: '0',
+        key: '4070001',
+        parent: '401000b',
+        statement: 'diff/time : %3.0f %%',
+        tag: '',
+        value: '50',
+      },
+    ];
+    renderScreen(subs, '', mockLog);
+    const badge = document.querySelector('.lcd-midi-badge');
+    expect(badge.classList.contains('lcd-midi-mapped')).toBe(true);
+    expect(badge.textContent).toBe('pan'); // mapped source shown, not "MIDI"
+    resetParamMappings();
   });
 });

--- a/tests/renderer.test.js
+++ b/tests/renderer.test.js
@@ -26,6 +26,12 @@ jest.mock('../src/logger.js', () => ({
   log: jest.fn(),
 }));
 
+jest.mock('../src/midi-map-ui.js', () => ({
+  openParamMapping: jest.fn(),
+}));
+
+import { openParamMapping } from '../src/midi-map-ui.js';
+
 describe('renderer.js', () => {
   let consoleLogSpy;
 
@@ -370,6 +376,71 @@ describe('renderer.js', () => {
     const progSel = document.querySelector('select[data-key="10020011"]');
     expect([...progSel.options].map((o) => o.text)).toEqual(['0 Mono Delay', '1 PingPong']);
     expect(document.getElementById('lcd').textContent).toContain('sync to browse all banks');
+  });
+
+  test('a DSP preset NUM gets a MIDI badge that opens the mapping card (#146)', () => {
+    appState.currentKey = '401000b';
+    const subs = [
+      {
+        type: 'COL',
+        position: '0',
+        key: '401000b',
+        parent: '401000b',
+        statement: 'Black Hole',
+        tag: '',
+      },
+      {
+        type: 'NUM',
+        position: '0',
+        key: '4070001', // DSP A preset param
+        parent: '401000b',
+        statement: 'diff/time : %3.0f %%',
+        tag: '',
+        value: '50',
+      },
+      {
+        type: 'NUM',
+        position: '0',
+        key: '4060001',
+        parent: '401000b',
+        statement: 'size : %3.0f %%',
+        tag: '',
+        value: '50',
+      },
+    ];
+    renderScreen(subs, '', mockLog);
+    const badges = document.querySelectorAll('.lcd-midi-badge');
+    expect(badges).toHaveLength(2); // one per modulatable param
+    expect(badges[0].dataset.midiRow).toBe('0'); // first param = row 0 (no DOWN)
+    expect(badges[1].dataset.midiRow).toBe('1');
+
+    badges[1].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(openParamMapping).toHaveBeenCalledWith(expect.objectContaining({ rowIndex: 1 }));
+  });
+
+  test('non-DSP params (load menu / setup) get NO MIDI badge (#146)', () => {
+    appState.currentKey = '10010001';
+    const subs = [
+      {
+        type: 'COL',
+        position: '0',
+        key: '10010001',
+        parent: '10010001',
+        statement: 'Input',
+        tag: 'input',
+      },
+      {
+        type: 'NUM',
+        position: '0',
+        key: '10010011', // setup key, not a preset param
+        parent: '10010001',
+        statement: 'lvl %3.0f',
+        tag: '',
+        value: '5',
+      },
+    ];
+    renderScreen(subs, '', mockLog);
+    expect(document.querySelector('.lcd-midi-badge')).toBeNull();
   });
 
   // #131: progressive paints during a wave must not destroy an open SET


### PR DESCRIPTION
Closes #146
Closes #152

## What

**Device-native MIDI mapping** — map any MIDI source to any parameter, run **in the Orville's own DSP** (zero app latency, persists in the preset; the app is only a configurator, never in the runtime signal path).

The whole modulation system turned out to be ordinary addressable userobjects (after a Phase-0 investigation + internet research corrected an earlier "not addressable" conclusion). So this builds on the app's existing `OBJECTINFO`/`VALUE_PUT` machinery.

### Engine — `src/midi-map.js` (DOM-free)
- **Global assign controllers** (the 8 reusable MIDI sources): read / Capture-learn / clear.
- **Per-parameter** ops: set source (by index — `MOD_SOURCES` table), range, type, Capture.
- **`bindParam`** — the one keypress step (`program → parameter → CURSOR-DOWN ×row → select-hold`), **verified by the surface OBJECTINFO title** so a wrong row aborts rather than mis-writing.

### UI — `src/midi-map-ui.js` (two themed modals)
- **MIDI Controllers panel** (the 8 assigns; one-click Learn) — opened from a new **MIDI Map** button.
- **Per-parameter card** — opened from a **MIDI** badge the renderer adds to DSP-preset NUM/SET rows: bind → pick source / range / type / Learn, all clean object writes.

### Also
- Delivers **#152** (inbound Program Change loads — confirmed live).
- `device-model.md` §8b documents the full system; `MOD`/`MOD_SOURCES` keys + `MIDI_MAP` timings; reset hooks at both seams.

## Validation

**280/280 tests, lint + format clean.** New: `midi-map.test.js`, `midi-map-ui.test.js`, renderer badge tests (+27).

**Live, end-to-end through the shipped module** (`logs/probe-midimap-e2e.mjs`): `bindParam('level')` → `"level setup"`, set source = volume(CC7) via the module, then **CC#7 drove `level` −100 → 0 dB with the app out of the runtime path.**

Reviewed (correctness + docs); **no blockers**. Fixes applied: tightened the bind title-guard to a full-token match (a short name like `"in"` must not match `"input gain setup"`), named the UI settle constant (`MIDI_MAP.UI_REFRESH_MS`), and reconciled the source-count / `type`-label docs.

## Known follow-ups (documented, not blocking)
- `bindParam` reaches parameters on a preset's **main param page**; deeply-nested sub-page params need extra navigation (the badge safely reports "could not bind" off the main page).
- The `mode` source table enumerates indices 0–40; the device reports 52 (higher indices set by index still work).

## Note
Base is `feat/preset-browser-153-135` (PR #156), which this is stacked on. Per-parameter mappings are per-program by nature (saved in the preset); the 8 controllers are global (set once) — a future copy/snapshot helper could cut repetitive per-program setup.
