### PR TITLE
fix: MIDI mapping on sub-block params + sequence-out polling starvation (#146 follow-ups)

### DIFF
--- a/docs/device-model.md
+++ b/docs/device-model.md
@@ -438,9 +438,34 @@ foot = CC4, volume = CC7, pan = CC10, expression = CC11, general 1-8 = CC16-23).
 `VALUE_PUT(10030402, 3)` over SysEx flipped the mode `low -> high` and the bound
 parameter moved in response — no keypress needed for the config. The one
 UI-driven step is **binding**: drive the device cursor onto the target parameter
-(`program`->`parameter`->`CURSOR-DOWN`×n, masks in `system_commands.txt`) then
-SELECT-hold, verified by the screen title `<param> setup`. After binding, all
-config is `VALUE_PUT` to the fixed keys above.
+then SELECT-hold, verified by the screen title `<param> setup`. After binding,
+all config is `VALUE_PUT` to the fixed keys above.
+
+**Navigation to any parameter (generic, probed live 2026-06-12 on `Horrors`,
+`logs/probe-reverb-nav*.mjs`).** A program's params are grouped into **blocks**
+— the preset's COL children (e.g. `Horrors` `401000b` -> `pitch`/`chorus`/
+`reverb`/`info`). The parameter area shows ONE block at a time:
+
+- **Block select / paging.** The bottom **softkeys** `soft1..soft4` select
+  blocks 0..3 (dump order). Pressing a block's softkey selects it at **page 0**;
+  pressing the *same* softkey again advances **one page** (cursor resets to the
+  page's top-left each press). So block `b`, page `p` = `soft(b+1)` pressed
+  `p+1` times. (`program`->`parameter` lands on block 0 page 0.)
+- **Within a page: a 4-row × 2-column grid, column-major, in dump order.**
+  `DOWN` walks a column (clamps at row 3); `RIGHT` moves to the next column
+  (clamps at col 1 — a third column is the next *page*, not a `RIGHT`). So the
+  on-screen page holds 8 params; param `i` within a block sits at
+  `page = floor(i/8)`, `col = floor((i%8)/4)`, `row = (i%8)%4`.
+- **Device cursor order == OBJECTINFO dump order**, so a param's index in its
+  block's dump IS its navigation index. Full recipe (live-verified 5/5 across
+  blocks + both reverb pages, `probe-midimap-subblock.mjs`):
+  `program -> parameter -> soft(b+1)×(page+1) -> RIGHT×col -> DOWN×row ->
+  SELECT-hold`, then read `10030401`'s title as the bind proof.
+
+This is what `midi-map.js bindParam` does, deriving `b`/`i` from the loaded
+tree (`paramCoords`), so it works for any program — not the legacy flat
+`CURSOR-DOWN×row` model, which only reached block 0 page 0 and mis-bound every
+sub-block param (it walked block 0 and hit whatever sat at that row).
 
 **`sequence out`** (`10010016`, options off/old/new): set to `new`, the unit
 EMITS the key of any field changed — `F0 1C 70 <dev> 3C <ascii-hex key> 20

--- a/src/constants.js
+++ b/src/constants.js
@@ -143,6 +143,18 @@ export const MIDI_MAP = {
   //                     came back blank and falsely reported "could not bind")
   LEARN_POLL_TRIES: 20, // how many times the Learn flow polls for a captured
   //                       controller before giving up (x UI_REFRESH_MS ~= 12s)
+  // The device's parameter-page grid, probed live (device-model §8b "navigation
+  // to a parameter"). A program's params are grouped into blocks (the preset's
+  // COL children); the device shows ONE block at a time as a grid of GRID_ROWS x
+  // GRID_COLS cells, filled COLUMN-MAJOR in the block's dump order. Pressing the
+  // block's softkey selects it (page 0); each FURTHER press of the same softkey
+  // advances one page (cursor returns to the page's top-left each press). So a
+  // param at dump-index i in block b is reached by:
+  //   program -> parameter -> soft(b+1) x (floor(i/PAGE)+1)
+  //            -> RIGHT x floor((i%PAGE)/GRID_ROWS) -> DOWN x ((i%PAGE)%GRID_ROWS)
+  GRID_ROWS: 4, // params per column on a parameter page (DOWN clamps at row 3)
+  GRID_COLS: 2, // columns shown per page (RIGHT clamps at col 1; col 2+ = next page)
+  BLOCK_SOFTKEYS: 4, // soft1..soft4 select blocks 0..3; more blocks aren't reachable
 };
 
 // Demo mode (src/demo.js): the canned device built from a live capture.

--- a/src/midi-map-ui.js
+++ b/src/midi-map-ui.js
@@ -245,24 +245,25 @@ function startLearnPoll(refresh, read, onClose, label) {
 
 /**
  * Opens the mapping card for a parameter and BINDS the modulation surface to
- * it (the one keypress step). rowIndex is the parameter's 0-based row on the
- * active DSP's main parameter page; paramName is its label for the bind check.
+ * it (the one keypress step). `block` is the param's block (parent COL) key and
+ * `key` its own key — bindParam derives the device keypath generically from the
+ * loaded program's tree. `name` is the label for the bind verification.
  *
- * @param {{name: string, rowIndex: number}} param
+ * @param {{name: string, key: string, block: string}} param
  */
 export function openParamMapping(param) {
   if (!cardEl) cardEl = modalShell('mm-modal');
   enableSequenceOut();
   card = {
     key: param.key,
+    block: param.block,
     paramName: param.name,
-    rowIndex: param.rowIndex,
     bound: null,
     loading: true,
   };
   cardEl.hidden = false;
   renderCard();
-  bindParam(param.rowIndex, (setup) => {
+  bindParam(param.block, param.key, (setup) => {
     card.loading = false;
     // The surface title ("<param> setup") is the binding proof. Match the WHOLE
     // first token + a trailing space, not just a prefix — a short name like
@@ -270,7 +271,11 @@ export function openParamMapping(param) {
     // could write the mapping to the wrong parameter.
     const want = strip(param.name) + ' ';
     card.bound = setup && setup.title && setup.title.startsWith(want) ? setup : null;
-    if (!card.bound) card.error = `Could not bind "${param.name}" (got "${setup?.title || '?'}")`;
+    if (!card.bound) {
+      card.error = setup?.unreachable
+        ? `"${param.name}" is in a block past the 4 the device exposes — not mappable yet`
+        : `Could not bind "${param.name}" (got "${setup?.title || '?'}")`;
+    }
     // Record what the bind read so the LCD badge reflects the real state.
     if (card.bound) recordParamMapping(card.key, card.bound.source);
     renderCard();

--- a/src/midi-map.js
+++ b/src/midi-map.js
@@ -16,7 +16,7 @@ import { sendValuePut, sendObjectInfoDump, sendValueDump, sendKeypress } from '.
 import { keypressMasks } from './controls.js';
 import { MOD, MOD_SOURCES, KEY_PREFIX } from './sysex-commands.js';
 import { MIDI_MAP } from './constants.js';
-import { getNode } from './tree.js';
+import { getNode, parentOf } from './tree.js';
 import { saveMidiMappings, loadMidiMappings } from './config.js';
 import { appState } from './state.js';
 
@@ -174,23 +174,79 @@ export function clearAssign(i) {
 // title (no bitmap scraping).
 
 /**
- * Binds the per-parameter modulation surface to the parameter at `rowIndex` on
- * the active DSP's main parameter page (0-based, in dump order). Drives the
- * device cursor there (program -> parameter resets to the top row, then DOWN x
- * rowIndex) and SELECT-holds, then reads the bound surface back. The returned
- * setup's `title` is the binding proof ("<param> setup") — the caller compares
- * it to the expected parameter and aborts on mismatch rather than writing to
- * the wrong target.
+ * The device keypath to a parameter, derived from the loaded program's tree
+ * (generic for any program — device-model §8b). A param belongs to a block (its
+ * parent COL); the block's order among the preset's COL children is the softkey
+ * index, and the param's order in the block's dump is the device cursor index.
+ * Returns null when the tree isn't loaded or the param can't be placed.
  *
- * @param {number} rowIndex
+ * @returns {{blockIndex:number, paramIndex:number}|null}
+ */
+export function paramCoords(blockKey, paramKey) {
+  const block = getNode(blockKey);
+  if (!block) return null;
+  const paramIndex = block.slice(1).findIndex((c) => c.key === paramKey);
+  if (paramIndex < 0) return null;
+  // The block's TRUE parent is the preset — from the tree's recorded child->
+  // parent links, NOT block[0].parent (a COL's own dump header is self-parented).
+  const preset = getNode(parentOf(blockKey));
+  // Softkeys select the preset's blocks in dump order (the COL children).
+  const blockIndex = (preset || [])
+    .slice(1)
+    .filter((c) => c.type === 'COL')
+    .findIndex((c) => c.key === blockKey);
+  if (blockIndex < 0) return null;
+  return { blockIndex, paramIndex };
+}
+
+/**
+ * Binds the per-parameter modulation surface to `paramKey` (a param in block
+ * `blockKey`) by driving the device cursor to it and SELECT-holding, then reads
+ * the bound surface back. The navigation is generic — see MIDI_MAP grid notes:
+ * select the block's softkey (paging within it for params past the first page),
+ * then RIGHT across columns and DOWN within a column. The returned setup's
+ * `title` ("<param> setup") is the binding proof; the caller compares it to the
+ * expected name and aborts on mismatch rather than writing to the wrong target.
+ * Returns `{title:''}` (or `unreachable:true`) when the param can't be placed or
+ * sits past the reachable blocks, so the caller reports a clean failure.
+ *
+ * @param {string} blockKey - the param's block (its parent COL key)
+ * @param {string} paramKey - the param's own key
  * @param {(setup: object) => void} [onDone] - called with readParamSetup()
  */
-export async function bindParam(rowIndex, onDone) {
+export async function bindParam(blockKey, paramKey, onDone) {
+  const coords = paramCoords(blockKey, paramKey);
+  if (!coords) {
+    onDone?.({ title: '' });
+    return;
+  }
+  const { blockIndex, paramIndex } = coords;
+  if (blockIndex >= MIDI_MAP.BLOCK_SOFTKEYS) {
+    onDone?.({ title: '', unreachable: true });
+    return;
+  }
+  const pageSize = MIDI_MAP.GRID_ROWS * MIDI_MAP.GRID_COLS;
+  const page = Math.floor(paramIndex / pageSize);
+  const inPage = paramIndex % pageSize;
+  const col = Math.floor(inPage / MIDI_MAP.GRID_ROWS);
+  const row = inPage % MIDI_MAP.GRID_ROWS;
+  const softkey = keypressMasks[`soft${blockIndex + 1}`];
+
   sendKeypress(keypressMasks.program); // reset to a known page...
   await sleep(MIDI_MAP.BIND_STEP_MS);
-  sendKeypress(keypressMasks.parameter); // ...then the param page (cursor at top)
+  sendKeypress(keypressMasks.parameter); // ...then the param area (block 0, page 0)
   await sleep(MIDI_MAP.BIND_SETTLE_MS);
-  for (let i = 0; i < rowIndex; i++) {
+  // Select the block, then advance to the param's page: one softkey press
+  // selects the block (page 0), each further press pages it (page+1 total).
+  for (let p = 0; p <= page; p++) {
+    sendKeypress(softkey);
+    await sleep(MIDI_MAP.BIND_STEP_MS);
+  }
+  for (let c = 0; c < col; c++) {
+    sendKeypress(keypressMasks.right);
+    await sleep(MIDI_MAP.BIND_STEP_MS);
+  }
+  for (let r = 0; r < row; r++) {
     sendKeypress(keypressMasks.down);
     await sleep(MIDI_MAP.BIND_STEP_MS);
   }

--- a/src/midi.js
+++ b/src/midi.js
@@ -326,8 +326,17 @@ export function addSysexListener() {
   // docs/protocol.md "Capturing screens (HIL)".)
   let sysexBuffer = [];
   const handler = (e) => {
-    noteLinkActivity(); // #107: partial packets are not silence
     const data = Array.from(e.data);
+    // #107: partial packets of a streaming RESPONSE (bitmap/OBJECTINFO) are
+    // activity, not silence, so they rearm the wave watchdog. But an UNSOLICITED
+    // sequence-out emit (0x3C, enabled by MIDI mapping) is NOT a wave response —
+    // letting it rearm meant a stream of them (e.g. a tempo-synced value moving
+    // under incoming MIDI clock) held every open wave to the WATCHDOG_MAX_MS
+    // ceiling, starving meter polling (gated while a wave is open). Exclude the
+    // start of a sequence-out frame; response continuation packets (no F0
+    // header) still count.
+    const isSequenceOut = data[0] === SYSEX.START && data[4] === CMD.SEQUENCE_OUT;
+    if (!isSequenceOut) noteLinkActivity();
     if (data[0] === SYSEX.START) sysexBuffer = data;
     else sysexBuffer = sysexBuffer.concat(data);
     // Flush only a properly framed message (starts F0, ends F7). The F0 guard

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -72,13 +72,14 @@ export function updateScreen(logParam = null) {
 const handleLcdClick = (e) => {
   if (e.target.classList.contains('lcd-midi-badge')) {
     // #146: map a MIDI controller to this parameter. Opens the mapping card,
-    // which binds the device modulation surface to the param (row index) and
-    // verifies by title before writing — see midi-map-ui.openParamMapping.
+    // which binds the device modulation surface to the param (derived from the
+    // param's block + key) and verifies by title before writing — see
+    // midi-map-ui.openParamMapping.
     e.stopPropagation();
     openParamMapping({
       key: e.target.dataset.midiKey || '',
+      block: e.target.dataset.midiBlock || '',
       name: e.target.dataset.midiName || '',
-      rowIndex: parseInt(e.target.dataset.midiRow, 10) || 0,
     });
     return;
   }
@@ -928,10 +929,11 @@ export function renderScreen(subs, ascii, logParam) {
       paramLines.push(graphicEqLine);
       paramHtmlLines.push(graphicEqHtml);
     }
-    // #146 MIDI-map: the modulatable params in device cursor order (how many
-    // DOWN presses from the top of the parameter page reach each one). NUM/SET
-    // get a "MIDI" badge whose data-midi-row drives the bind. The bind verifies
-    // by surface title, so a mismatch (wrong page) aborts rather than mis-writes.
+    // #146 MIDI-map: the set of modulatable params on this page. NUM/SET get a
+    // "MIDI" badge; the bind derives the device keypath from the param's block
+    // (s.parent) + key (midi-map.paramCoords), and verifies by surface title, so
+    // a mismatch aborts rather than mis-writes. This map is just the membership
+    // gate — which rows are mappable params (not gang 'a'-grouped, not COL/TRG).
     const midiRowByKey = new Map(
       subs
         .slice(1)
@@ -945,8 +947,7 @@ export function renderScreen(subs, ascii, logParam) {
       // navigates to the active preset's page — so a badge only makes sense on
       // a DSP preset param.
       if (!s.key.startsWith(KEY_PREFIX.DSP_A) && !s.key.startsWith(KEY_PREFIX.DSP_B)) return '';
-      const row = rowMap.get(s.key);
-      if (row === undefined) return '';
+      if (rowMap.get(s.key) === undefined) return '';
       const name = escapeHtml(s.statement || s.tag || '');
       // A mapped param shows its source lit (e.g. "pan"); an unmapped one shows
       // a dim "MIDI" affordance (#146). Mapping state is what the app has set or
@@ -957,7 +958,7 @@ export function renderScreen(subs, ascii, logParam) {
       const title = mapped
         ? `Mapped to ${escapeHtml(mapped)} — click to edit`
         : 'Map a MIDI controller to this parameter';
-      return ` <span class="${cls}" data-midi-key="${s.key}" data-midi-row="${row}" data-midi-name="${name}" title="${title}">${label}</span>`;
+      return ` <span class="${cls}" data-midi-key="${s.key}" data-midi-block="${s.parent || ''}" data-midi-name="${name}" title="${title}">${label}</span>`;
     };
     subs.slice(1).forEach((s) => {
       if (prePainting) {

--- a/src/sysex-commands.js
+++ b/src/sysex-commands.js
@@ -38,6 +38,9 @@ export const CMD = {
   VALUE_DUMP: 0x2e, // in:  VALUE_DUMP response
   OBJECTINFO_DUMP: 0x31, // out: OBJECTINFO_DUMP request
   OBJECTINFO: 0x32, // in:  OBJECTINFO_DUMP response (ASCII sub-object lines)
+  SEQUENCE_OUT: 0x3c, // in:  UNSOLICITED emit of a changed field's key+value when
+  //                     `sequence out = new` is set (device-model §8b). Not a
+  //                     response to any request — see midi.js watchdog handling.
 };
 
 // Parameter keys referenced directly in application logic. Most keys are

--- a/tests/midi-map-ui.test.js
+++ b/tests/midi-map-ui.test.js
@@ -10,7 +10,7 @@ jest.mock('../src/midi-map.js', () => ({
   refreshAssign: jest.fn(),
   captureAssign: jest.fn((i, onDone) => onDone?.()),
   clearAssign: jest.fn(),
-  bindParam: jest.fn((row, onDone) =>
+  bindParam: jest.fn((block, key, onDone) =>
     onDone?.({
       title: 'level setup',
       source: 'off',
@@ -123,8 +123,8 @@ describe('midi-map-ui', () => {
 
   describe('per-parameter card', () => {
     test('binds the surface then renders source / range / type from the bound setup', () => {
-      openParamMapping({ name: 'level  : %4.0f dB', rowIndex: 0 });
-      expect(bindParam).toHaveBeenCalledWith(0, expect.any(Function));
+      openParamMapping({ name: 'level  : %4.0f dB', key: '42e0001', block: '41e0001' });
+      expect(bindParam).toHaveBeenCalledWith('41e0001', '42e0001', expect.any(Function));
       // The card shows the editable fields (bind succeeded — title matched).
       expect(q('.mm-card')).toBeTruthy();
       expect(qa('.mm-field')).toHaveLength(4); // source, range, type, monitor
@@ -132,7 +132,7 @@ describe('midi-map-ui', () => {
     });
 
     test('changing the source writes it by index (clean object PUT)', () => {
-      openParamMapping({ name: 'level  : %4.0f dB', rowIndex: 0 });
+      openParamMapping({ name: 'level  : %4.0f dB', key: '42e0001', block: '41e0001' });
       const sourceSel = q('.mm-card-body select');
       sourceSel.value = '30'; // volume / CC7
       sourceSel.dispatchEvent(new Event('change', { bubbles: true }));
@@ -140,7 +140,7 @@ describe('midi-map-ui', () => {
     });
 
     test('changing the range writes it', () => {
-      openParamMapping({ name: 'level  : %4.0f dB', rowIndex: 0 });
+      openParamMapping({ name: 'level  : %4.0f dB', key: '42e0001', block: '41e0001' });
       const range = q('.mm-card-body input[type="number"]');
       range.value = '50';
       range.dispatchEvent(new Event('change', { bubbles: true }));
@@ -148,14 +148,14 @@ describe('midi-map-ui', () => {
     });
 
     test('Learn on the card arms Capture for the bound param', () => {
-      openParamMapping({ name: 'level  : %4.0f dB', rowIndex: 0 });
+      openParamMapping({ name: 'level  : %4.0f dB', key: '42e0001', block: '41e0001' });
       q('.mm-card-foot .mm-learn').click();
       expect(captureParam).toHaveBeenCalled();
     });
 
     test('a bind whose title does NOT match the param aborts with an error (no mis-write)', () => {
-      bindParam.mockImplementationOnce((row, onDone) => onDone({ title: 'something else' }));
-      openParamMapping({ name: 'level  : %4.0f dB', rowIndex: 0 });
+      bindParam.mockImplementationOnce((block, key, onDone) => onDone({ title: 'something else' }));
+      openParamMapping({ name: 'level  : %4.0f dB', key: '42e0001', block: '41e0001' });
       // No editable fields; an error + Close instead.
       expect(qa('.mm-field')).toHaveLength(0);
       expect(q('.mm-card .mm-note').textContent).toMatch(/could not bind/i);
@@ -164,7 +164,7 @@ describe('midi-map-ui', () => {
 
   test('resetMidiMapUI removes both modals', () => {
     openControllers();
-    openParamMapping({ name: 'level  : %4.0f dB', rowIndex: 0 });
+    openParamMapping({ name: 'level  : %4.0f dB', key: '42e0001', block: '41e0001' });
     expect(qa('.mm-modal').length).toBeGreaterThan(0);
     resetMidiMapUI();
     expect(qa('.mm-modal')).toHaveLength(0);

--- a/tests/midi-map.test.js
+++ b/tests/midi-map.test.js
@@ -15,12 +15,18 @@ jest.mock('../src/controls.js', () => ({
     program: ['program'],
     parameter: ['parameter'],
     down: ['down'],
+    right: ['right'],
     'select-hold': ['select-hold'],
+    soft1: ['soft1'],
+    soft2: ['soft2'],
+    soft3: ['soft3'],
+    soft4: ['soft4'],
   },
 }));
 
 jest.mock('../src/tree.js', () => ({
   getNode: jest.fn(),
+  parentOf: jest.fn(),
 }));
 
 jest.mock('../src/constants.js', () => {
@@ -28,6 +34,7 @@ jest.mock('../src/constants.js', () => {
   return {
     ...actual,
     MIDI_MAP: {
+      ...actual.MIDI_MAP, // keep the real grid geometry (GRID_ROWS/COLS, BLOCK_SOFTKEYS)
       CAPTURE_SETTLE_MS: 1,
       UI_REFRESH_MS: 1,
       BIND_STEP_MS: 1,
@@ -60,8 +67,8 @@ import {
   resetParamMappings,
 } from '../src/midi-map.js';
 import { sendValuePut, sendObjectInfoDump, sendValueDump, sendKeypress } from '../src/midi.js';
-import { getNode } from '../src/tree.js';
-import { bindParam } from '../src/midi-map.js';
+import { getNode, parentOf } from '../src/tree.js';
+import { bindParam, paramCoords } from '../src/midi-map.js';
 import { emit } from '../src/events.js';
 import { appState } from '../src/state.js';
 
@@ -284,32 +291,89 @@ test('readParamSetup surfaces the con# (CC number) for MIDI single/double', () =
   ]);
 });
 
-describe('bindParam (the one keypress step)', () => {
-  test('drives program->parameter->DOWN x row->select-hold, then reads the surface', async () => {
-    getNode.mockReturnValue([
-      { key: '10030401', type: 'COL', statement: 't_delay setup' },
-      { key: '10030402', value: '0 off' },
-    ]);
+describe('bindParam (generic block + grid navigation)', () => {
+  // A program (preset PRE) with three blocks; reverb is block index 2 -> soft3.
+  const PRE = '401000b';
+  const REVERB = '41e0001';
+  const presetNode = [
+    { key: PRE, type: 'COL', parent: '0', statement: 'Horrors' },
+    { key: '4040001', type: 'COL', parent: PRE, statement: 'pitch params' },
+    { key: '40f0001', type: 'COL', parent: PRE, statement: 'chorus params' },
+    { key: REVERB, type: 'COL', parent: PRE, statement: 'reverb params' },
+  ];
+  // reverb block: header (parent = preset) + 9 params, lowfreq at dump index 8.
+  const reverbNode = [
+    { key: REVERB, type: 'COL', parent: PRE, statement: 'reverb params' },
+    { key: '42e0001', type: 'NUM' }, // 0 level
+    { key: '41f0001', type: 'SET' }, // 1 t_rdecay
+    { key: '4220001', type: 'NUM' }, // 2 rdecay
+    { key: '42c0001', type: 'NUM' }, // 3 rsize
+    { key: '4270001', type: 'NUM' }, // 4 predly
+    { key: '4280001', type: 'NUM' }, // 5 hicut
+    { key: '4290001', type: 'NUM' }, // 6 lowcut
+    { key: '42a0001', type: 'NUM' }, // 7 hifreq
+    { key: '42b0001', type: 'NUM' }, // 8 lowfreq
+  ];
+  const surface = (title) => [{ key: '10030401', type: 'COL', statement: title }];
+
+  function mockTree(preset, surfaceTitle) {
+    getNode.mockImplementation((k) => {
+      if (k === PRE) return preset;
+      if (k === REVERB) return reverbNode;
+      if (k === '10030401') return surface(surfaceTitle);
+      return null;
+    });
+    // The block's true parent (preset) comes from the tree's child->parent map.
+    parentOf.mockImplementation((k) => (k === REVERB ? PRE : undefined));
+  }
+
+  test('paramCoords derives block index (softkey) + dump index from the tree', () => {
+    mockTree(presetNode, 'lowfreq setup');
+    expect(paramCoords(REVERB, '42b0001')).toEqual({ blockIndex: 2, paramIndex: 8 });
+    expect(paramCoords(REVERB, '42e0001')).toEqual({ blockIndex: 2, paramIndex: 0 });
+  });
+
+  test('lowfreq (block 2, idx 8 = page 1 top-left) binds via soft3 x2, no RIGHT/DOWN', async () => {
+    mockTree(presetNode, 'lowfreq setup');
     let result;
-    await bindParam(1, (s) => (result = s)); // row 1 = second param
+    await bindParam(REVERB, '42b0001', (s) => (result = s));
     expect(sendKeypress.mock.calls.map((c) => c[0])).toEqual([
       ['program'],
       ['parameter'],
-      ['down'], // one DOWN for row index 1
+      ['soft3'], // select reverb (page 0)
+      ['soft3'], // page to page 1
       ['select-hold'],
     ]);
-    // The surface is read back; its title is the binding proof.
-    expect(result.title).toBe('t_delay setup');
+    expect(result.title).toBe('lowfreq setup');
     expect(sendObjectInfoDump).toHaveBeenCalledWith('10030401');
   });
 
-  test('row 0 binds with no DOWN presses', async () => {
-    getNode.mockReturnValue([{ key: '10030401', type: 'COL', statement: 'level setup' }]);
-    await bindParam(0);
+  test('a page-0 grid cell (idx 5 = col 1 row 1) uses RIGHT then DOWN', async () => {
+    mockTree(presetNode, 'hicut setup');
+    await bindParam(REVERB, '4280001'); // idx 5
     expect(sendKeypress.mock.calls.map((c) => c[0])).toEqual([
       ['program'],
       ['parameter'],
+      ['soft3'], // select reverb (page 0)
+      ['right'], // col 1
+      ['down'], // row 1
       ['select-hold'],
     ]);
+  });
+
+  test('a block past the 4 softkeys reports unreachable and sends no keypress', async () => {
+    const sixBlocks = [
+      presetNode[0],
+      { key: 'b0', type: 'COL', parent: PRE },
+      { key: 'b1', type: 'COL', parent: PRE },
+      { key: 'b2', type: 'COL', parent: PRE },
+      { key: 'b3', type: 'COL', parent: PRE },
+      { key: REVERB, type: 'COL', parent: PRE }, // index 4 -> soft5, unreachable
+    ];
+    mockTree(sixBlocks, 'x');
+    let result;
+    await bindParam(REVERB, '42b0001', (s) => (result = s));
+    expect(result.unreachable).toBe(true);
+    expect(sendKeypress).not.toHaveBeenCalled();
   });
 });

--- a/tests/midi.test.js
+++ b/tests/midi.test.js
@@ -150,6 +150,32 @@ describe('midi.js per-wave counter and watchdog (7c)', () => {
     expect(received[0]).toMatchObject({ reason: 'watchdog' });
   });
 
+  test('an unsolicited sequence-out (0x3C) emit does NOT rearm the watchdog (#146)', () => {
+    // sequence-out emits are not wave responses; if they rearmed the watchdog,
+    // a stream of them (a value moving under incoming MIDI clock) held every
+    // open wave to the 10s cap and starved meter polling. The idle watchdog
+    // must still fire on its original schedule despite the 0x3C traffic.
+    let handler;
+    const input = {
+      addListener: (type, fn) => {
+        handler = fn;
+      },
+      removeListener: jest.fn(),
+    };
+    setMidiPorts({ sendSysex: jest.fn() }, input, 0);
+    addSysexListener();
+
+    sendObjectInfoDump('a'); // idle watchdog armed: fires at t=1500
+    jest.advanceTimersByTime(1000); // t=1000
+    // F0 1C 70 dev 3C ... F7 — a complete unsolicited sequence-out frame.
+    handler({ data: [0xf0, 0x1c, 0x70, 0x00, 0x3c, 0x31, 0x30, 0xf7] });
+    jest.advanceTimersByTime(499); // t=1499: NOT rearmed, so still alive
+    expect(received).toHaveLength(0);
+    jest.advanceTimersByTime(1); // t=1500: the ORIGINAL idle deadline fires
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({ reason: 'watchdog' });
+  });
+
   test('isWaveOpen tracks outstanding across send/receive/watchdog (#107 poll gate)', () => {
     expect(isWaveOpen()).toBe(false);
     sendObjectInfoDump('a');

--- a/tests/renderer.test.js
+++ b/tests/renderer.test.js
@@ -419,11 +419,16 @@ describe('renderer.js', () => {
     renderScreen(subs, '', mockLog);
     const badges = document.querySelectorAll('.lcd-midi-badge');
     expect(badges).toHaveLength(2); // one per modulatable param
-    expect(badges[0].dataset.midiRow).toBe('0'); // first param = row 0 (no DOWN)
-    expect(badges[1].dataset.midiRow).toBe('1');
+    // The badge carries the param's block (parent COL) + key — the bind derives
+    // the device keypath from those (midi-map.paramCoords), not a flat row.
+    expect(badges[0].dataset.midiBlock).toBe('401000b');
+    expect(badges[0].dataset.midiKey).toBe('4070001');
+    expect(badges[1].dataset.midiKey).toBe('4060001');
 
     badges[1].dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    expect(openParamMapping).toHaveBeenCalledWith(expect.objectContaining({ rowIndex: 1 }));
+    expect(openParamMapping).toHaveBeenCalledWith(
+      expect.objectContaining({ key: '4060001', block: '401000b' })
+    );
   });
 
   test('non-DSP params (load menu / setup) get NO MIDI badge (#146)', () => {


### PR DESCRIPTION
Two fixes found while live-testing MIDI mapping on the `Horrors` multi-effect (follow-ups to #146), both verified against the device.

## 1. Bind MIDI mapping to params in ANY block/page (the reverb bug)
Mapping a sub-block param (e.g. reverb `lowfreq`) failed with `Could not bind "lowfreq" (got "fback setup")`. `bindParam` used a flat `program -> parameter -> DOWN x row` that only reaches block 0, page 0, so it walked the wrong block.

Probed the real device navigation (`logs/probe-reverb-nav*.mjs`) and rebuilt it generically from the loaded program's tree (device-model section 8b):
- Softkeys `soft1..soft4` select the program's blocks (the preset's COL children); pressing a block's softkey again pages within it.
- Each page is a 4-row x 2-column grid, column-major, in dump order.
- `paramCoords` derives the block (softkey) + dump index from the tree; `bindParam` navigates `soft(b+1) x (page+1) -> RIGHT x col -> DOWN x row`.
- Live-verified 5/5 across pitch/chorus/reverb and both reverb pages (`logs/probe-midimap-subblock.mjs`). Blocks past the 4 softkeys report a clean "not mappable yet".

## 2. Sequence-out emits no longer starve meter polling
MIDI mapping turns on `sequence out = new`; the device then emits unsolicited `0x3C` packets on every value change. The inbound handler rearmed the dump-wave idle watchdog on every raw packet (#107), including these — so a continuously-changing value (a tempo-synced param under incoming MIDI clock) held every open wave to the 10s ceiling, and meter polling (gated while a wave is open) stopped. A `0x3C` emit isn't a wave response, so it's now excluded from the rearm; multi-packet response streams still rearm.

## Tests
292 passing (new: grid/coords binding cases, the unreachable-block case, the sequence-out watchdog case). Lint clean.