### PR TITLE
feat: backup & restore the unit to a .syx file (#147)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,8 @@ index.html
       ├─ preset-browser.js  top-level modal: browse/search the library, preview a program on the idle DSP (remember-and-restore), load to A/B (#153/#135)
       ├─ midi-map.js        DOM-free device-native modulation engine: assign controllers, per-param source/range/type, bindParam (#146)
       ├─ midi-map-ui.js     MIDI controllers panel + per-parameter mapping card modals (#146)
+      ├─ backup.js          DOM-free backup/restore engine: Tech Note 34 want/dump opcodes, capture + checksum, restore-by-replay (#147)
+      ├─ backup-ui.js       Backup & Restore modal: kind picker, progress, .syx download/upload, restore confirm (#147)
       ├─ navigation.js      toggleDspKey
       ├─ tree.js            persistent device object tree: recordDump, deriveKeyStack, labels (T1b/#105)
       ├─ eager-loader.js    background preset-subtree structure warm-up, one request in flight (#106)

--- a/docs/device-model.md
+++ b/docs/device-model.md
@@ -79,6 +79,21 @@ ack/error replies:
 | `0x08`/`0x09` | SIGFILE dump/want | **preset as a human-readable operator netlist** (HEAD…TAIL); a different representation than the §3 OBJECTINFO menu tree |
 | `0x0A`/`0x0B` | SIGFILE remote/quick | remote-editor variants; `0x0A` replies `OK`/`ERROR` |
 | `0x19`/`0x1A` | INFO dump/want    | ASCII system info (ROM name/revision/time/size) |
+| `0x10`/`0x0F` | FILES want/dump   | the current presets (FILES_DUMP wire format)    |
+| `0x12`/`0x38` | INTERNAL want/dump | **all internal NV RAM** — the full-unit backup (#147) |
+| `0x14`/`0x13` | CARD want/dump    | memory-card contents                            |
+
+The `<X>_DUMP` wire format (`0x15`/`0x16`/`0x0F`/`0x38`/`0x13`) is: an 8-nibble
+(4-byte) block size, the nibbled data, then a 1-byte checksum — the sum of every
+decoded byte (size + block + checksum) is 0 mod 256. These dumps are large/slow
+(~1.6 KB/s); sent BACK to the unit, the same opcode loads/replaces that data.
+**Opcode caveat `[V]`:** TN34 is the DSP4000 note, and the Orville's bigger dumps
+differ from it — the **internal dump replies with `0x38`, not TN34's `0x11`**
+(live-verified 2026-06-12: 512 KB, checksum OK). The app's backup capture is
+therefore opcode-AGNOSTIC (`midi.js`): during a backup any non-object-protocol
+frame is the dump. The full-unit dump has a **variable, sometimes slow startup**
+(1 s after a reboot, tens of seconds right after a prior dump) — and cutting it
+off mid-stream jams the link, so it must run to completion (see #147 notes).
 
 Whether the object commands (`0x2d`, etc.) ever reply with `OK`/`ERROR` is
 unknown — see §12.

--- a/src/backup-ui.js
+++ b/src/backup-ui.js
@@ -1,0 +1,242 @@
+// backup-ui.js
+// The Backup & Restore modal (#147) over the DOM-free engine in backup.js.
+// Backup reads a dump from the unit and downloads a .syx; restore replays a .syx
+// back to the unit. Device I/O lives in backup.js; this file renders + sequences
+// and tells the host when it's busy (onBusy) so meter polling can pause — the
+// dump saturates the 31250-baud link for minutes.
+
+import { requestBackup, restore, frameFromFile, backupFilename, BACKUP_KINDS } from './backup.js';
+
+let modalEl = null;
+let onBusy = null; // injected: (busy:boolean) => void — host pauses polling while true
+let busy = false;
+let pickedFrame = null; // the dump frame parsed from an uploaded .syx
+
+/** Wires the host hooks once at boot. @param {{onBusy?:(b:boolean)=>void}} cfg */
+export function setupBackupUI(cfg) {
+  onBusy = cfg?.onBusy || null;
+}
+
+function setBusy(b) {
+  busy = b;
+  onBusy?.(b);
+  render();
+}
+
+function el(tag, cls, text) {
+  const e = document.createElement(tag);
+  if (cls) e.className = cls;
+  if (text != null) e.textContent = text;
+  return e;
+}
+
+/** Opens the modal (idempotent). */
+export function openBackup() {
+  if (!modalEl) {
+    modalEl = el('div', 'bk-modal');
+    modalEl.addEventListener('click', (e) => {
+      if (e.target === modalEl && !busy) closeBackup();
+    });
+    document.body.appendChild(modalEl);
+  }
+  modalEl.hidden = false;
+  render();
+}
+
+export function closeBackup() {
+  if (busy) return; // never tear down mid-transfer
+  if (modalEl) modalEl.hidden = true;
+}
+
+/** Closes + clears (disconnect / Sync). */
+export function resetBackupUI() {
+  busy = false;
+  pickedFrame = null;
+  if (modalEl) {
+    modalEl.remove();
+    modalEl = null;
+  }
+}
+
+let status = { msg: '', kind: '', error: false, bytes: 0, running: false };
+
+function startBackup(kind) {
+  if (busy) return;
+  setBusy(true);
+  status = {
+    msg: `Reading ${BACKUP_KINDS[kind].label.toLowerCase()} from the unit…`,
+    kind,
+    error: false,
+    bytes: 0,
+    running: true,
+  };
+  render();
+  requestBackup(kind, {
+    onProgress: (bytes) => {
+      status.bytes = bytes;
+      renderStatusOnly();
+    },
+    onError: (e) => {
+      status = { msg: e, kind, error: true, bytes: status.bytes, running: false };
+      setBusy(false);
+    },
+    onDone: (r) => {
+      download(r.frame, backupFilename(kind, new Date().toISOString().slice(0, 19)));
+      status = {
+        msg: r.checksumOk
+          ? `Saved ${(r.frame.length / 1024).toFixed(0)} KB. Checksum OK.`
+          : `Saved ${(r.frame.length / 1024).toFixed(0)} KB — WARNING: checksum FAILED, the backup may be corrupt.`,
+        kind,
+        error: !r.checksumOk,
+        bytes: r.frame.length,
+        running: false,
+      };
+      setBusy(false);
+    },
+  });
+}
+
+function startRestore() {
+  if (busy || !pickedFrame) return;
+  const kind = Object.keys(BACKUP_KINDS).find((k) => BACKUP_KINDS[k].dump === pickedFrame[4]);
+  const spec = kind ? BACKUP_KINDS[kind] : null;
+  const what = spec ? spec.label.toLowerCase() : 'this data';
+  const warn = spec?.replaces
+    ? `This will REPLACE ${what} on the unit, overwriting what's there now. This cannot be undone. Continue?`
+    : `Load ${what} onto the unit? Continue?`;
+  if (!window.confirm(warn)) return;
+  setBusy(true);
+  status = {
+    msg: `Restoring ${what} to the unit…`,
+    kind: kind || '',
+    error: false,
+    bytes: 0,
+    running: true,
+  };
+  render();
+  restore(pickedFrame, {
+    onError: (e) => {
+      status = { msg: e, kind: kind || '', error: true, bytes: 0, running: false };
+      setBusy(false);
+    },
+    onDone: () => {
+      status = {
+        msg: `Restore sent. The unit may take a moment to reload.`,
+        kind: kind || '',
+        error: false,
+        bytes: 0,
+        running: false,
+      };
+      setBusy(false);
+    },
+  });
+}
+
+function download(frame, filename) {
+  const blob = new Blob([new Uint8Array(frame)], { type: 'application/octet-stream' });
+  const url = URL.createObjectURL(blob);
+  const a = el('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+function renderStatusOnly() {
+  const s = modalEl?.querySelector('.bk-status');
+  if (s)
+    s.textContent = status.running
+      ? `${status.msg}  (${status.bytes.toLocaleString()} bytes)`
+      : status.msg;
+  const bar = modalEl?.querySelector('.bk-bar');
+  if (bar) bar.classList.toggle('bk-bar-active', status.running);
+}
+
+function render() {
+  if (!modalEl || modalEl.hidden) return;
+  modalEl.innerHTML = '';
+  const panel = el('div', 'bk-panel');
+
+  const head = el('div', 'bk-head');
+  head.append(el('div', 'bk-title', 'Backup & Restore'));
+  const close = el('button', 'bk-close', '✕');
+  close.disabled = busy;
+  close.addEventListener('click', closeBackup);
+  head.append(close);
+  panel.append(head);
+
+  // Backup section
+  panel.append(el('div', 'bk-section-h', 'Back up'));
+  panel.append(
+    el(
+      'div',
+      'bk-note',
+      'Reads data from the unit and downloads a .syx file. The full unit and all presets take several minutes — keep the unit connected.'
+    )
+  );
+  const grid = el('div', 'bk-grid');
+  for (const [kind, spec] of Object.entries(BACKUP_KINDS)) {
+    const b = el('button', 'bk-btn', spec.label);
+    b.disabled = busy;
+    b.addEventListener('click', () => startBackup(kind));
+    grid.append(b);
+  }
+  panel.append(grid);
+
+  // Restore section
+  panel.append(el('div', 'bk-section-h', 'Restore'));
+  panel.append(
+    el(
+      'div',
+      'bk-note',
+      'Replays a .syx backup to the unit. Full-unit / all-presets restores OVERWRITE the unit and are confirmed first.'
+    )
+  );
+  const restoreRow = el('div', 'bk-restore-row');
+  const file = el('input', 'bk-file');
+  file.type = 'file';
+  file.accept = '.syx';
+  file.disabled = busy;
+  file.addEventListener('change', async () => {
+    pickedFrame = null;
+    const f = file.files?.[0];
+    if (!f) return render();
+    const bytes = new Uint8Array(await f.arrayBuffer());
+    pickedFrame = frameFromFile(bytes);
+    status = pickedFrame
+      ? {
+          msg: `Loaded ${f.name} (${pickedFrame.length.toLocaleString()} bytes).`,
+          kind: '',
+          error: false,
+          bytes: 0,
+          running: false,
+        }
+      : {
+          msg: `${f.name} is not a valid Eventide .syx backup.`,
+          kind: '',
+          error: true,
+          bytes: 0,
+          running: false,
+        };
+    render();
+  });
+  const restoreBtn = el('button', 'bk-btn bk-restore-btn', 'Restore to unit');
+  restoreBtn.disabled = busy || !pickedFrame;
+  restoreBtn.addEventListener('click', startRestore);
+  restoreRow.append(file, restoreBtn);
+  panel.append(restoreRow);
+
+  // Status + progress
+  const bar = el('div', 'bk-bar');
+  if (status.running) bar.classList.add('bk-bar-active');
+  panel.append(bar);
+  const st = el('div', `bk-status${status.error ? ' bk-error' : ''}`);
+  st.textContent = status.running
+    ? `${status.msg}  (${status.bytes.toLocaleString()} bytes)`
+    : status.msg;
+  panel.append(st);
+
+  modalEl.append(panel);
+}

--- a/src/backup.js
+++ b/src/backup.js
@@ -111,7 +111,10 @@ export function requestBackup(kind, { onProgress, onDone, onError } = {}) {
         finish(null, 'The device reported an error.');
         return;
       }
-      if (frame[4] !== spec.dump) return; // ignore a stray OK / other frame
+      if (frame[4] === CMD.OK) return; // an ack, not the dump — keep waiting
+      // Any other (non-object-protocol) frame the capture routes here IS the
+      // dump — its opcode varies across the unit's dump types (TN34 vs Orville),
+      // so don't gate on a specific one.
       const parsed = parseDumpFrame(frame);
       finish({ kind, label: spec.label, frame, ...parsed });
     },

--- a/src/backup.js
+++ b/src/backup.js
@@ -1,0 +1,184 @@
+// backup.js
+// Full-unit backup & restore (#147) over the Tech Note 34 dump protocol. DOM-free
+// like library.js: it sends "want" opcodes, captures the (large, slow) dump frame
+// via midi.js's raw-capture hook, verifies the checksum, and hands back the raw
+// SysEx frame for download. Restore sends a captured/loaded dump frame back to
+// the unit. See docs/device-model.md §2 + logs/tn34.txt.
+//
+// All dumps share the FILES_DUMP wire format: an 8-nibble (4-byte) block size,
+// the nibbled data block, then a 1-byte checksum — the sum of every decoded byte
+// (size + block + checksum) is 0 mod 256. Bytes travel as MS-nibble-first pairs.
+
+import { sendSysEx, setBackupCapture } from './midi.js';
+import { CMD } from './sysex-commands.js';
+import { BACKUP } from './constants.js';
+
+/**
+ * The backup targets. `want` requests the dump; `dump` is both the inbound dump
+ * opcode and the opcode to send back to restore. `replaces` flags the wide-blast
+ * restores (whole presets / all NV RAM) that need a strong confirmation.
+ */
+export const BACKUP_KINDS = {
+  internal: {
+    want: CMD.INTERNAL_WANT,
+    dump: CMD.INTERNAL_DUMP,
+    label: 'Full unit (internal memory)',
+    replaces: true,
+  },
+  files: { want: CMD.FILES_WANT, dump: CMD.FILES_DUMP, label: 'All presets', replaces: true },
+  program: {
+    want: CMD.PROGRAM_WANT,
+    dump: CMD.PROGRAM_DUMP,
+    label: 'Current program',
+    replaces: false,
+  },
+  setup: { want: CMD.SETUP_WANT, dump: CMD.SETUP_DUMP, label: 'Unit setup', replaces: false },
+};
+
+/** Decode MS-nibble-first pairs into bytes. */
+export function denibble(nibbles) {
+  const out = new Uint8Array(nibbles.length >> 1);
+  for (let i = 0; i < out.length; i++)
+    out[i] = ((nibbles[2 * i] & 0x0f) << 4) | (nibbles[2 * i + 1] & 0x0f);
+  return out;
+}
+
+/** Encode bytes into MS-nibble-first pairs (for restore framing). */
+export function renibble(bytes) {
+  const out = new Array(bytes.length * 2);
+  for (let i = 0; i < bytes.length; i++) {
+    out[2 * i] = (bytes[i] >> 4) & 0x0f;
+    out[2 * i + 1] = bytes[i] & 0x0f;
+  }
+  return out;
+}
+
+/**
+ * Parse a dump frame (`F0 1C 70 dev cmd <nibbles…> F7`) into its decoded block,
+ * declared size, and checksum validity. INFO dumps are ASCII (not nibbled) and
+ * are not parsed here — they are not a backup target.
+ *
+ * @param {number[]} frame
+ */
+export function parseDumpFrame(frame) {
+  const cmd = frame[4];
+  const nibbles = frame.slice(5, frame.length - 1);
+  const data = denibble(nibbles); // 4-byte size header + block + 1-byte checksum
+  const declaredSize =
+    data.length >= 4 ? ((data[0] << 24) | (data[1] << 16) | (data[2] << 8) | data[3]) >>> 0 : 0;
+  let sum = 0;
+  for (const b of data) sum = (sum + b) & 0xff;
+  const checksumOk = data.length > 0 && sum === 0;
+  return { cmd, data, declaredSize, checksumOk };
+}
+
+/**
+ * Requests a backup of `kind`, capturing the dump frame. Reports byte progress
+ * through the transfer; resolves via onDone with `{ kind, label, frame, data,
+ * declaredSize, checksumOk }` or onError. Returns a cancel function.
+ *
+ * @param {string} kind - a key of BACKUP_KINDS
+ * @param {{onProgress?:(bytes:number)=>void, onDone?:(r:object)=>void, onError?:(msg:string)=>void}} cb
+ */
+export function requestBackup(kind, { onProgress, onDone, onError } = {}) {
+  const spec = BACKUP_KINDS[kind];
+  if (!spec) {
+    onError?.(`Unknown backup kind: ${kind}`);
+    return () => {};
+  }
+  let started = false;
+  let lastBytes = 0;
+  let lastAt = Date.now();
+  let done = false;
+  let idleTimer = null;
+  const finish = (result, err) => {
+    if (done) return;
+    done = true;
+    if (idleTimer) clearInterval(idleTimer);
+    setBackupCapture(null);
+    if (err) onError?.(err);
+    else onDone?.(result);
+  };
+  setBackupCapture({
+    onProgress: (bytes) => {
+      started = true;
+      lastBytes = bytes;
+      lastAt = Date.now();
+      onProgress?.(bytes);
+    },
+    onFrame: (frame) => {
+      if (frame[4] === CMD.ERROR) {
+        finish(null, 'The device reported an error.');
+        return;
+      }
+      if (frame[4] !== spec.dump) return; // ignore a stray OK / other frame
+      const parsed = parseDumpFrame(frame);
+      finish({ kind, label: spec.label, frame, ...parsed });
+    },
+  });
+  // Idle watchdog: never started -> no device / wrong reply; started then silent
+  // for STALL_MS -> the (terminator-less so far) frame finished or stalled.
+  idleTimer = setInterval(() => {
+    const idle = Date.now() - lastAt;
+    if (!started && idle > BACKUP.START_TIMEOUT_MS) finish(null, 'No response from the device.');
+    else if (started && idle > BACKUP.STALL_MS)
+      finish(null, `Transfer stalled at ${lastBytes} bytes.`);
+  }, 1000);
+  sendSysEx(spec.want, []);
+  return () => finish(null, 'Cancelled.');
+}
+
+/**
+ * Restores by sending a dump frame back to the unit. The frame is re-sent under
+ * the CURRENTLY connected device id (via sendSysEx), so a backup taken at one id
+ * restores at another. Most dumps ack nothing (Tech Note 34 "Response: none"),
+ * so it settles after a grace period unless an OK/ERROR arrives first.
+ *
+ * @param {number[]} frame - a dump frame (F0 1C 70 dev cmd … F7)
+ * @param {{onDone?:()=>void, onError?:(msg:string)=>void}} cb
+ */
+export function restore(frame, { onDone, onError } = {}) {
+  const cmd = frame[4];
+  const nibbles = frame.slice(5, frame.length - 1);
+  let done = false;
+  let settle = null;
+  const finish = (err) => {
+    if (done) return;
+    done = true;
+    if (settle) clearTimeout(settle);
+    setBackupCapture(null);
+    if (err) onError?.(err);
+    else onDone?.();
+  };
+  setBackupCapture({
+    onProgress: () => {},
+    onFrame: (f) => {
+      if (f[4] === CMD.ERROR) finish('The device reported an error during restore.');
+      else if (f[4] === CMD.OK) finish();
+    },
+  });
+  sendSysEx(cmd, nibbles); // re-frames as F0 1C 70 <current-dev> <cmd> <nibbles> F7
+  settle = setTimeout(() => finish(), BACKUP.RESTORE_SETTLE_MS);
+}
+
+/** A timestamped, filesystem-safe default filename for a backup of `kind`. */
+export function backupFilename(kind, stamp) {
+  const safe = String(stamp || '').replace(/[: ]/g, '-');
+  return `orville-${kind}-${safe}.syx`;
+}
+
+/**
+ * Extracts the dump frame from uploaded file bytes (a raw .syx). Returns the
+ * `F0 … F7` frame as a number[], or null if no Eventide dump frame is present.
+ *
+ * @param {Uint8Array|number[]} bytes
+ */
+export function frameFromFile(bytes) {
+  const a = Array.from(bytes);
+  const start = a.indexOf(0xf0);
+  const end = a.lastIndexOf(0xf7);
+  if (start < 0 || end <= start) return null;
+  const frame = a.slice(start, end + 1);
+  if (frame[1] !== 0x1c || frame[2] !== 0x70) return null; // not an Eventide frame
+  return frame;
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -163,8 +163,11 @@ export const MIDI_MAP = {
 // is generous, and the "want" can take several seconds to start (the program
 // want had ~8 s latency before the dump began).
 export const BACKUP = {
-  START_TIMEOUT_MS: 15000, // give up if a dump never starts arriving after the want
-  STALL_MS: 15000, // give up if a started transfer goes silent this long (= done/stall)
+  START_TIMEOUT_MS: 60000, // give up if a dump never starts arriving after the want.
+  //                          Generous because the full internal gather is slow to
+  //                          BEGIN (live: it can take tens of seconds before the
+  //                          first byte, unlike program/setup which start in ~1-8s).
+  STALL_MS: 20000, // give up if a STARTED transfer goes silent this long (= done/stall)
   RESTORE_SETTLE_MS: 12000, // most dumps reply nothing on restore — settle after this
 };
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -157,6 +157,17 @@ export const MIDI_MAP = {
   BLOCK_SOFTKEYS: 4, // soft1..soft4 select blocks 0..3; more blocks aren't reachable
 };
 
+// Backup/restore (#147). The Tech Note 34 dumps are large, slow single frames
+// over the 31250-baud DIN link (~1.6 KB/s measured live; a full internal dump is
+// ~350 KB / ~3-4 min). The device adds inter-block delays, so the stall window
+// is generous, and the "want" can take several seconds to start (the program
+// want had ~8 s latency before the dump began).
+export const BACKUP = {
+  START_TIMEOUT_MS: 15000, // give up if a dump never starts arriving after the want
+  STALL_MS: 15000, // give up if a started transfer goes silent this long (= done/stall)
+  RESTORE_SETTLE_MS: 12000, // most dumps reply nothing on restore — settle after this
+};
+
 // Demo mode (src/demo.js): the canned device built from a live capture.
 export const DEMO = {
   REPLY_LATENCY_MS: 25, // per-reply delay so the dump-wave lifecycle (BUSY

--- a/src/index.html
+++ b/src/index.html
@@ -65,6 +65,13 @@
         >
           MIDI Map
         </button>
+        <button
+          id="open-backup"
+          class="util-btn"
+          title="Back up the unit to a file, or restore from one"
+        >
+          Backup
+        </button>
         <span id="sync-status" class="sync-status">not synced</span>
         <span class="conn-spacer"></span>
         <button id="save-config" class="util-btn">Save Config</button>

--- a/src/main.js
+++ b/src/main.js
@@ -31,6 +31,7 @@ import {
   resetPresetBrowser,
 } from './preset-browser.js';
 import { setupMidiMapUI, openControllers, resetMidiMapUI } from './midi-map-ui.js';
+import { setupBackupUI, openBackup, resetBackupUI } from './backup-ui.js';
 import { setupKeypressControls, setupDataKnob, testKeypress, meterPollTick } from './controls.js';
 import {
   setMidiPorts,
@@ -188,6 +189,7 @@ function resetAndLand() {
   resetPresetLoader();
   resetPresetBrowser(); // also drop any open browser + in-flight preview state
   resetMidiMapUI(); // close MIDI modals; the new device re-reads on demand
+  resetBackupUI(); // close any backup modal on reconnect
   setState(
     {
       currentKey: KEY.ROOT,
@@ -292,6 +294,7 @@ syncBtn.addEventListener('click', () => {
   resetPresetLoader();
   resetPresetBrowser();
   resetMidiMapUI();
+  resetBackupUI();
   setState({ currentKey: KEY.ROOT, keyStack: [] }, 'main:sync-root');
   updateScreen(log);
   log('Synced to root', 'info', 'general');
@@ -515,6 +518,17 @@ function setupLibraryUI() {
   setupMidiMapUI({ onChange: afterLoad });
   const midiBtn = document.getElementById('open-midi-map');
   if (midiBtn) midiBtn.addEventListener('click', openControllers);
+
+  // Backup & restore (#147): a long dump saturates the link, so pause meter
+  // polling while a backup/restore runs and resume it after (if it was on).
+  setupBackupUI({
+    onBusy: (b) => {
+      if (b) stopPolling();
+      else if (appState.pollingEnabled) startPolling();
+    },
+  });
+  const backupBtn = document.getElementById('open-backup');
+  if (backupBtn) backupBtn.addEventListener('click', openBackup);
 
   // "12m ago" style relative time from an ISO stamp.
   const timeAgo = (iso) => {

--- a/src/midi.js
+++ b/src/midi.js
@@ -292,19 +292,19 @@ export function setMidiPorts(output, input, devId) {
 }
 
 // --- Backup/restore capture (#147) ---------------------------------------
-// The Tech Note 34 dump opcodes are large unsolicited frames, NOT the object
-// protocol. When a backup is armed, the inbound handler routes a matching dump
-// frame to the capture callback and skips parseResponse; onProgress reports the
-// in-progress byte count so a multi-minute dump can show progress.
-const BACKUP_DUMP_CMDS = new Set([
-  CMD.PROGRAM_DUMP,
-  CMD.SETUP_DUMP,
-  CMD.FILES_DUMP,
-  CMD.INTERNAL_DUMP,
-  CMD.CARD_DUMP,
-  CMD.INFO_DUMP,
-  CMD.OK,
-  CMD.ERROR,
+// A dump is a large frame that is NOT the object protocol. When a backup is
+// armed, the inbound handler routes any non-object-protocol frame to the capture
+// callback (skipping parseResponse) and reports the in-progress byte count for a
+// multi-minute dump's progress. Capturing by EXCLUSION (not an opcode allowlist)
+// is deliberate: the Orville's dump opcodes differ from Tech Note 34 (the full
+// internal dump is 0x38, not 0x11 — live-verified), so an allowlist would miss
+// them. During a backup the app pauses polling and doesn't navigate, so the only
+// inbound frames are the dump itself plus OK/ERROR acks.
+const BACKUP_OBJECT_PROTOCOL = new Set([
+  CMD.OBJECTINFO,
+  CMD.VALUE_DUMP,
+  CMD.SCREEN_BITMAP,
+  CMD.SEQUENCE_OUT,
 ]);
 let backupCapture = null; // { onProgress(bytes), onFrame(frameBytes) } | null
 
@@ -373,7 +373,7 @@ export function addSysexListener() {
         backupCapture &&
         sysexBuffer[1] === SYSEX.MANUFACTURER[0] &&
         sysexBuffer[2] === SYSEX.MANUFACTURER[1] &&
-        BACKUP_DUMP_CMDS.has(sysexBuffer[4])
+        !BACKUP_OBJECT_PROTOCOL.has(sysexBuffer[4])
       ) {
         const frame = sysexBuffer;
         sysexBuffer = [];

--- a/src/midi.js
+++ b/src/midi.js
@@ -361,9 +361,20 @@ export function addSysexListener() {
     if (!isSequenceOut) noteLinkActivity();
     if (data[0] === SYSEX.START) sysexBuffer = data;
     else sysexBuffer = sysexBuffer.concat(data);
-    // #147: while a backup is armed, report the growing dump frame's size so the
-    // UI can show progress through a multi-minute transfer.
-    if (backupCapture) backupCapture.onProgress(sysexBuffer.length);
+    // #147: while a backup is armed, report the growing DUMP frame's size so the
+    // UI can show progress through a multi-minute transfer. Guard it with the same
+    // manufacturer + non-object-protocol check as the capture routing below: a
+    // stray SEQUENCE_OUT/foreign frame must NOT arm the engine's `started` flag,
+    // or it would flip the slow-start watchdog to the short stall window and abort
+    // a legitimately slow internal dump (review).
+    if (
+      backupCapture &&
+      sysexBuffer[1] === SYSEX.MANUFACTURER[0] &&
+      sysexBuffer[2] === SYSEX.MANUFACTURER[1] &&
+      !BACKUP_OBJECT_PROTOCOL.has(sysexBuffer[4])
+    ) {
+      backupCapture.onProgress(sysexBuffer.length);
+    }
     // Flush only a properly framed message (starts F0, ends F7). The F0 guard
     // discards a stray continuation packet that arrives with no header.
     if (sysexBuffer[0] === SYSEX.START && sysexBuffer[sysexBuffer.length - 1] === SYSEX.END) {

--- a/src/midi.js
+++ b/src/midi.js
@@ -291,6 +291,28 @@ export function setMidiPorts(output, input, devId) {
   setState({ deviceId: devId }, 'midi:set-ports');
 }
 
+// --- Backup/restore capture (#147) ---------------------------------------
+// The Tech Note 34 dump opcodes are large unsolicited frames, NOT the object
+// protocol. When a backup is armed, the inbound handler routes a matching dump
+// frame to the capture callback and skips parseResponse; onProgress reports the
+// in-progress byte count so a multi-minute dump can show progress.
+const BACKUP_DUMP_CMDS = new Set([
+  CMD.PROGRAM_DUMP,
+  CMD.SETUP_DUMP,
+  CMD.FILES_DUMP,
+  CMD.INTERNAL_DUMP,
+  CMD.CARD_DUMP,
+  CMD.INFO_DUMP,
+  CMD.OK,
+  CMD.ERROR,
+]);
+let backupCapture = null; // { onProgress(bytes), onFrame(frameBytes) } | null
+
+/** Arms (or disarms, with null) capture of backup dump frames (#147). */
+export function setBackupCapture(cap) {
+  backupCapture = cap;
+}
+
 /**
  * Adds a SysEx event listener to the selected MIDI input.
  * Parses incoming SysEx messages and categorizes them (e.g., screenDump for bitmap data).
@@ -339,9 +361,25 @@ export function addSysexListener() {
     if (!isSequenceOut) noteLinkActivity();
     if (data[0] === SYSEX.START) sysexBuffer = data;
     else sysexBuffer = sysexBuffer.concat(data);
+    // #147: while a backup is armed, report the growing dump frame's size so the
+    // UI can show progress through a multi-minute transfer.
+    if (backupCapture) backupCapture.onProgress(sysexBuffer.length);
     // Flush only a properly framed message (starts F0, ends F7). The F0 guard
     // discards a stray continuation packet that arrives with no header.
     if (sysexBuffer[0] === SYSEX.START && sysexBuffer[sysexBuffer.length - 1] === SYSEX.END) {
+      // #147: a backup dump frame is not the object protocol — hand the raw
+      // frame to the capture callback and skip parseResponse entirely.
+      if (
+        backupCapture &&
+        sysexBuffer[1] === SYSEX.MANUFACTURER[0] &&
+        sysexBuffer[2] === SYSEX.MANUFACTURER[1] &&
+        BACKUP_DUMP_CMDS.has(sysexBuffer[4])
+      ) {
+        const frame = sysexBuffer;
+        sysexBuffer = [];
+        backupCapture.onFrame(frame);
+        return;
+      }
       // #47: reject malformed frames at the boundary with a logged reason
       // instead of letting them half-parse into state. A rejected frame
       // never reaches notifyResponse; if it was the answer to a counted

--- a/src/parser.js
+++ b/src/parser.js
@@ -18,6 +18,19 @@ import { denibble } from './bitmap.js';
 import { emit } from './events.js';
 import { splitLine } from './sysex-split.js';
 
+// Bytes -> string without spreading the whole array into String.fromCharCode:
+// a `String.fromCharCode(...bytes)` spread overflows the call stack on very
+// large frames (a ~1 MB backup dump that bypasses the capture hook hit this).
+// Chunked apply() stays well under the argument-count limit (#147).
+function bytesToString(bytes) {
+  const CHUNK = 8192;
+  let s = '';
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    s += String.fromCharCode.apply(null, bytes.slice(i, i + CHUNK));
+  }
+  return s;
+}
+
 // Keys the gang fan-out (#132) has already requested for the CURRENT menu
 // visit. Structural guard (review): the gang fan-out is the first
 // response->request chain in the parser, and a malformed dump graph (gang
@@ -35,7 +48,7 @@ export function parseResponse(data) {
       setState({ deviceId: data[3] }, 'parser:device-id-detect');
       log(`Detected device ID: ${appState.deviceId}`, 'info', 'general');
     }
-    const ascii = String.fromCharCode(...data.slice(SYSEX.FRAME_PREFIX_LEN, data.length - 1))
+    const ascii = bytesToString(data.slice(SYSEX.FRAME_PREFIX_LEN, data.length - 1))
       .replace(/\0+$/, '')
       .trim();
     if (data[3] === appState.deviceId && data[4] === CMD.OBJECTINFO) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1769,6 +1769,130 @@ body {
   padding: 3px 8px;
   font-size: 11px;
 }
+
+/* Backup & Restore modal (#147) */
+.bk-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 55;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+}
+.bk-modal[hidden] {
+  display: none;
+}
+.bk-panel {
+  width: min(520px, 92vw);
+  max-height: 88vh;
+  overflow: auto;
+  background: color-mix(in srgb, var(--lcd-bg) 60%, var(--btn-cap));
+  border: 1px solid var(--panel-line);
+  border-radius: 6px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
+  font-family: var(--legend-font);
+  color: var(--legend);
+}
+.bk-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--panel-line);
+}
+.bk-title {
+  font-size: 15px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.bk-close {
+  background: none;
+  border: none;
+  color: var(--legend);
+  font-size: 16px;
+  cursor: pointer;
+}
+.bk-close:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.bk-section-h {
+  padding: 12px 16px 4px;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+.bk-note {
+  padding: 0 16px 8px;
+  font-size: 12px;
+  opacity: 0.75;
+  line-height: 1.4;
+}
+.bk-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  padding: 4px 16px 8px;
+}
+.bk-btn {
+  padding: 8px 12px;
+  font-family: var(--legend-font);
+  font-size: 13px;
+  color: var(--legend);
+  background: color-mix(in srgb, var(--lcd-bg) 70%, var(--btn-cap));
+  border: 1px solid var(--panel-line);
+  border-radius: 3px;
+  cursor: pointer;
+}
+.bk-btn:hover:not(:disabled) {
+  border-color: var(--lcd-px);
+}
+.bk-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.bk-restore-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 4px 16px 8px;
+}
+.bk-file {
+  flex: 1;
+  font-size: 12px;
+  color: var(--legend);
+}
+.bk-bar {
+  height: 4px;
+  margin: 8px 16px 0;
+  border-radius: 2px;
+  background: var(--panel-line);
+  overflow: hidden;
+}
+.bk-bar-active {
+  background: linear-gradient(90deg, transparent, var(--lcd-px), transparent);
+  background-size: 40% 100%;
+  animation: bk-scan 1.1s linear infinite;
+}
+@keyframes bk-scan {
+  from {
+    background-position: -40% 0;
+  }
+  to {
+    background-position: 140% 0;
+  }
+}
+.bk-status {
+  padding: 8px 16px 14px;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  min-height: 1em;
+}
+.bk-status.bk-error {
+  color: #e88;
+}
 .mm-card-foot {
   display: flex;
   gap: 8px;

--- a/src/sysex-commands.js
+++ b/src/sysex-commands.js
@@ -53,7 +53,11 @@ export const CMD = {
   FILES_WANT: 0x10, // out: request the current presets -> FILES_DUMP
   FILES_DUMP: 0x0f, // in/out: the preset files; sent back, it replaces them
   INTERNAL_WANT: 0x12, // out: request ALL internal NV RAM -> INTERNAL_DUMP (full backup)
-  INTERNAL_DUMP: 0x11, // in/out: complete internal NV RAM; sent back, it REPLACES it
+  INTERNAL_DUMP: 0x38, // in/out: complete internal NV RAM; sent back, it REPLACES it.
+  //                      NOTE: TN34 (DSP4000) lists 0x11, but the Orville actually
+  //                      replies with 0x38 (live-verified: 512 KB, checksum OK).
+  //                      Backup capture is opcode-AGNOSTIC (midi.js) so it doesn't
+  //                      depend on this; it's named for the restore confirm + docs.
   CARD_WANT: 0x14, // out: request the memory card -> CARD_DUMP
   CARD_DUMP: 0x13, // in/out: memory-card contents
   INFO_WANT: 0x1a, // out: request system info -> INFO_DUMP (ASCII)

--- a/src/sysex-commands.js
+++ b/src/sysex-commands.js
@@ -41,6 +41,25 @@ export const CMD = {
   SEQUENCE_OUT: 0x3c, // in:  UNSOLICITED emit of a changed field's key+value when
   //                     `sequence out = new` is set (device-model §8b). Not a
   //                     response to any request — see midi.js watchdog handling.
+  // Backup/restore — the Tech Note 34 want/dump pairs (#147; logs/tn34.txt). A
+  // "want" is sent to request the matching "dump"; the same "dump" opcode sent
+  // BACK TO the unit loads/replaces that data. All dumps share the FILES_DUMP
+  // wire format: 8-nibble block size + nibbled data + a 1-byte sum-to-zero
+  // checksum. These are large, slow single frames (~1.6 KB/s over the DIN link).
+  PROGRAM_WANT: 0x06, // out: request the current program -> PROGRAM_DUMP
+  PROGRAM_DUMP: 0x15, // in/out: current program (binary); sent back, it loads it
+  SETUP_WANT: 0x07, // out: request unit setup -> SETUP_DUMP
+  SETUP_DUMP: 0x16, // in/out: unit setup; sent back, it loads it
+  FILES_WANT: 0x10, // out: request the current presets -> FILES_DUMP
+  FILES_DUMP: 0x0f, // in/out: the preset files; sent back, it replaces them
+  INTERNAL_WANT: 0x12, // out: request ALL internal NV RAM -> INTERNAL_DUMP (full backup)
+  INTERNAL_DUMP: 0x11, // in/out: complete internal NV RAM; sent back, it REPLACES it
+  CARD_WANT: 0x14, // out: request the memory card -> CARD_DUMP
+  CARD_DUMP: 0x13, // in/out: memory-card contents
+  INFO_WANT: 0x1a, // out: request system info -> INFO_DUMP (ASCII)
+  INFO_DUMP: 0x19, // in:  system info (ROM name/revision/time/size), ASCII
+  OK: 0x00, // in:  "last command OK" ack (assorted commands)
+  ERROR: 0x0d, // in:  error reply; may carry an ASCII message
 };
 
 // Parameter keys referenced directly in application logic. Most keys are

--- a/tests/backup-ui.test.js
+++ b/tests/backup-ui.test.js
@@ -1,0 +1,115 @@
+// tests/backup-ui.test.js
+// The Backup & Restore modal (#147): renders the kind buttons + restore row,
+// routes a backup through the engine, pauses the host (onBusy) during a
+// transfer, downloads on success, and confirms before a replacing restore.
+// The engine (backup.js) is mocked at its boundary.
+
+jest.mock('../src/backup.js', () => ({
+  requestBackup: jest.fn(),
+  restore: jest.fn(),
+  frameFromFile: jest.fn(() => [0xf0, 0x1c, 0x70, 1, 0x15, 0xf7]),
+  backupFilename: jest.fn(() => 'orville-program-x.syx'),
+  BACKUP_KINDS: {
+    internal: { want: 0x12, dump: 0x11, label: 'Full unit (internal memory)', replaces: true },
+    files: { want: 0x10, dump: 0x0f, label: 'All presets', replaces: true },
+    program: { want: 0x06, dump: 0x15, label: 'Current program', replaces: false },
+    setup: { want: 0x07, dump: 0x16, label: 'Unit setup', replaces: false },
+  },
+}));
+
+import { setupBackupUI, openBackup, closeBackup, resetBackupUI } from '../src/backup-ui.js';
+import { requestBackup, restore } from '../src/backup.js';
+
+const q = (s) => document.querySelector(s);
+const qa = (s) => [...document.querySelectorAll(s)];
+
+beforeAll(() => {
+  // jsdom lacks object URLs; the download path needs them.
+  global.URL.createObjectURL = jest.fn(() => 'blob:x');
+  global.URL.revokeObjectURL = jest.fn();
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  document.body.innerHTML = '';
+  resetBackupUI();
+});
+
+test('opens with a backup button per kind + a restore row', () => {
+  setupBackupUI({});
+  openBackup();
+  expect(q('.bk-modal')).toBeTruthy();
+  expect(qa('.bk-grid .bk-btn').map((b) => b.textContent)).toEqual([
+    'Full unit (internal memory)',
+    'All presets',
+    'Current program',
+    'Unit setup',
+  ]);
+  expect(q('.bk-file')).toBeTruthy();
+  expect(q('.bk-restore-btn').disabled).toBe(true); // nothing loaded yet
+});
+
+test('a backup pauses the host, runs the engine, downloads + reports on success', () => {
+  const onBusy = jest.fn();
+  setupBackupUI({ onBusy });
+  openBackup();
+  qa('.bk-grid .bk-btn')
+    .find((b) => b.textContent === 'Current program')
+    .click();
+
+  expect(requestBackup).toHaveBeenCalledWith('program', expect.any(Object));
+  expect(onBusy).toHaveBeenLastCalledWith(true); // host paused
+  expect(q('.bk-grid .bk-btn').disabled).toBe(true); // buttons locked during transfer
+
+  // engine reports done with a good checksum
+  const cb = requestBackup.mock.calls[0][1];
+  cb.onProgress(2048);
+  cb.onDone({ frame: new Array(4096).fill(0), checksumOk: true });
+
+  expect(global.URL.createObjectURL).toHaveBeenCalled(); // downloaded
+  expect(onBusy).toHaveBeenLastCalledWith(false); // host resumed
+  expect(q('.bk-status').textContent).toMatch(/checksum ok/i);
+});
+
+test('a failed checksum surfaces a warning', () => {
+  setupBackupUI({});
+  openBackup();
+  qa('.bk-grid .bk-btn')[0].click();
+  requestBackup.mock.calls[0][1].onDone({ frame: new Array(10).fill(0), checksumOk: false });
+  expect(q('.bk-status').classList.contains('bk-error')).toBe(true);
+  expect(q('.bk-status').textContent).toMatch(/checksum failed/i);
+});
+
+test('restore is gated until a valid backup is loaded, and never fires unconfirmed', async () => {
+  setupBackupUI({});
+  openBackup();
+  window.confirm = jest.fn(() => false);
+  // Nothing loaded -> button disabled, clicking is a no-op.
+  expect(q('.bk-restore-btn').disabled).toBe(true);
+  q('.bk-restore-btn').click();
+  expect(restore).not.toHaveBeenCalled();
+
+  // Load a valid internal-dump backup (frameFromFile is mocked to a 0x15 frame).
+  const file = q('.bk-file');
+  const f = new File([new Uint8Array([0xf0, 0x1c, 0x70, 1, 0x15, 0xf7])], 'b.syx');
+  f.arrayBuffer = () => Promise.resolve(new Uint8Array([0xf0, 0x1c, 0x70, 1, 0x15, 0xf7]).buffer);
+  Object.defineProperty(file, 'files', { value: [f], configurable: true });
+  file.dispatchEvent(new Event('change'));
+  await Promise.resolve(); // let the async change handler settle
+  await Promise.resolve();
+  expect(q('.bk-restore-btn').disabled).toBe(false);
+
+  // Declining the confirm must NOT call the engine.
+  q('.bk-restore-btn').click();
+  expect(window.confirm).toHaveBeenCalled();
+  expect(restore).not.toHaveBeenCalled();
+});
+
+test('closeBackup hides; resetBackupUI removes the modal', () => {
+  setupBackupUI({});
+  openBackup();
+  closeBackup();
+  expect(q('.bk-modal').hidden).toBe(true);
+  resetBackupUI();
+  expect(q('.bk-modal')).toBeNull();
+});

--- a/tests/backup.test.js
+++ b/tests/backup.test.js
@@ -101,6 +101,19 @@ describe('requestBackup', () => {
     expect(onError).toHaveBeenCalledWith(expect.stringMatching(/error/i));
   });
 
+  test('captures the dump regardless of its opcode (Orville internal = 0x38, not TN34 0x11)', () => {
+    const onDone = jest.fn();
+    requestBackup('internal', { onDone });
+    const cap = setBackupCapture.mock.calls[0][0];
+    // a real Orville internal dump arrives with cmd 0x38, which is NOT CMD.INTERNAL_DUMP-as-TN34
+    cap.onFrame([0xf0, 0x1c, 0x70, 1, CMD.OK, 0xf7]); // an ack first — must be ignored
+    expect(onDone).not.toHaveBeenCalled();
+    cap.onFrame(makeDumpFrame(0x38, [1, 2, 3, 4]));
+    expect(onDone).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'internal', checksumOk: true, declaredSize: 4 })
+    );
+  });
+
   test('times out when the device never replies', () => {
     jest.useFakeTimers(); // modern fake timers also advance Date.now()
     const onError = jest.fn();

--- a/tests/backup.test.js
+++ b/tests/backup.test.js
@@ -1,0 +1,164 @@
+// tests/backup.test.js
+// Backup/restore engine (#147): the Tech Note 34 dump wire format (nibble pack,
+// 4-byte size header, sum-to-zero checksum), the want->capture->parse flow, and
+// restore re-framing. Device I/O is mocked at the midi.js boundary.
+
+jest.mock('../src/midi.js', () => ({
+  sendSysEx: jest.fn(),
+  setBackupCapture: jest.fn(),
+}));
+
+jest.mock('../src/constants.js', () => {
+  const actual = jest.requireActual('../src/constants.js');
+  return { ...actual, BACKUP: { START_TIMEOUT_MS: 50, STALL_MS: 50, RESTORE_SETTLE_MS: 20 } };
+});
+
+import {
+  denibble,
+  renibble,
+  parseDumpFrame,
+  requestBackup,
+  restore,
+  frameFromFile,
+  backupFilename,
+  BACKUP_KINDS,
+} from '../src/backup.js';
+import { sendSysEx, setBackupCapture } from '../src/midi.js';
+import { CMD } from '../src/sysex-commands.js';
+
+beforeEach(() => jest.clearAllMocks());
+
+// Build a valid dump frame for `cmd` carrying `block` bytes: 4-byte big-endian
+// size header + block + 1-byte sum-to-zero checksum, all nibble-packed.
+function makeDumpFrame(cmd, block, dev = 1) {
+  const size = block.length;
+  const body = [
+    (size >>> 24) & 0xff,
+    (size >>> 16) & 0xff,
+    (size >>> 8) & 0xff,
+    size & 0xff,
+    ...block,
+  ];
+  let sum = 0;
+  for (const b of body) sum = (sum + b) & 0xff;
+  const checksum = (256 - sum) & 0xff; // makes the grand total 0 mod 256
+  const data = [...body, checksum];
+  return [0xf0, 0x1c, 0x70, dev, cmd, ...renibble(data), 0xf7];
+}
+
+describe('nibble codec', () => {
+  test('renibble/denibble round-trip (MS nibble first)', () => {
+    const bytes = [0x00, 0x01, 0x1b, 0x58, 0xff, 0xa5];
+    expect(renibble([0x1b])).toEqual([0x1, 0xb]); // high nibble first
+    expect(Array.from(denibble(renibble(bytes)))).toEqual(bytes);
+  });
+});
+
+describe('parseDumpFrame', () => {
+  test('decodes size header + verifies a good checksum', () => {
+    const block = [10, 20, 30, 40, 50];
+    const frame = makeDumpFrame(CMD.PROGRAM_DUMP, block);
+    const p = parseDumpFrame(frame);
+    expect(p.cmd).toBe(CMD.PROGRAM_DUMP);
+    expect(p.declaredSize).toBe(block.length);
+    expect(p.checksumOk).toBe(true);
+    // decoded data is size(4) + block + checksum(1)
+    expect(p.data.length).toBe(4 + block.length + 1);
+  });
+
+  test('flags a bad checksum (corrupted block)', () => {
+    const frame = makeDumpFrame(CMD.SETUP_DUMP, [1, 2, 3]);
+    frame[frame.length - 3] ^= 0x0f; // corrupt a data nibble near the end
+    expect(parseDumpFrame(frame).checksumOk).toBe(false);
+  });
+});
+
+describe('requestBackup', () => {
+  test('sends the want, captures the matching dump, resolves with parsed result', () => {
+    const onDone = jest.fn();
+    requestBackup('program', { onDone });
+    // armed capture + sent the PROGRAM want
+    expect(setBackupCapture).toHaveBeenCalledWith(
+      expect.objectContaining({ onFrame: expect.any(Function) })
+    );
+    expect(sendSysEx).toHaveBeenCalledWith(CMD.PROGRAM_WANT, []);
+    // feed the captured dump frame
+    const cap = setBackupCapture.mock.calls[0][0];
+    const frame = makeDumpFrame(CMD.PROGRAM_DUMP, [7, 7, 7]);
+    cap.onFrame(frame);
+    expect(onDone).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'program', checksumOk: true, declaredSize: 3 })
+    );
+    // capture disarmed on completion
+    expect(setBackupCapture).toHaveBeenLastCalledWith(null);
+  });
+
+  test('reports a device ERROR frame as a failure', () => {
+    const onError = jest.fn();
+    requestBackup('internal', { onError });
+    const cap = setBackupCapture.mock.calls[0][0];
+    cap.onFrame([0xf0, 0x1c, 0x70, 1, CMD.ERROR, 0xf7]);
+    expect(onError).toHaveBeenCalledWith(expect.stringMatching(/error/i));
+  });
+
+  test('times out when the device never replies', () => {
+    jest.useFakeTimers(); // modern fake timers also advance Date.now()
+    const onError = jest.fn();
+    requestBackup('setup', { onError });
+    // the idle watchdog polls every 1s; advance past one tick so the elapsed
+    // idle (Date.now-based) exceeds the mocked START_TIMEOUT_MS (50).
+    jest.advanceTimersByTime(1100);
+    expect(onError).toHaveBeenCalledWith(expect.stringMatching(/no response/i));
+    jest.useRealTimers();
+  });
+
+  test('rejects an unknown kind', () => {
+    const onError = jest.fn();
+    requestBackup('nope', { onError });
+    expect(onError).toHaveBeenCalled();
+    expect(sendSysEx).not.toHaveBeenCalled();
+  });
+});
+
+describe('restore', () => {
+  test('re-sends the dump opcode + payload under the current device id', () => {
+    jest.useFakeTimers();
+    const onDone = jest.fn();
+    const frame = makeDumpFrame(CMD.PROGRAM_DUMP, [1, 2], 9); // captured at dev 9
+    restore(frame, { onDone });
+    // re-framed via sendSysEx(cmd, nibbles) so the CURRENT device id is used
+    expect(sendSysEx).toHaveBeenCalledWith(CMD.PROGRAM_DUMP, frame.slice(5, -1));
+    jest.advanceTimersByTime(25); // settle (no ack expected)
+    expect(onDone).toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+
+  test('an OK ack finishes restore immediately', () => {
+    const onDone = jest.fn();
+    restore(makeDumpFrame(CMD.SETUP_DUMP, [1]), { onDone });
+    const cap = setBackupCapture.mock.calls[0][0];
+    cap.onFrame([0xf0, 0x1c, 0x70, 1, CMD.OK, 0xf7]);
+    expect(onDone).toHaveBeenCalled();
+  });
+});
+
+describe('file helpers', () => {
+  test('frameFromFile extracts an Eventide frame, rejects foreign bytes', () => {
+    const frame = makeDumpFrame(CMD.INTERNAL_DUMP, [5, 6, 7]);
+    const padded = [0x00, 0x00, ...frame, 0x00]; // leading/trailing junk
+    expect(frameFromFile(padded)).toEqual(frame);
+    expect(frameFromFile([0xf0, 0x42, 0x00, 0xf7])).toBeNull(); // not 1C 70
+  });
+
+  test('backupFilename is timestamped + filesystem-safe', () => {
+    expect(backupFilename('internal', '2026-06-12 20:01:02')).toBe(
+      'orville-internal-2026-06-12-20-01-02.syx'
+    );
+  });
+
+  test('BACKUP_KINDS flags the wide-blast restores', () => {
+    expect(BACKUP_KINDS.internal.replaces).toBe(true);
+    expect(BACKUP_KINDS.files.replaces).toBe(true);
+    expect(BACKUP_KINDS.program.replaces).toBe(false);
+  });
+});

--- a/tests/midi.test.js
+++ b/tests/midi.test.js
@@ -45,6 +45,7 @@ import {
   sendKeypress,
   addSysexListener,
   inboundFrameError,
+  setBackupCapture,
 } from '../src/midi.js';
 import { parseResponse } from '../src/parser.js';
 import { on } from '../src/events.js';
@@ -174,6 +175,37 @@ describe('midi.js per-wave counter and watchdog (7c)', () => {
     jest.advanceTimersByTime(1); // t=1500: the ORIGINAL idle deadline fires
     expect(received).toHaveLength(1);
     expect(received[0]).toMatchObject({ reason: 'watchdog' });
+  });
+
+  test('backup capture: a dump frame routes to onFrame; object-protocol frames do not (#147)', () => {
+    let handler;
+    const input = {
+      addListener: (type, fn) => {
+        handler = fn;
+      },
+      removeListener: jest.fn(),
+    };
+    setMidiPorts({ sendSysex: jest.fn() }, input, 0);
+    addSysexListener();
+
+    const onProgress = jest.fn();
+    const onFrame = jest.fn();
+    setBackupCapture({ onProgress, onFrame });
+
+    // A sequence-out (object protocol) frame: NOT a dump — must not be captured,
+    // must not arm progress (else it flips the engine's slow-start watchdog).
+    handler({ data: [0xf0, 0x1c, 0x70, 0x00, 0x3c, 0x31, 0x30, 0xf7] });
+    expect(onFrame).not.toHaveBeenCalled();
+    expect(onProgress).not.toHaveBeenCalled();
+
+    // A dump frame with the Orville internal opcode 0x38 (not in the object set):
+    // captured + progress reported, regardless of the specific opcode.
+    const dump = [0xf0, 0x1c, 0x70, 0x00, 0x38, 0x00, 0x00, 0x00, 0x00, 0xf7];
+    handler({ data: dump });
+    expect(onProgress).toHaveBeenCalledWith(dump.length);
+    expect(onFrame).toHaveBeenCalledWith(dump);
+
+    setBackupCapture(null);
   });
 
   test('isWaveOpen tracks outstanding across send/receive/watchdog (#107 poll gate)', () => {


### PR DESCRIPTION
Device-native backup & restore (#147) over the Tech Note 34 dump protocol, validated live on the unit.

## Validated live
- **Current program**: 14,712 B wire, checksum OK
- **Unit setup**: 2,064 B wire, checksum OK
- **Full unit (internal NV RAM)**: 524,288 B (512 KB) decoded, **checksum OK** — the complete dump captured cleanly

## What it does
- `src/backup.js` (DOM-free): sends a Tech Note 34 `want` opcode, captures the large/slow dump frame via a raw-capture hook in `midi.js`, verifies the checksum, hands back the raw `.syx`; restore re-sends a dump frame (using the frame's own opcode).
- **Capture by exclusion**: during a backup, any non-object-protocol frame is the dump. This was the key fix — the real Orville **internal dump opcode is `0x38`, not Tech Note 34's `0x11`** (TN34 is the DSP4000 note), so an opcode allowlist would have missed it. Exclusion is immune to all such TN34-vs-Orville differences.
- `src/backup-ui.js`: Backup & Restore modal — pick a target, live progress, auto-download `.syx`; upload a `.syx` to restore (wide-blast restores confirmed first). Pauses meter polling during a transfer.
- Hardened `parser.js` against a ~1 MB frame (chunked ASCII decode; no spread overflow).

## Notes
- The full dump is ~512 KB / many minutes over the 31250-baud link, with a variable/slow startup; cutting it off mid-stream jams the link, so the UI runs it to completion (start-timeout widened to 60s).
- Tests 310/310, lint clean. Engine + UI + capture + checksum unit-tested; full chain validated live.