### PR TITLE
fix: stop faceplate controls overflowing at scaled widths (#172)

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -943,9 +943,11 @@ body {
   grid-area: fn;
   justify-content: flex-end;
   /* Reflow the five key columns into a second row when the controls track is
-     squeezed (intermediate viewport widths) rather than spilling past the
-     faceplate. The hero side-by-side layout (wide viewports) keeps them on one
-     row; below the stacking breakpoint the panel goes single-column anyway. */
+     squeezed rather than spilling past the faceplate. The row needs 390px
+     (5 x 78px, no inter-column gap); the controls track only reaches that at
+     ~1588px rack width, so between the 1520px stacking breakpoint and ~1588px
+     the keys wrap to two rows (intended — wrap beats clip). Above ~1588px they
+     sit on one row; below 1520px the panel goes single-column anyway. */
   flex-wrap: wrap;
 }
 .key-col {
@@ -1357,8 +1359,9 @@ body {
 
 /* ---------- responsive --------------------------------------------------- */
 /* 1520px is the narrowest the 4-column hero faceplate fits without clipping:
-   ears 80 + panel padding 48 + 3 gaps 72 + brand 170 + LCD/bezel 772 + a
-   wrapped controls floor 316 + card 56 ~= 1514. Below it, stack to a single
+   ears 80 + panel padding 48 + 3 gaps 72 + brand 170 + LCD/bezel 772 + the
+   wrapped controls floor 320 (the cursor 128 + gap 24 + keypad 168 row, wider
+   than a wrapped key row) + card 56 ~= 1518. Below it, stack to a single
    centred column. (Was 1100px — far below the real minimum, which left a dead
    band where the right-hand controls overflowed the faceplate at high-DPI /
    OS-scaled widths; #130 follow-up.) */

--- a/src/styles.css
+++ b/src/styles.css
@@ -145,7 +145,13 @@ body {
 .panel {
   flex: 1;
   display: grid;
-  grid-template-columns: 170px auto 1fr 56px;
+  /* The LCD column (col 2) is a fixed 772px (bezel around a 40-char grid that
+     must not scale — see #lcd). The controls track is minmax(0, 1fr) so it may
+     shrink BELOW its content's natural width: paired with .function-keys
+     flex-wrap, the key row reflows instead of overflowing the faceplate's right
+     edge when the viewport is tight. Below the stacking breakpoint (responsive
+     section) the whole panel goes single-column. */
+  grid-template-columns: 170px auto minmax(0, 1fr) 56px;
   gap: 24px;
   padding: 24px 24px 28px;
 }
@@ -936,6 +942,11 @@ body {
 .function-keys {
   grid-area: fn;
   justify-content: flex-end;
+  /* Reflow the five key columns into a second row when the controls track is
+     squeezed (intermediate viewport widths) rather than spilling past the
+     faceplate. The hero side-by-side layout (wide viewports) keeps them on one
+     row; below the stacking breakpoint the panel goes single-column anyway. */
+  flex-wrap: wrap;
 }
 .key-col {
   display: flex;
@@ -1345,7 +1356,13 @@ body {
 }
 
 /* ---------- responsive --------------------------------------------------- */
-@media (max-width: 1100px) {
+/* 1520px is the narrowest the 4-column hero faceplate fits without clipping:
+   ears 80 + panel padding 48 + 3 gaps 72 + brand 170 + LCD/bezel 772 + a
+   wrapped controls floor 316 + card 56 ~= 1514. Below it, stack to a single
+   centred column. (Was 1100px — far below the real minimum, which left a dead
+   band where the right-hand controls overflowed the faceplate at high-DPI /
+   OS-scaled widths; #130 follow-up.) */
+@media (max-width: 1520px) {
   .panel {
     grid-template-columns: 1fr;
     justify-items: center;


### PR DESCRIPTION
Closes #172. Follow-up regression to the #130 virtual-rack faceplate.

## Problem
The `.panel` 4-column grid (brand / LCD / controls / card) needs ~1620px to fit: the LCD column is a fixed 772px (a 40-char grid that must stay pixel-aligned — it cannot scale) and the function-key row is 422px. But the single-column reflow only kicked in at `max-width: 1100px`, leaving a ~500px-wide dead band where the controls track is pinned to its content width and the key columns spill past the faceplate's right edge, clipping PARAMETER / SELECT / LEVELS. High-DPI / OS-scaled displays land the effective CSS width in that band.

## Fix
- panel controls track `1fr` -> `minmax(0, 1fr)` so it may shrink below its content width
- `.function-keys` `flex-wrap` so the key columns reflow to a second row instead of overflowing when squeezed
- raise the single-column stacking breakpoint `1100px` -> `1520px`, the real minimum the side-by-side hero faceplate needs

Below 1520px the panel stacks to one centred column (brand row, LCD, controls, card). This preserves the LCD at full size — the maintainer's stated priority ("the screen is most important") — which is the constraint that rules out scaling the glyphs to keep the side-by-side layout.

## Verification
- Live: maintainer confirmed the spill is gone at their (scaled) width.
- CSS-only change; no JS touched. `npm test` unaffected.