### PR TITLE
feat: glass-forward faceplate — bigger glass, keys to drawer, BUSY scanner (#174)

### DIFF
--- a/src/bitmap.js
+++ b/src/bitmap.js
@@ -72,9 +72,11 @@ export function renderBitmap(canvasId, rawBytes) {
   }
   canvas.width = width;
   canvas.height = height;
-  canvas.style.width = CANVAS.CSS_WIDTH;
-  canvas.style.height = CANVAS.CSS_HEIGHT;
-  canvas.style.aspectRatio = CANVAS.ASPECT_RATIO; // Force aspect ratio
+  canvas.style.width = CANVAS.CSS_WIDTH; // x3 base width; CSS max-width caps it to the drawer column
+  // Height is governed by aspect-ratio (not pinned) so a column-capped width
+  // scales the capture proportionally instead of squashing it. An explicit
+  // height would override aspect-ratio, which was the distortion bug.
+  canvas.style.aspectRatio = CANVAS.ASPECT_RATIO;
   canvas.style.imageRendering = CANVAS.IMAGE_RENDERING; // Sharp pixels
   const imgData = ctx.getImageData(0, 0, width, height);
   imgData.data.set(computePixels(rawBytes, { width, height, ...themePixelColors() }));

--- a/src/constants.js
+++ b/src/constants.js
@@ -179,13 +179,14 @@ export const DEMO = {
   //                       parser inside the send call
 };
 
-// Canvas presentation for the bitmap screen (CSS, cosmetic only).
-// x3 integer scale (240x64 -> 720x192) so the bitmap mirror and the virtual
-// #lcd are the SAME physical size — one display, two modes (#130; the
-// pixel font is likewise locked to x3, fractional scales smear it).
+// Canvas presentation for the true-screen (0x17) bitmap capture in the service
+// drawer (CSS, cosmetic only). CSS_WIDTH is the x3 integer base (240 -> 720px);
+// height is NOT pinned — ASPECT_RATIO governs it so the canvas scales down to
+// its drawer column without distorting the 240x64 capture. (The hero glass is
+// the text #lcd at x4 now; the capture is decoupled from it, so they no longer
+// need to be the same physical size — #130 follow-up.)
 export const CANVAS = {
   CSS_WIDTH: '720px',
-  CSS_HEIGHT: '192px',
   ASPECT_RATIO: '240 / 64',
   IMAGE_RENDERING: 'pixelated',
 };

--- a/src/index.html
+++ b/src/index.html
@@ -128,85 +128,16 @@
               <button id="soft3-btn" class="key key-soft" aria-label="Soft key 3"></button>
               <button id="soft4-btn" class="key key-soft" aria-label="Soft key 4"></button>
             </div>
-          </div>
-
-          <div class="controls-block">
-            <!-- Hold sub-labels are the manual's real hold functions (p.8-9):
-                 PROGRAM-hold = routing storage, PARAMETER-hold = patch
-                 editor, SELECT-hold = remote-control setup. -->
-            <div class="key-group function-keys">
-              <div class="key-col">
-                <button id="ab-btn" class="key key-accent">DSP A/B</button>
-                <div class="bypass-leds" aria-hidden="true">
-                  <span class="status-led"><i></i><b>A</b></span>
-                  <span class="status-led"><i></i><b>B</b></span>
-                </div>
-                <button id="bypass-btn" class="key key-danger">BYPASS</button>
-              </div>
-              <div class="key-col">
-                <button id="program-btn" class="key">PROGRAM</button>
-                <button id="program-hold-btn" class="key key-hold">HOLD · ROUTING</button>
-              </div>
-              <div class="key-col">
-                <button id="parameter-btn" class="key">PARAMETER</button>
-                <button id="parameter-hold-btn" class="key key-hold">HOLD · PATCH</button>
-              </div>
-              <div class="key-col">
-                <button id="select-btn" class="key">SELECT</button>
-                <button id="select-hold-btn" class="key key-hold">HOLD · REMOTE</button>
-              </div>
-              <div class="key-col">
-                <button id="levels-btn" class="key">LEVELS</button>
-                <button id="setup-btn" class="key">SETUP</button>
-              </div>
+            <!-- Link-activity indicator (manual p.10 BUSY LED), reimagined as a
+                 phosphor scanner bar under the glass: a knight-rider sweep while
+                 a dump wave moves data, calm and dim when idle. id + the .lit
+                 toggle are unchanged (event-bridge.js). The physical front-panel
+                 keys (redundant with clicking the glass) and the decorative
+                 memory-card slot moved to the service drawer's Front Panel col. -->
+            <div id="busy-led" class="busy-bar" role="status" aria-label="MIDI link activity">
+              <span class="busy-track" aria-hidden="true"><i class="busy-scan"></i></span>
+              <b class="busy-legend">BUSY</b>
             </div>
-
-            <div class="key-group cursor-keys">
-              <button id="up-btn" class="key key-cursor" aria-label="Cursor up">▲</button>
-              <button id="left-btn" class="key key-cursor" aria-label="Cursor left">◀</button>
-              <button id="right-btn" class="key key-cursor" aria-label="Cursor right">▶</button>
-              <button id="down-btn" class="key key-cursor" aria-label="Cursor down">▼</button>
-            </div>
-
-            <!-- Manual p.9 items L/O: the KNOB plus INC/DEC keys. The knob
-                 answers wheel-scroll and vertical drag (controls.js). -->
-            <div class="key-group wheel-keys">
-              <span class="group-legend">DATA</span>
-              <div id="data-knob" class="knob" role="slider" aria-label="Data knob" tabindex="0">
-                <i class="knob-pointer"></i>
-              </div>
-              <div class="incdec">
-                <button id="inc-btn" class="key key-wheel" aria-label="Increment">▲</button>
-                <button id="dec-btn" class="key key-wheel" aria-label="Decrement">▼</button>
-              </div>
-            </div>
-
-            <div class="key-group keypad">
-              <button id="7-btn" class="key key-num">7</button>
-              <button id="8-btn" class="key key-num">8</button>
-              <button id="9-btn" class="key key-num">9</button>
-              <button id="4-btn" class="key key-num">4</button>
-              <button id="5-btn" class="key key-num">5</button>
-              <button id="6-btn" class="key key-num">6</button>
-              <button id="1-btn" class="key key-num">1</button>
-              <button id="2-btn" class="key key-num">2</button>
-              <button id="3-btn" class="key key-num">3</button>
-              <button id="dot-btn" class="key key-num">·</button>
-              <button id="0-btn" class="key key-num">0</button>
-              <button id="minus-btn" class="key key-num">−</button>
-              <button id="cxl-btn" class="key key-num key-danger">CXL</button>
-              <button id="enter-btn" class="key key-num key-accent keypad-enter">ENT</button>
-            </div>
-          </div>
-
-          <!-- Manual p.10 items Q/R/S: BUSY LED (wired to dump waves —
-               lit while data moves on the MIDI link) over the memory card
-               slot and its release key (decorative). -->
-          <div class="card-block">
-            <span id="busy-led" class="status-led busy"><i></i><b>BUSY</b></span>
-            <div class="card-slot" aria-hidden="true"></div>
-            <span class="card-release" aria-hidden="true"></span>
-            <b class="card-legend" aria-hidden="true">MEMORY CARD</b>
           </div>
         </div>
 
@@ -217,6 +148,79 @@
       <details class="service-panel">
         <summary><span class="hazard"></span>SERVICE<span class="hazard"></span></summary>
         <div class="service-body">
+          <!-- Front panel: the emulated physical keys. Redundant with clicking
+               the glass directly, so they live here off the hero faceplate
+               (maintainer direction) — still fully wired (controls.js binds by
+               id, location-independent). Hold sub-labels are the manual's real
+               hold functions (p.8-9): PROGRAM-hold = routing storage,
+               PARAMETER-hold = patch editor, SELECT-hold = remote-control setup.
+               The KNOB answers wheel-scroll and vertical drag (controls.js). -->
+          <div class="service-col service-col-frontpanel">
+            <h3 class="service-heading">Front panel</h3>
+            <div class="controls-block">
+              <div class="key-group function-keys">
+                <div class="key-col">
+                  <button id="ab-btn" class="key key-accent">DSP A/B</button>
+                  <div class="bypass-leds" aria-hidden="true">
+                    <span class="status-led"><i></i><b>A</b></span>
+                    <span class="status-led"><i></i><b>B</b></span>
+                  </div>
+                  <button id="bypass-btn" class="key key-danger">BYPASS</button>
+                </div>
+                <div class="key-col">
+                  <button id="program-btn" class="key">PROGRAM</button>
+                  <button id="program-hold-btn" class="key key-hold">HOLD · ROUTING</button>
+                </div>
+                <div class="key-col">
+                  <button id="parameter-btn" class="key">PARAMETER</button>
+                  <button id="parameter-hold-btn" class="key key-hold">HOLD · PATCH</button>
+                </div>
+                <div class="key-col">
+                  <button id="select-btn" class="key">SELECT</button>
+                  <button id="select-hold-btn" class="key key-hold">HOLD · REMOTE</button>
+                </div>
+                <div class="key-col">
+                  <button id="levels-btn" class="key">LEVELS</button>
+                  <button id="setup-btn" class="key">SETUP</button>
+                </div>
+              </div>
+
+              <div class="key-group cursor-keys">
+                <button id="up-btn" class="key key-cursor" aria-label="Cursor up">▲</button>
+                <button id="left-btn" class="key key-cursor" aria-label="Cursor left">◀</button>
+                <button id="right-btn" class="key key-cursor" aria-label="Cursor right">▶</button>
+                <button id="down-btn" class="key key-cursor" aria-label="Cursor down">▼</button>
+              </div>
+
+              <div class="key-group wheel-keys">
+                <span class="group-legend">DATA</span>
+                <div id="data-knob" class="knob" role="slider" aria-label="Data knob" tabindex="0">
+                  <i class="knob-pointer"></i>
+                </div>
+                <div class="incdec">
+                  <button id="inc-btn" class="key key-wheel" aria-label="Increment">▲</button>
+                  <button id="dec-btn" class="key key-wheel" aria-label="Decrement">▼</button>
+                </div>
+              </div>
+
+              <div class="key-group keypad">
+                <button id="7-btn" class="key key-num">7</button>
+                <button id="8-btn" class="key key-num">8</button>
+                <button id="9-btn" class="key key-num">9</button>
+                <button id="4-btn" class="key key-num">4</button>
+                <button id="5-btn" class="key key-num">5</button>
+                <button id="6-btn" class="key key-num">6</button>
+                <button id="1-btn" class="key key-num">1</button>
+                <button id="2-btn" class="key key-num">2</button>
+                <button id="3-btn" class="key key-num">3</button>
+                <button id="dot-btn" class="key key-num">·</button>
+                <button id="0-btn" class="key key-num">0</button>
+                <button id="minus-btn" class="key key-num">−</button>
+                <button id="cxl-btn" class="key key-num key-danger">CXL</button>
+                <button id="enter-btn" class="key key-num key-accent keypad-enter">ENT</button>
+              </div>
+            </div>
+          </div>
           <div class="service-col">
             <h3 class="service-heading">True screen (0x17 capture)</h3>
             <canvas id="lcd-canvas"></canvas>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1315,10 +1315,11 @@ body {
   border: 1px solid var(--btn-edge);
   border-radius: 2px;
   image-rendering: pixelated;
-  /* Scale to fit the drawer column WITHOUT distorting the 240x64 native
-     aspect: cap the width and let height track it (height:auto). max-width
-     alone shrank the width while the attribute height stayed fixed, squashing
-     the capture vertically. */
+  /* Scale to fit the drawer column without distorting the 240x64 capture:
+     bitmap.js sets an inline width (720px) + aspect-ratio (240/64) and no
+     pinned height; max-width caps the width to the column and height:auto lets
+     the aspect-ratio derive the height. (A pinned inline height used to defeat
+     the aspect-ratio and squash the capture when the width was capped.) */
   max-width: 100%;
   height: auto;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -826,8 +826,11 @@ body {
   margin: 0;
   width: auto;
   display: inline;
-  height: 24px;
-  line-height: 24px;
+  /* Match the character cell so the in-glass dropdown lines up with its text
+     row at any LCD scale (derive, don't pin — these were 24px literals that
+     only happened to equal the cell at x3 and fell short at x4). */
+  height: var(--lcd-cell-h);
+  line-height: var(--lcd-cell-h);
 }
 #lcd select:hover {
   background: var(--lcd-px);
@@ -839,6 +842,9 @@ body {
 #lcd select option {
   background: var(--lcd-bg);
   color: var(--lcd-px);
+  /* The opened option list is the OS-native popup, not in-glass, so it uses a
+     normal monospace at a fixed readable size — intentionally decoupled from
+     the LCD scale (the bitmap LCD font renders poorly in a native popup). */
   font-family: ui-monospace, Consolas, monospace;
   font-size: 14px;
 }
@@ -916,7 +922,7 @@ body {
   top: 0;
   bottom: 0;
   left: 0;
-  width: 22%;
+  width: 22%; /* Larson band: ~1/5 of the track, the classic scanner proportion */
   border-radius: 3px;
   background: var(--led-amber);
   box-shadow: 0 0 8px var(--led-amber);

--- a/src/styles.css
+++ b/src/styles.css
@@ -22,20 +22,23 @@
   --lcd-px: #3bf06e;
   --lcd-px-dim: #1e7a3c;
   --lcd-glow: color-mix(in srgb, var(--lcd-px) 45%, transparent);
-  /* The hardware cell is 6x8 and so is the font's, so at x3 the natural
-     advance is 18px — EXACTLY the x3 canvas pitch (720/40 = 18px per
-     column), no letter-spacing tricks. All in-LCD widths derive from this
-     variable so the grid geometry has one source of truth. */
-  --lcd-advance: 18px;
-  --lcd-cell-h: 24px;
-  /* Row leading (maintainer feedback: contiguous hardware rows read
-     cramped at x3): +6px = two hardware scanlines at x3 = 25% leading,
-     the dense-monospace norm — and a 3px multiple, so glyphs stay on
-     the integer pixel grid. Section grouping still comes from the
-     renderer's blank separator lines, as on the device. */
-  --lcd-row-gap: 6px;
+  /* The hardware cell is 6x8 and so is the font's, so at an integer scale the
+     advance is 6 * scale px with no letter-spacing tricks. Rendered at x4 (the
+     glass is the faceplate's centerpiece — maintainer direction): 6*4 = 24px
+     per column, EXACTLY the x4 canvas pitch (960/40 = 24px). The font is a
+     bitmap face so ONLY integer scales stay crisp (x3=18, x4=24, x5=30).
+     All in-LCD widths derive from this variable so the grid geometry has one
+     source of truth. */
+  --lcd-advance: 24px;
+  --lcd-cell-h: 32px; /* 8px cell * x4 */
+  /* Row leading (maintainer feedback: contiguous hardware rows read cramped):
+     two hardware scanlines of leading = 25%, the dense-monospace norm. At x4
+     that is 2 * 4 = 8px, an integer-grid multiple so glyphs stay pixel-aligned.
+     Section grouping still comes from the renderer's blank separator lines, as
+     on the device. */
+  --lcd-row-gap: 8px;
   --lcd-row-h: calc(var(--lcd-cell-h) + var(--lcd-row-gap));
-  --lcd-pad: 12px; /* glass margin around the character grid */
+  --lcd-pad: 16px; /* glass margin around the character grid (4px native * x4) */
   --bezel-pad: 14px; /* the recess ring around the lit glass — kept thin
                         (was 24px): pure black on near-black read as a
                         dead moat (maintainer feedback) */
@@ -48,8 +51,8 @@
    100LX 6x8 (Ultimate Oldschool PC Font Pack, CC BY-SA 4.0, src/fonts/) is
    a true 6x8 cell — each glyph keeps its native 1px gutter, which is what
    lets the phosphor glow form a distinct halo per character instead of
-   smearing. Design size is 8px; rendered at x3 (24px) only — fractional
-   scales smear pixel fonts. */
+   smearing. Design size is 8px; rendered at an integer scale only (x4 = 32px
+   today) — fractional scales smear pixel fonts. */
 @font-face {
   font-family: 'OrvilleLCD';
   src: url('fonts/PxPlus_HP_100LX_6x8.ttf') format('truetype');
@@ -145,15 +148,17 @@ body {
 .panel {
   flex: 1;
   display: grid;
-  /* The LCD column (col 2) is a fixed 772px (bezel around a 40-char grid that
-     must not scale — see #lcd). The controls track is minmax(0, 1fr) so it may
-     shrink BELOW its content's natural width: paired with .function-keys
-     flex-wrap, the key row reflows instead of overflowing the faceplate's right
-     edge when the viewport is tight. Below the stacking breakpoint (responsive
-     section) the whole panel goes single-column. */
-  grid-template-columns: 170px auto minmax(0, 1fr) 56px;
+  /* Glass-forward faceplate: a slim brand rail + the LCD glass as the
+     centerpiece. The physical front-panel keys (keypad, cursor pad, DATA knob,
+     function keys) moved to the service drawer — they were redundant with
+     clicking the glass directly — which frees the whole right side for the
+     glass. The LCD column is fixed (~1012px: a 40-char grid at x4 plus bezel)
+     and must not scale; it is centred in the remaining space. Below the
+     stacking breakpoint (responsive section) the panel goes single-column. */
+  grid-template-columns: 170px 1fr;
   gap: 24px;
   padding: 24px 24px 28px;
+  align-items: start;
 }
 
 /* ---------- brand block ------------------------------------------------- */
@@ -304,10 +309,6 @@ body {
   letter-spacing: 0.12em;
   color: var(--legend-dim);
 }
-.status-led.busy.lit i {
-  background: var(--led-amber);
-  box-shadow: 0 0 5px color-mix(in srgb, var(--led-amber) 60%, transparent);
-}
 
 /* ---------- the display -------------------------------------------------- */
 .display-block {
@@ -315,6 +316,7 @@ body {
   flex-direction: column;
   align-items: center;
   gap: 10px;
+  justify-self: center; /* centre the glass in the freed right-hand space */
 }
 .bezel {
   position: relative; /* anchors the .glass overlay */
@@ -885,6 +887,66 @@ body {
   height: 22px;
 }
 
+/* ---------- BUSY scanner ------------------------------------------------- */
+/* Link-activity indicator under the glass (the manual p.10 BUSY LED). While a
+   dump wave is open, event-bridge.js adds .lit to #busy-led and a bright band
+   sweeps the track — the Larson/Knight-Rider vocabulary the sync dialog uses
+   (.sync-scanner), so "data is moving" reads consistently across the app. Idle
+   it is a calm dim rail. Amber, the hardware BUSY colour, distinct from the
+   phosphor glass above it. Width matches the bezel so it aligns to the glass. */
+.busy-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: calc(40 * var(--lcd-advance) + 2 * var(--lcd-pad) + 2 * var(--bezel-pad));
+  max-width: 100%;
+  padding: 2px;
+}
+.busy-track {
+  position: relative;
+  flex: 1;
+  height: 6px;
+  border-radius: 3px;
+  background: #0b0c0d;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.8);
+  overflow: hidden;
+}
+.busy-scan {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 22%;
+  border-radius: 3px;
+  background: var(--led-amber);
+  box-shadow: 0 0 8px var(--led-amber);
+  opacity: 0; /* hidden until a wave opens */
+}
+/* 78% = 100% - the band's 22% width, so the head never clips the right edge. */
+#busy-led.lit .busy-scan {
+  opacity: 1;
+  animation: busy-larson 1.1s ease-in-out infinite alternate;
+}
+@keyframes busy-larson {
+  from {
+    left: 0;
+  }
+  to {
+    left: 78%;
+  }
+}
+.busy-legend {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  color: var(--legend-dim);
+  transition: color 0.2s;
+}
+#busy-led.lit .busy-legend {
+  color: var(--led-amber);
+  text-shadow: 0 0 6px color-mix(in srgb, var(--led-amber) 60%, transparent);
+}
+
 /* ---------- keys --------------------------------------------------------- */
 .key {
   font-family: var(--legend-font);
@@ -924,6 +986,9 @@ body {
   color: var(--led-amber);
 }
 
+/* Lives in the service drawer's Front Panel column now (the emulated physical
+   keys left the hero faceplate). Left-aligned within the drawer; the function
+   keys wrap to keep the cluster inside the column on narrow drawers. */
 .controls-block {
   display: grid;
   grid-template-columns: auto auto;
@@ -933,7 +998,7 @@ body {
     'wheel keypad';
   gap: 18px 24px;
   align-content: start;
-  justify-content: end;
+  justify-content: start;
 }
 .key-group {
   display: flex;
@@ -941,13 +1006,6 @@ body {
 }
 .function-keys {
   grid-area: fn;
-  justify-content: flex-end;
-  /* Reflow the five key columns into a second row when the controls track is
-     squeezed rather than spilling past the faceplate. The row needs 390px
-     (5 x 78px, no inter-column gap); the controls track only reaches that at
-     ~1588px rack width, so between the 1520px stacking breakpoint and ~1588px
-     the keys wrap to two rows (intended — wrap beats clip). Above ~1588px they
-     sit on one row; below 1520px the panel goes single-column anyway. */
   flex-wrap: wrap;
 }
 .key-col {
@@ -1064,39 +1122,8 @@ body {
   grid-column: 2 / 4;
 }
 
-/* Memory card slot + BUSY LED (manual p.10 items Q/R/S). BUSY is wired:
-   event-bridge lights it while a dump wave is open. */
-.card-block {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 10px;
-  padding-top: 4px;
-}
-.card-slot {
-  width: 10px;
-  height: 110px;
-  border-radius: 2px;
-  background: #060708;
-  box-shadow:
-    inset 0 0 4px rgba(0, 0, 0, 1),
-    0 1px 0 rgba(255, 255, 255, 0.04);
-  border: 1px solid #000;
-}
-.card-release {
-  width: 14px;
-  height: 8px;
-  border-radius: 2px;
-  background: linear-gradient(var(--btn-cap-hi), var(--btn-cap));
-  border: 1px solid var(--btn-edge);
-}
-.card-legend {
-  font-size: 7px;
-  font-weight: 600;
-  letter-spacing: 0.14em;
-  color: var(--legend-dim);
-  writing-mode: vertical-rl;
-}
+/* (The memory-card slot + old dot-style BUSY LED were removed with the
+   glass-forward redesign — BUSY is now the .busy-bar scanner under the glass.) */
 
 /* ---------- shared utility widgets -------------------------------------- */
 .util-btn {
@@ -1250,9 +1277,12 @@ body {
   border-radius: 2px;
   opacity: 0.7;
 }
+/* Auto-fitting columns: the drawer gained a fourth column (Front panel) when
+   the emulated keys moved here from the faceplate, so the tracks wrap instead
+   of being pinned at three. Each column is >=300px and shares the slack. */
 .service-body {
   display: grid;
-  grid-template-columns: auto auto 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: 24px;
   padding: 20px;
   margin-top: 2px;
@@ -1285,6 +1315,7 @@ body {
   border: 1px solid var(--btn-edge);
   border-radius: 2px;
   image-rendering: pixelated;
+  max-width: 100%;
 }
 .toggle {
   display: inline-flex;
@@ -1358,14 +1389,13 @@ body {
 }
 
 /* ---------- responsive --------------------------------------------------- */
-/* 1520px is the narrowest the 4-column hero faceplate fits without clipping:
-   ears 80 + panel padding 48 + 3 gaps 72 + brand 170 + LCD/bezel 772 + the
-   wrapped controls floor 320 (the cursor 128 + gap 24 + keypad 168 row, wider
-   than a wrapped key row) + card 56 ~= 1518. Below it, stack to a single
-   centred column. (Was 1100px — far below the real minimum, which left a dead
-   band where the right-hand controls overflowed the faceplate at high-DPI /
-   OS-scaled widths; #130 follow-up.) */
-@media (max-width: 1520px) {
+/* 1350px is the narrowest the glass-forward (brand + glass) faceplate fits
+   side-by-side: ears 80 + panel padding 48 + 1 gap 24 + brand 170 + LCD/bezel
+   1020 (a 40-char grid at x4 plus the bezel ring) ~= 1342. Below it, stack the
+   brand above the glass, both centred. (The physical keys left the faceplate
+   for the service drawer, so there is no controls column to fit any more — the
+   binding constraint is now the enlarged glass itself; #130 follow-ups.) */
+@media (max-width: 1350px) {
   .panel {
     grid-template-columns: 1fr;
     justify-items: center;
@@ -1380,9 +1410,6 @@ body {
     margin: 0 0 0 auto;
     border: none;
     padding: 0;
-  }
-  .controls-block {
-    justify-content: center;
   }
   .conn-strip {
     flex-wrap: wrap;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1315,7 +1315,12 @@ body {
   border: 1px solid var(--btn-edge);
   border-radius: 2px;
   image-rendering: pixelated;
+  /* Scale to fit the drawer column WITHOUT distorting the 240x64 native
+     aspect: cap the width and let height track it (height:auto). max-width
+     alone shrank the width while the attribute height stayed fixed, squashing
+     the capture vertically. */
   max-width: 100%;
+  height: auto;
 }
 .toggle {
   display: inline-flex;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1319,7 +1319,11 @@ body {
      bitmap.js sets an inline width (720px) + aspect-ratio (240/64) and no
      pinned height; max-width caps the width to the column and height:auto lets
      the aspect-ratio derive the height. (A pinned inline height used to defeat
-     the aspect-ratio and squash the capture when the width was capped.) */
+     the aspect-ratio and squash the capture when the width was capped.)
+     content-box (overriding the global border-box) so the aspect-ratio governs
+     the IMAGE area, not the border box — otherwise the 1px border insets the
+     pixels and scales them ~1.4% non-uniformly. */
+  box-sizing: content-box;
   max-width: 100%;
   height: auto;
 }

--- a/tests/event-bridge.test.js
+++ b/tests/event-bridge.test.js
@@ -375,7 +375,10 @@ describe('event-bridge (C1: dumpComplete-driven rendering)', () => {
   });
 
   test('BUSY LED lights on wave:opened and clears on dumpComplete (#131)', () => {
-    document.body.innerHTML = '<span id="busy-led" class="status-led busy"></span>';
+    // The glass-forward redesign made BUSY a scanner bar; the .lit toggle on
+    // #busy-led (the only thing event-bridge drives) is unchanged.
+    document.body.innerHTML =
+      '<div id="busy-led" class="busy-bar"><span class="busy-track"><i class="busy-scan"></i></span><b class="busy-legend">BUSY</b></div>';
     const led = document.getElementById('busy-led');
 
     emit('wave:opened', { kind: 'objectinfo' });


### PR DESCRIPTION
Closes #174. Follow-up to the #130 virtual-rack faceplate, from live maintainer direction. Visual confirmed live (glass + BUSY scanner approved; true-screen capture aspect corrected).

## What changed
- **Keys off the faceplate**: the emulated physical keys (keypad, cursor pad, DATA knob, INC/DEC, function keys incl. HOLD variants) move into a new "Front panel" column in the service drawer. Still fully wired — controls.js binds by id, location-independent. No JS handler changes.
- **Bigger glass**: LCD scale x3 -> x4, pixel-perfect (advance 24, cell-h 32, row-gap 8, pad 16; the bitmap font only stays crisp on integer multiples). All in-glass geometry derives from `--lcd-advance`, so one token drives the scale.
- **Reflow**: `.panel` becomes brand rail + centred glass (was a 4-column grid). Stacking breakpoint 1520 -> 1350 (the new min is the enlarged glass, not a controls column).
- **BUSY reborn**: the dot-over-card-slot (the slot read as a broken black bar) becomes a Larson/Knight-Rider scanner bar under the glass — amber sweep while a dump wave is open, calm when idle, sharing the sync dialog's progress vocabulary. `#busy-led` + the `.lit` toggle unchanged (event-bridge.js). Dead `.card-*` / `.status-led.busy` rules removed.
- **True-screen capture**: decoupled from the glass (it no longer has to match the x4 #lcd). The canvas distortion (pinned inline height defeating its aspect-ratio + a border-box inset) is fixed structurally: width capped by the drawer column, height via `aspect-ratio` on a `content-box`. Removed the now-unused `CANVAS.CSS_HEIGHT`.
- Service drawer columns auto-fit to absorb the new column.

## Tests
311 pass, lint clean. CSS/HTML/constants + a 2-line bitmap.js change; no behavioural JS touched.

## Follow-ups (separate)
- E: in-glass section shading/alignment.
- D: mapped-param auto-poll + mod indicator.